### PR TITLE
fix: dp compositions off-by-one

### DIFF
--- a/src/nemo_safe_synthesizer/privacy/dp_transformers/dp_utils.py
+++ b/src/nemo_safe_synthesizer/privacy/dp_transformers/dp_utils.py
@@ -139,7 +139,7 @@ class DPCallback(TrainerCallback):
     def _check_max_epsilon_exceeded(self, state: TrainerState, control: TrainerControl) -> TrainerControl:
         eps = self.accountant.compute_epsilon(steps=state.global_step + 1)
         if eps > self._max_epsilon:
-            logger.info("Max epsilon will be exceeded if trained for one more step. Stopping training.")
+            logger.info("Max epsilon exceeded. Stopping training.")
             control.should_training_stop = True
         return control
 

--- a/src/nemo_safe_synthesizer/privacy/dp_transformers/privacy_args.py
+++ b/src/nemo_safe_synthesizer/privacy/dp_transformers/privacy_args.py
@@ -24,13 +24,15 @@ logger = get_logger()
 @dataclass
 class SafeSynthesizerAccountant:
     def __init__(self, use_prv: bool, noise_multiplier, sampling_probability, delta, num_steps):
+        # +1 provides headroom for a forward-looking epsilon check
+        # (i.e. "would one more step exceed the budget?").
+        self.max_compositions = num_steps + 1
         if use_prv:
-            # TODO: +1 was added in max_compositions due to a bug in NavFT, we should try to fix it
             self.accountant = PRVAccountant(
                 noise_multiplier=noise_multiplier,
                 sampling_probability=sampling_probability,
                 delta=delta,
-                max_compositions=num_steps + 1,
+                max_compositions=self.max_compositions,
                 eps_error=0.01,
             )
         else:
@@ -40,6 +42,11 @@ class SafeSynthesizerAccountant:
 
     def compute_epsilon(self, steps):
         if self.use_prv:
+            # Cap to max_compositions so callers never exceed the
+            # accountant's pre-computed range.  This can happen when the
+            # HF Trainer runs an extra optimizer step for an incomplete
+            # gradient-accumulation batch at the end of an epoch.
+            steps = min(steps, self.max_compositions)
             return self.accountant.compute_epsilon(steps)[2]
         else:
             return self.accountant.get_epsilon(self.delta)

--- a/tests/training/test_dp_accountant.py
+++ b/tests/training/test_dp_accountant.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Unit tests for SafeSynthesizerAccountant, covering the clamping
+behaviour that prevents crashes when the HF Trainer runs more
+optimizer steps than the PRV accountant was configured for.
+"""
+
+import pytest
+from nemo_safe_synthesizer.privacy.dp_transformers.privacy_args import SafeSynthesizerAccountant
+
+# Representative DP-training parameters (low num_steps keeps the test fast).
+NOISE_MULTIPLIER = 1.0
+SAMPLING_PROBABILITY = 0.01
+DELTA = 1e-5
+NUM_STEPS = 10
+
+
+@pytest.fixture
+def prv_accountant():
+    return SafeSynthesizerAccountant(
+        use_prv=True,
+        noise_multiplier=NOISE_MULTIPLIER,
+        sampling_probability=SAMPLING_PROBABILITY,
+        delta=DELTA,
+        num_steps=NUM_STEPS,
+    )
+
+
+class TestSafeSynthesizerAccountant:
+    """Tests for SafeSynthesizerAccountant.compute_epsilon clamping."""
+
+    def test_compute_epsilon_within_range(self, prv_accountant):
+        """compute_epsilon works normally for steps within max_compositions."""
+        eps = prv_accountant.compute_epsilon(steps=NUM_STEPS)
+        assert isinstance(eps, float)
+        assert eps > 0
+
+    def test_compute_epsilon_at_max_compositions(self, prv_accountant):
+        """compute_epsilon works at the exact max_compositions boundary."""
+        max_comp = prv_accountant.max_compositions  # num_steps + 1
+        eps = prv_accountant.compute_epsilon(steps=max_comp)
+        assert isinstance(eps, float)
+        assert eps > 0
+
+    def test_compute_epsilon_beyond_max_compositions_does_not_raise(self, prv_accountant):
+        """compute_epsilon clamps instead of raising when steps exceed max_compositions."""
+        beyond = prv_accountant.max_compositions + 1
+        eps = prv_accountant.compute_epsilon(steps=beyond)
+        assert isinstance(eps, float)
+        assert eps > 0
+
+    def test_compute_epsilon_clamped_equals_max(self, prv_accountant):
+        """Clamped result equals the result at max_compositions."""
+        max_comp = prv_accountant.max_compositions
+        eps_at_max = prv_accountant.compute_epsilon(steps=max_comp)
+        eps_beyond = prv_accountant.compute_epsilon(steps=max_comp + 5)
+        assert eps_at_max == eps_beyond
+
+    def test_epsilon_increases_with_steps(self, prv_accountant):
+        """Sanity check: more compositions means higher epsilon."""
+        eps_low = prv_accountant.compute_epsilon(steps=1)
+        eps_high = prv_accountant.compute_epsilon(steps=NUM_STEPS)
+        assert eps_high > eps_low


### PR DESCRIPTION
depends on #43. tracks https://gitlab-master.nvidia.com/aire/microservices/nmp/-/issues/3676 internally:

> When running Mistral-7B with DP enabled, we get this error "Requested number of compositions exceeds the maximum number of compositions" Also observed with other models when num_input_records_to_sample=10000 
> These runs are with epsilon=8.