### PR TITLE
refactor: make sync-from-mr.sh MR-scoped

### DIFF
--- a/tools/sync-from-mr.sh
+++ b/tools/sync-from-mr.sh
@@ -2,7 +2,11 @@
 #
 # sync-from-mr.sh - Sync changes from a merged NMP GitLab MR to Safe-Synthesizer
 #
-# Usage: ./script/sync-from-mr.sh <MR_NUMBER>
+# Only copies files that were actually changed in the MR, rather than mirroring
+# the full src/ and tests/ directories. This avoids deleting Safe-Synthesizer-
+# specific files that don't yet exist in NMP.
+#
+# Usage: ./tools/sync-from-mr.sh <MR_NUMBER>
 #
 
 set -euo pipefail
@@ -11,11 +15,12 @@ set -euo pipefail
 readonly GITLAB_HOST="gitlab-master.nvidia.com"
 readonly PROJECT_ID="150981"
 readonly NMP_REPO_PATH="${NMP_REPO_PATH:-$HOME/dev/aire/microservices/nmp}"
+readonly NMP_PKG_PREFIX="packages/nemo_safe_synthesizer/"
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly SAFE_SYNTH_ROOT="$(git rev-parse --show-toplevel)"
 
 # Check dependencies
-for cmd in glab jq rsync; do
+for cmd in glab jq; do
     command -v "$cmd" &>/dev/null || { echo "Error: $cmd is required"; exit 1; }
 done
 
