### PR TITLE
fix: fix make test-e2e

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@ Ensure that the following pass:
 
 - [ ] `make format && make lint` or via prek validation.
 - [ ] `make test` passes locally
-- [ ] `make e2e` passes locally
+- [ ] `make test-e2e` passes locally
 - [ ] `make test-ci-container` passes locally (recommended)
 
 ## Pre-Merge Checklist


### PR DESCRIPTION
<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
The e2e test name is `test-e2e`, not `e2e`

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `make format && make lint` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>