@@ -36,8 +41,8 @@ MR_JSON=$(glab api --hostname "$GITLAB_HOST" "projects/$PROJECT_ID/merge_request
 SQUASH_SHA=$(echo "$MR_JSON" | jq -r '.squash_commit_sha')
 
 if [[ "$SQUASH_SHA" == "null" || -z "$SQUASH_SHA" ]]; then
-    echo "Error: MR !$MR_NUMBER is not merged"
-    echo "$MR_JSON" | jq .
+    echo "Error: MR !$MR_NUMBER is not merged or has no squash commit"
+    echo "$MR_JSON" | jq '{iid, title, state, merged_at}'
     exit 1
 fi
 
@@ -47,35 +52,88 @@ echo "Squash commit: $SQUASH_SHA"
 cd "$NMP_REPO_PATH"
 git fetch origin main
 git checkout "$SQUASH_SHA" --quiet
+cd "$SAFE_SYNTH_ROOT"
 
-# Rsync excludes
-RSYNC_EXCLUDES=(
-    --exclude='__pycache__'
-    --exclude='*.pyc'
-    --exclude='.pytest_cache'
-)
-
-# Sync src/ and tests/ directories
-echo "Syncing src/..."
-rsync -av --delete "${RSYNC_EXCLUDES[@]}" \
-    "$NMP_REPO_PATH/packages/nemo_safe_synthesizer/src/" \
-    "$SAFE_SYNTH_ROOT/src/"
-
-echo "Syncing tests/..."
-rsync -av --delete "${RSYNC_EXCLUDES[@]}" \
-    "$NMP_REPO_PATH/packages/nemo_safe_synthesizer/tests/" \
-    "$SAFE_SYNTH_ROOT/tests/"
-
-# Report files outside src/tests that changed in the MR
-echo ""
-echo "Files changed in MR but NOT synced (may need manual review):"
+# Get all file changes in the MR scoped to our package
 MR_CHANGES=$(glab api --hostname "$GITLAB_HOST" "projects/$PROJECT_ID/merge_requests/$MR_NUMBER/changes")
+
+# Extract files in src/ and tests/ that were changed in the MR
+# Each line: <action>\t<relative_path>
+# action is one of: copy, delete
+SYNC_PLAN=$(echo "$MR_CHANGES" | jq -r '
+    .changes[] |
+    # Consider both old_path and new_path for renames
+    . as $change |
+    [
+        # If renamed/moved, delete the old path (if it was in our package)
+        (if $change.renamed_file and ($change.old_path | startswith("'"$NMP_PKG_PREFIX"'"))
+         then {action: "delete", path: ($change.old_path | ltrimstr("'"$NMP_PKG_PREFIX"'"))}
+         else empty end),
+        # Handle the new_path
+        (if ($change.new_path | startswith("'"$NMP_PKG_PREFIX"'"))
+         then
+            ($change.new_path | ltrimstr("'"$NMP_PKG_PREFIX"'")) as $rel |
+            if ($rel | startswith("src/")) or ($rel | startswith("tests/"))
+            then
+                if $change.deleted_file
+                then {action: "delete", path: $rel}
+                else {action: "copy", path: $rel}
+                end
+            else empty
+            end
+         else empty end)
+    ] | .[] | "\(.action)\t\(.path)"
+')
+
+if [[ -z "$SYNC_PLAN" ]]; then
+    echo "No src/ or tests/ files changed in MR !$MR_NUMBER for nemo_safe_synthesizer."
+    echo ""
+    echo "This MR may have only changed files outside src/ and tests/."
+else
+    # Process the sync plan
+    COPIED=0
+    DELETED=0
+
+    while IFS=$'\t' read -r action rel_path; do
+        case "$action" in
+            copy)
+                src="$NMP_REPO_PATH/$NMP_PKG_PREFIX$rel_path"
+                dst="$SAFE_SYNTH_ROOT/$rel_path"
+                if [[ -f "$src" ]]; then
+                    mkdir -p "$(dirname "$dst")"
+                    cp "$src" "$dst"
+                    echo "  copied: $rel_path"
+                    COPIED=$((COPIED + 1))
+                else
+                    echo "  WARNING: source file not found: $src"
+                fi
+                ;;
+            delete)
+                dst="$SAFE_SYNTH_ROOT/$rel_path"
+                if [[ -f "$dst" ]]; then
+                    rm "$dst"
+                    echo "  deleted: $rel_path"
+                    DELETED=$((DELETED + 1))
+                else
+                    echo "  (skip delete, not present): $rel_path"
+                fi
+                ;;
+        esac
+    done <<< "$SYNC_PLAN"
+
+    echo ""
+    echo "Synced $COPIED file(s), deleted $DELETED file(s)."
+fi
+
+# Report files outside src/tests that changed in the MR (need manual review)
+echo ""
+echo "Files changed in MR but NOT synced (outside src/ and tests/, may need manual review):"
 NON_SYNCED=$(echo "$MR_CHANGES" | jq -r '
     [.changes[] | (.old_path, .new_path)
-     | select(startswith("packages/nemo_safe_synthesizer/"))
-     | select(startswith("packages/nemo_safe_synthesizer/src/") | not)
-     | select(startswith("packages/nemo_safe_synthesizer/tests/") | not)
-     | ltrimstr("packages/nemo_safe_synthesizer/")]
+     | select(startswith("'"$NMP_PKG_PREFIX"'"))
+     | ltrimstr("'"$NMP_PKG_PREFIX"'")
+     | select(startswith("src/") | not)
+     | select(startswith("tests/") | not)]
     | unique | .[]')
 if [[ -n "$NON_SYNCED" ]]; then
     echo "$NON_SYNCED"
@@ -87,4 +145,4 @@ echo ""
 echo "Sync complete! Next steps:"
 echo "  git status"
 echo "  git diff"
-echo "  git add -A && git commit -m 'Sync from NMP MR !$MR_NUMBER'"
+echo "  git add -A && git commit -m 'chore: sync from NMP MR !$MR_NUMBER'"


### PR DESCRIPTION
## Summary
- Rewrites `tools/sync-from-mr.sh` to only copy files that were actually changed in the MR, instead of mirroring the full `src/` and `tests/` directories with `rsync --delete`
- Prevents accidental deletion of Safe-Synthesizer-specific files that haven't been synced to NMP yet
- Handles additions, modifications, deletions, and renames via the GitLab MR changes API

## Motivation
The old script used `rsync --delete` to mirror entire directories from NMP, which would remove files that exist in Safe-Synthesizer but not yet in NMP. The new approach queries the MR's changed files and only touches those specific files.

## Test plan
- [x] Successfully used to sync MR !5153 (25 files copied, 0 unwanted deletions)

Made with [Cursor](https://cursor.com)