### PR TITLE
chore(docs): remove decorative bold from markdown files

### DIFF
--- a/.cursor/agents/verifier.md
+++ b/.cursor/agents/verifier.md
@@ -12,24 +12,24 @@ You are a skeptical verification agent. Your job is to confirm that completed wo
 
 ## Core Principles
 
-1. **Be skeptical by default.** Assume nothing works until you have evidence it does.
-2. **Run the tests.** Execute the relevant test suite to verify implementations produce correct results. If tests don't exist for the changed code, flag that as a gap.
-3. **Look for edge cases.** Consider boundary conditions, empty inputs, error paths, type mismatches, and concurrency issues that the implementation may not handle.
-4. **Check integration points.** Verify that changes work correctly with the rest of the system, not just in isolation.
+1. Be skeptical by default. Assume nothing works until you have evidence it does.
+2. Run the tests. Execute the relevant test suite to verify implementations produce correct results. If tests don't exist for the changed code, flag that as a gap.
+3. Look for edge cases. Consider boundary conditions, empty inputs, error paths, type mismatches, and concurrency issues that the implementation may not handle.
+4. Check integration points. Verify that changes work correctly with the rest of the system, not just in isolation.
 
 ## Verification Workflow
 
-1. **Identify what changed.** Review the diff or task description to understand what was implemented.
-2. **Run existing tests.** Execute tests related to the changed code (`make test` or targeted pytest invocations). Report pass/fail results verbatim.
-3. **Inspect edge cases.** Read the implementation and reason about inputs and states that could break it — nulls, empty collections, large inputs, malformed data, permission errors, race conditions.
-4. **Validate behavior.** If feasible, run the code or a quick smoke test to confirm the feature works end-to-end beyond what unit tests cover.
-5. **Report findings.** Clearly state what passed, what failed, and what remains untested. Be specific — include file paths, test names, and error output.
+1. Identify what changed. Review the diff or task description to understand what was implemented.
+2. Run existing tests. Execute tests related to the changed code (`make test` or targeted pytest invocations). Report pass/fail results verbatim.
+3. Inspect edge cases. Read the implementation and reason about inputs and states that could break it — nulls, empty collections, large inputs, malformed data, permission errors, race conditions.
+4. Validate behavior. If feasible, run the code or a quick smoke test to confirm the feature works end-to-end beyond what unit tests cover.
+5. Report findings. Clearly state what passed, what failed, and what remains untested. Be specific — include file paths, test names, and error output.
 
 ## Output Format
 
 Summarize your findings as:
 
-- **Status**: PASS | FAIL | PARTIAL
-- **Tests run**: list of test commands executed and their results
-- **Issues found**: any failures, edge cases, or gaps discovered
-- **Untested areas**: aspects of the implementation that lack coverage
+- Status: PASS | FAIL | PARTIAL
+- Tests run: list of test commands executed and their results
+- Issues found: any failures, edge cases, or gaps discovered
+- Untested areas: aspects of the implementation that lack coverage

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,7 +24,7 @@ GPU tests (`gpu-tests.yml`) run on NVIDIA self-hosted runners, which block `pull
 1. When a PR is opened by a trusted user with trusted changes, `copy-pr-bot` automatically copies the code to a `pull-request/<number>` branch
 2. The push to `pull-request/<number>` triggers the GPU workflow
 3. Untrusted PRs require a vetter to comment `/ok to test <SHA>` before GPU tests run
-4. Draft PRs do **not** auto-sync (`auto_sync_draft: false`), saving GPU resources
+4. Draft PRs do not auto-sync (`auto_sync_draft: false`), saving GPU resources
 
 Configuration: [`.github/copy-pr-bot.yaml`](../copy-pr-bot.yaml)
 
@@ -89,12 +89,12 @@ flowchart LR
 
 The `ci-checks.yml` workflow runs on every push to `main` and on pull requests:
 
-- **Detect Changes**: Uses `dorny/paths-filter` to skip jobs when only non-source files change
-- **Format**: Verifies code formatting with `ruff format --check`
-- **Lint**: Runs `ruff check` linting
-- **Typecheck**: Runs `ty` type checks
-- **Unit Tests**: Runs pytest with coverage
-- **CI Status**: Aggregation job -- single required check for branch protection
+- Detect Changes: Uses `dorny/paths-filter` to skip jobs when only non-source files change
+- Format: Verifies code formatting with `ruff format --check`
+- Lint: Runs `ruff check` linting
+- Typecheck: Runs `ty` type checks
+- Unit Tests: Runs pytest with coverage
+- CI Status: Aggregation job -- single required check for branch protection
 
 All jobs run on `ubuntu-latest` (GitHub-hosted).
 
@@ -102,8 +102,8 @@ All jobs run on `ubuntu-latest` (GitHub-hosted).
 
 The `gpu-tests.yml` workflow runs on pushes to `main` and `pull-request/*` branches (via copy-pr-bot):
 
-- **GPU E2E Tests**: Runs end-to-end tests on `linux-amd64-gpu-a100-latest-1` (A100) with a 60-minute job timeout and 45-minute step timeout
-- **GPU CI Status**: Aggregation job -- single required check for branch protection
+- GPU E2E Tests: Runs end-to-end tests on `linux-amd64-gpu-a100-latest-1` (A100) with a 60-minute job timeout and 45-minute step timeout
+- GPU CI Status: Aggregation job -- single required check for branch protection
 
 ### Runners
 
@@ -160,16 +160,16 @@ The `internal-release.yml` workflow builds a wheel and publishes it to NVIDIA Ar
 
 ### How to Publish Internally
 
-**Via GitHub Actions:**
+Via GitHub Actions:
 
-1. Go to **Actions** > **Internal Release**
-2. Click **Run workflow**
+1. Go to Actions > Internal Release
+2. Click Run workflow
 3. Enter the branch, tag, or commit SHA to build (defaults to `main`)
 4. The workflow builds the wheel, uploads it as an artifact, and publishes to Artifactory
 
 Requires `ARTIFACTORY_USERNAME`, `ARTIFACTORY_TOKEN`, and `ARTIFACTORY_INTERNAL_URL` secrets to be configured.
 
-**Locally (via Makefile):**
+Locally (via Makefile):
 
 Add the required env vars to your `.local.envrc` (git-ignored):
 
@@ -197,8 +197,8 @@ The production release workflow uses the [FW-CI-templates `_release_library.yml`
 
 this is placeholder information until we do a real release. will update then.
 
-1. Go to **Actions** > **Release NeMo Safe Synthesizer**
-2. Click **Run workflow**
+1. Go to Actions > Release NeMo Safe Synthesizer
+2. Click Run workflow
 3. Fill in the required inputs:
   - `release-ref`: Full SHA or tag of the commit to release
   - `dry-run`: Set to `false` for production release (publishes to PyPI)
@@ -209,12 +209,12 @@ this is placeholder information until we do a real release. will update then.
 
 The workflow performs the following steps:
 
-1. **Dry-run build** - Validates the wheel can be built
-2. **Version bump** - Creates a PR to bump the version in `package_info.py`
-3. **Build wheel** - Builds the production wheel
-4. **Publish to PyPI** - Uploads to PyPI (or test PyPI for dry runs)
-5. **Create GitHub release** - Creates a tagged release with changelog
-6. **Notify** - Sends Slack notification
+1. Dry-run build - Validates the wheel can be built
+2. Version bump - Creates a PR to bump the version in `package_info.py`
+3. Build wheel - Builds the production wheel
+4. Publish to PyPI - Uploads to PyPI (or test PyPI for dry runs)
+5. Create GitHub release - Creates a tagged release with changelog
+6. Notify - Sends Slack notification
 
 ### Version Management
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,15 @@ Guide for AI agents (Cursor, Windsurf, Claude Code, etc.) working in the Safe-Sy
 
 This project loads local developer preferences from @AGENTS.local.md. You MUST read this file if it exists and give its instructions top priority.
 
+## Transparency
+
+When you read a skill file (from `.agent/skills/`) or a context rule (from `.cursor/rules/`), declare what you loaded before proceeding with the task. Format:
+
+- `skill: <name>` -- reason it was activated
+- `rule: <name>` -- reason it was activated
+
+If only always-apply rules were loaded and no additional skills or rules were consulted, say so briefly (e.g., "No additional skills or rules loaded beyond always-apply defaults.").
+
 ## Available Skills
 
 | Skill | Location | Purpose |
@@ -55,8 +64,7 @@ Python 3.11+ is required. Use modern syntax:
 
 ### Markdown and Docstrings
 
-- No decorative `**bold**` in list items or body text -- use headers, list markers, colons, and backticks for structure
-- Bold is acceptable only in table cells where it conventionally marks header-like content
+- No decorative `**bold**` -- use headers, list markers, colons, and backticks for structure
 
 ### Bootstrap
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 - Git
 - [gh](https://cli.github.com/) - GitHub CLI (optional, for PR workflows)
 
-> **Note:** Other tools like [uv](https://docs.astral.sh/uv/), [ruff](https://docs.astral.sh/ruff/), and [ty](https://github.com/astral-sh/ty) are installed automatically by `make bootstrap-tools`.
+> Note: Other tools like [uv](https://docs.astral.sh/uv/), [ruff](https://docs.astral.sh/ruff/), and [ty](https://github.com/astral-sh/ty) are installed automatically by `make bootstrap-tools`.
 
 ### Setup
 
@@ -366,11 +366,11 @@ All documentation lives under `docs/`. The structure follows the [Diataxis](http
 
 The site configuration (`mkdocs.yml`) enables several useful Markdown extensions:
 
-- **Admonitions** -- callout boxes (`!!! note`, `!!! warning`, `??? tip` for collapsible)
-- **Content tabs** -- tabbed content blocks (`=== "Python SDK"` / `=== "CLI"`)
-- **Code blocks** -- syntax highlighting, line numbers, copy button, and annotations
-- **Mermaid diagrams** -- fenced code blocks with ` ```mermaid `
-- **Task lists**, **footnotes**, **definition lists**, and **emoji**
+- Admonitions -- callout boxes (`!!! note`, `!!! warning`, `??? tip` for collapsible)
+- Content tabs -- tabbed content blocks (`=== "Python SDK"` / `=== "CLI"`)
+- Code blocks -- syntax highlighting, line numbers, copy button, and annotations
+- Mermaid diagrams -- fenced code blocks with ` ```mermaid `
+- Task lists, footnotes, definition lists, and emoji
 
 See the [MkDocs Material reference](https://squidfunk.github.io/mkdocs-material/reference/) for full syntax.
 
@@ -385,10 +385,10 @@ Documentation is deployed to GitHub Pages automatically when changes to `docs/`,
 ## AI Agents
 
 This project supports AI coding assistants (Cursor, Windsurf, Claude Code). Key files:
-- **AGENTS.md** -- primary agent guide
-- **.agent/skills/** -- domain-specific skills (canonical location)
-- **.cursor/rules/** -- Cursor workflow rules
-- **.cursor/skills/** -- symlinks to `.agent/skills/` for Cursor discoverability
+- `AGENTS.md` -- primary agent guide
+- `.agent/skills/` -- domain-specific skills (canonical location)
+- `.cursor/rules/` -- Cursor workflow rules
+- `.cursor/skills/` -- symlinks to `.agent/skills/` for Cursor discoverability
 
 Before contributing, run `make format` and `make lint`. See AGENTS.md for full conventions.
 

--- a/README.md
+++ b/README.md
@@ -260,9 +260,9 @@ Additionally, the registry supports custom config overrides or args that are spe
 
 You can supply a dataset registry (YAML file) via either the CLI or an environment variable:
 
-- **CLI Option**:
+- CLI Option:
 `--dataset-registry <path_or_url>`
-- **Environment Variable**:
+- Environment Variable:
 Set `NSS_DATASET_REGISTRY` to point to your YAML file (path or URL).
 
 If both are provided, the CLI option takes precedence.
@@ -318,9 +318,9 @@ For running on Slurm clusters, Safe Synthesizer provides a set of helper scripts
 
 These scripts support:
 
-- **Matrix runs**: Launching jobs across multiple configurations and datasets.
-- **Two-stage pipelines**: Running training and generation as separate jobs with dependencies.
-- **Containerized execution**: Running jobs inside enroot containers.
+- Matrix runs: Launching jobs across multiple configurations and datasets.
+- Two-stage pipelines: Running training and generation as separate jobs with dependencies.
+- Containerized execution: Running jobs inside enroot containers.
 
 See [script/slurm/README.md](script/slurm/README.md) for detailed instructions on cluster setup and job submission.
 

--- a/design.md
+++ b/design.md
@@ -202,50 +202,50 @@ flowchart LR
 
 ### 1. Configuration Layer
 
-**Path**: `src/nemo_safe_synthesizer/config/`
+Path: `src/nemo_safe_synthesizer/config/`
 
-- **SafeSynthesizerParameters**: Main configuration class that aggregates all parameters
-- **DataParameters**: Dataset and preprocessing configurations
-- **TrainingHyperparams**: Training settings (learning rate, epochs, batch size, etc.)
-- **GenerateParameters**: Generation settings (temperature, top_p, num_records, etc.)
-- **EvaluationParameters**: Evaluation component toggles and settings
-- **PiiReplacerConfig**: PII detection and replacement settings
-- **DifferentialPrivacyHyperparams**: DP training parameters (epsilon, delta, clipping norm)
+- `SafeSynthesizerParameters`: Main configuration class that aggregates all parameters
+- `DataParameters`: Dataset and preprocessing configurations
+- `TrainingHyperparams`: Training settings (learning rate, epochs, batch size, etc.)
+- `GenerateParameters`: Generation settings (temperature, top_p, num_records, etc.)
+- `EvaluationParameters`: Evaluation component toggles and settings
+- `PiiReplacerConfig`: PII detection and replacement settings
+- `DifferentialPrivacyHyperparams`: DP training parameters (epsilon, delta, clipping norm)
 
 ### 2. Data Processing Pipeline
 
-**Path**: `src/nemo_safe_synthesizer/data_processing/`
+Path: `src/nemo_safe_synthesizer/data_processing/`
 
 #### Components:
 
-- **Holdout** (`holdout/`): Splits data into train/test sets with stratification support
-- **NemoPII** (`pii_replacer/`): 
+- Holdout (`holdout/`): Splits data into train/test sets with stratification support
+- `NemoPII` (`pii_replacer/`): 
   - Detects PII entities (names, emails, SSN, etc.)
   - Replaces with synthetic but realistic values
   - Maintains column statistics
-- **ActionExecutor** (`actions/`): Executes data transformations (date normalization, distributions)
-- **ExampleAssembler** (`assembler.py`): 
+- `ActionExecutor` (`actions/`): Executes data transformations (date normalization, distributions)
+- `ExampleAssembler` (`assembler.py`): 
   - Converts records to JSON format
   - Tokenizes for model training
   - Handles truncation and padding
 
 ### 3. Training Backend
 
-**Path**: `src/nemo_safe_synthesizer/training/`
+Path: `src/nemo_safe_synthesizer/training/`
 
 #### Abstract Base:
 
-- **TrainingBackend**: Defines interface for training implementations
+- `TrainingBackend`: Defines interface for training implementations
 
 #### Implementations:
 
-- **HuggingFaceBackend**: 
+- `HuggingFaceBackend`: 
   - Supports quantization (4-bit, 8-bit via bitsandbytes)
   - LoRA fine-tuning via PEFT
   - Differential Privacy via Opacus integration
   - Custom callbacks for monitoring
   
-- **UnslothBackend**: Optimized training with Unsloth library
+- `UnslothBackend`: Optimized training with Unsloth library
 
 #### Key Features:
 
@@ -256,43 +256,43 @@ flowchart LR
 
 ### 4. Generation Backend
 
-**Path**: `src/nemo_safe_synthesizer/generation/`
+Path: `src/nemo_safe_synthesizer/generation/`
 
 #### Components:
 
-- **VllmBackend**: 
+- `VllmBackend`: 
   - Fast inference using VLLM
   - Loads base model + LoRA adapter
   - Batch generation support
   
-- **RegexManager**: 
+- `RegexManager`: 
   - Enforces structured output (JSON format)
   - Validates generated records
   
-- **Processors**: Post-processing of generated text
-- **BatchGenerator**: Manages batch generation with retry logic
-- **Stopping Criteria**: Custom stopping conditions for generation
+- Processors: Post-processing of generated text
+- `BatchGenerator`: Manages batch generation with retry logic
+- Stopping Criteria: Custom stopping conditions for generation
 
 ### 5. Evaluation System
 
-**Path**: `src/nemo_safe_synthesizer/evaluation/`
+Path: `src/nemo_safe_synthesizer/evaluation/`
 
 #### Core:
 
-- **Evaluator**: Orchestrates all evaluation components
+- Evaluator: Orchestrates all evaluation components
 
 #### Evaluation Components (`components/`):
 
-- **Data Privacy Score**: Overall privacy assessment
-- **PII Replay**: Detects if original PII values appear in synthetic data
-- **Membership Inference Protection**: Measures resistance to MI attacks
-- **Attribute Inference Protection**: Measures resistance to AI attacks
-- **Column Distributions**: Statistical similarity of distributions
-- **Correlations**: Preservation of column relationships
-- **Text Semantic Similarity**: Semantic similarity (embedding-based)
-- **Text Structure Similarity**: Structural similarity
-- **SQS Score**: Synthetic Quality Score
-- **Deep Structure**: Deep structural analysis
+- Data Privacy Score: Overall privacy assessment
+- PII Replay: Detects if original PII values appear in synthetic data
+- Membership Inference Protection: Measures resistance to MI attacks
+- Attribute Inference Protection: Measures resistance to AI attacks
+- Column Distributions: Statistical similarity of distributions
+- Correlations: Preservation of column relationships
+- Text Semantic Similarity: Semantic similarity (embedding-based)
+- Text Structure Similarity: Structural similarity
+- SQS Score: Synthetic Quality Score
+- Deep Structure: Deep structural analysis
 
 #### Reporting (`reports/`, `render.py`):
 
@@ -305,27 +305,27 @@ flowchart LR
 
 #### LLM Utilities (`llm/`)
 
-- **LLM Definition**: Model metadata and configuration
-- **Model Loading**: Utilities for loading models
-- **Memory Management**: VRAM optimization
+- LLM Definition: Model metadata and configuration
+- Model Loading: Utilities for loading models
+- Memory Management: VRAM optimization
 
 #### Privacy Module (`privacy/dp_transformers/`)
 
-- **OpacusDPTrainer**: Integration with Opacus for DP-SGD
-- **Privacy Arguments**: DP hyperparameters
-- **Custom Layers**: DP-compatible layers
+- `OpacusDPTrainer`: Integration with Opacus for DP-SGD
+- Privacy Arguments: DP hyperparameters
+- Custom Layers: DP-compatible layers
 
 #### Artifacts (`artifacts/`)
 
-- **Analyzers**: Data quality checks and field analysis
-- **Metadata**: Dataset metadata management
-- **Manifest**: Artifact tracking
+- Analyzers: Data quality checks and field analysis
+- Metadata: Dataset metadata management
+- Manifest: Artifact tracking
 
 #### Records System (`data_processing/records/`)
 
-- **JSONRecord**: JSON record representation
-- **Fragment**: Record fragment handling
-- **ValuePath**: Path-based value access
+- JSONRecord: JSON record representation
+- Fragment: Record fragment handling
+- `ValuePath`: Path-based value access
 
 ---
 
@@ -364,13 +364,13 @@ The execution follows a clear pipeline: Data → PII Replacement → Training �
 
 ## Technology Stack
 
-- **ML Frameworks**: PyTorch, Transformers, PEFT (LoRA)
-- **Inference**: VLLM for fast generation
-- **Privacy**: Opacus for Differential Privacy
-- **Data**: Pandas, Datasets (HuggingFace)
-- **Config**: Pydantic for validation
-- **CLI**: Click for command-line interface
-- **Visualization**: Jinja2, HTML/CSS/JS for reports
+- ML Frameworks: PyTorch, Transformers, PEFT (LoRA)
+- Inference: VLLM for fast generation
+- Privacy: Opacus for Differential Privacy
+- Data: Pandas, Datasets (HuggingFace)
+- Config: Pydantic for validation
+- CLI: Click for command-line interface
+- Visualization: Jinja2, HTML/CSS/JS for reports
 
 ---
 
@@ -401,14 +401,14 @@ results = synthesizer.results
 
 ## Data Flow
 
-1. **Input**: Raw CSV/DataFrame with potentially sensitive data
-2. **Holdout**: Split into train/test sets
-3. **PII Replacement**: Detect and replace PII in training set only
-4. **Data Assembly**: Convert to JSON format and tokenize
-5. **Training**: Fine-tune LLM with LoRA (+ optional DP)
-6. **Generation**: Generate synthetic records using trained adapter
-7. **Evaluation**: Compute privacy and quality metrics
-8. **Output**: 
+1. Input: Raw CSV/DataFrame with potentially sensitive data
+2. Holdout: Split into train/test sets
+3. PII Replacement: Detect and replace PII in training set only
+4. Data Assembly: Convert to JSON format and tokenize
+5. Training: Fine-tune LLM with LoRA (+ optional DP)
+6. Generation: Generate synthetic records using trained adapter
+7. Evaluation: Compute privacy and quality metrics
+8. Output: 
    - Synthetic data CSV
    - HTML evaluation report
    - Timing and summary statistics
@@ -455,21 +455,21 @@ safe-synthesizer-artifacts/
 
 ## Extension Points
 
-1. **Custom Training Backend**: Implement `TrainingBackend` abstract class
-2. **Custom Generation Backend**: Implement `GeneratorBackend` abstract class
-3. **Custom Evaluation Component**: Extend `Component` base class
-4. **Custom Data Actions**: Add to `data_processing/actions/`
-5. **Custom PII Detectors**: Extend NER pipeline
+1. Custom Training Backend: Implement `TrainingBackend` abstract class
+2. Custom Generation Backend: Implement `GeneratorBackend` abstract class
+3. Custom Evaluation Component: Extend `Component` base class
+4. Custom Data Actions: Add to `data_processing/actions/`
+5. Custom PII Detectors: Extend NER pipeline
 
 ---
 
 ## Performance Considerations
 
-- **Quantization**: 4-bit/8-bit quantization for memory efficiency
-- **LoRA**: Low-rank adaptation for efficient fine-tuning
-- **VLLM**: Optimized inference with PagedAttention
-- **Batch Processing**: Configurable batch sizes for generation
-- **GPU Memory Management**: Automatic cleanup and optimization
+- Quantization: 4-bit/8-bit quantization for memory efficiency
+- `LoRA`: Low-rank adaptation for efficient fine-tuning
+- VLLM: Optimized inference with PagedAttention
+- Batch Processing: Configurable batch sizes for generation
+- GPU Memory Management: Automatic cleanup and optimization
 
 ---
 

--- a/script/slurm/README.md
+++ b/script/slurm/README.md
@@ -16,10 +16,10 @@ Pipeline entrypoints (invoked by Slurm scripts) via uv:
 
 ### Prerequisites
 
-- **Slurm Cluster Access:** Ensure you have access to the Slurm clusters. You can verify this by running `ssh cs-oci-ord-login-01.nvidia.com` in your terminal (VPN connection required). For an introduction to Slurm, see [these onboarding resources](https://confluence.nvidia.com/display/HWINFCSSUP/Onboarding+to+Clusters).
-- **NIM API Key:** You will need a `NIM_API_KEY` to run column classification. If you do not have one, you can generate it at [build.nvidia.com](https://build.nvidia.com) using your `nvidian` organization account.
-- **Enroot Credentials** Follow https://confluence.nvidia.com/display/HWINFCSSUP/Using+Containers#UsingContainers-SettingupEnrootCredentials. You should add the lines for all 3 of `nvcr.io`, `authn.nvidia.com`, and `gitlab-master.nvidia.com`.
-- **uv and python install in the slurm cluster**
+- Slurm Cluster Access: Ensure you have access to the Slurm clusters. You can verify this by running `ssh cs-oci-ord-login-01.nvidia.com` in your terminal (VPN connection required). For an introduction to Slurm, see [these onboarding resources](https://confluence.nvidia.com/display/HWINFCSSUP/Onboarding+to+Clusters).
+- NIM API Key: You will need a `NIM_API_KEY` to run column classification. If you do not have one, you can generate it at [build.nvidia.com](https://build.nvidia.com) using your `nvidian` organization account.
+- Enroot Credentials Follow https://confluence.nvidia.com/display/HWINFCSSUP/Using+Containers#UsingContainers-SettingupEnrootCredentials. You should add the lines for all 3 of `nvcr.io`, `authn.nvidia.com`, and `gitlab-master.nvidia.com`.
+- uv and python install in the slurm cluster
   - This is a strongly recommended setup, but is not be the only way to get things working.
   - The key issues about working in slurm we need to address
     - /home/$USER is quite small (10 GB) and not recommended for accessing data, easily filled up by uv cache
@@ -41,8 +41,8 @@ uv python install 3.11
 
 #### Nice to have
 
-- **Passwordless login** See https://confluence.nvidia.com/display/HWINFCSSUP/Setting+Up+Passwordless+SSH+Key+Authentication?src=contextnavpagetreemode
-- **Env vars in .bashrc**
+- Passwordless login See https://confluence.nvidia.com/display/HWINFCSSUP/Setting+Up+Passwordless+SSH+Key+Authentication?src=contextnavpagetreemode
+- Env vars in .bashrc
   - Add `export VARIABLE=VALUE` to the end of `~/.bashrc` for commonly used environment variables, like `USER_NAME` and `LUSTRE_DIR`.
   - Recommended snippet to have in `~/.bashrc` so uv and python work on login node and slurm jobs:
 ```bash
@@ -93,7 +93,7 @@ Edit `env_variables.sh` to match your environment. Key items:
 - `NSS_SHARED_DIR`: location of shared files such as benchmark data and container images, see section below for details.
 - Time limits: `CONFIG_TIME_LIMITS_SHORT` and `CONFIG_TIME_LIMITS_LONG` associative maps. Keys are matched by pattern (`unsloth`, `dp`), falling back to `max`.
 
-**NSS CLI Environment Variables** (used by `safe-synthesizer` CLI via pydantic-settings):
+NSS CLI Environment Variables (used by `safe-synthesizer` CLI via pydantic-settings):
 - `NSS_ARTIFACTS_PATH`: Base directory for artifacts (aliased from `ADAPTER_PATH`).
 - `NSS_PHASE`: Current phase (train, generate, end_to_end).
 - `NSS_CONFIG`: Path to YAML config file.
@@ -117,23 +117,23 @@ bash submit_slurm_jobs.sh --exp-name matrix_seq --dataset-group short --runs 1 -
 bash submit_slurm_jobs.sh --exp-name matrix_e2e_seq --dataset-group short --runs 1 --partition polar4 --pipeline-mode end_to_end --submit-mode sequential
 ```
 
-- **CONFIGS source**: By default, configs come from `CONFIGS=(...)` in `env_variables.sh`. Override with `--configs c1,c2` (base names without `.yaml`).
-- **RUNS**: Number of runs per dataset-config pair.
-- **PARTITION**: Slurm partition to use. See partition info in your cluster docs.
-- **EXP_NAME**: Experiment namespace for logs/outputs.
-- **DATASET_GROUP**: `short` or `long` (selects built-in dataset sets and time limits).
-- **SLEEP_SEC**: Pause between submissions to reduce image import contention.
-- **PIPELINE_MODE**: `two_stage` (TRAIN→GEN with dependency) or `end_to_end` (single job).
-- **SUBMIT_MODE**: `array` (submit arrays) or `sequential` (submit jobs with dependencies per dataset/run).
-- **WANDB_PROJECT**: Name of the Weights & Biases project to track experiments. Defaults to the experiment name if not specified.
+- CONFIGS source: By default, configs come from `CONFIGS=(...)` in `env_variables.sh`. Override with `--configs c1,c2` (base names without `.yaml`).
+- RUNS: Number of runs per dataset-config pair.
+- PARTITION: Slurm partition to use. See partition info in your cluster docs.
+- `EXP_NAME`: Experiment namespace for logs/outputs.
+- `DATASET_GROUP`: `short` or `long` (selects built-in dataset sets and time limits).
+- `SLEEP_SEC`: Pause between submissions to reduce image import contention.
+- `PIPELINE_MODE`: `two_stage` (TRAIN→GEN with dependency) or `end_to_end` (single job).
+- `SUBMIT_MODE`: `array` (submit arrays) or `sequential` (submit jobs with dependencies per dataset/run).
+- `WANDB_PROJECT`: Name of the Weights & Biases project to track experiments. Defaults to the experiment name if not specified.
 
-**How many jobs will run concurrently?**
+How many jobs will run concurrently?
 
 For the built-in `short` group there are currently 17 datasets (see `slurm_nss_matrix.sh`).
 - In `two_stage` mode with arrays, the submitter launches one TRAIN array and one GEN array. GEN tasks are linked to corresponding TRAIN tasks via `aftercorr`. Effective max concurrency is cluster/partition limited, but GEN tasks won’t start until their matching TRAIN tasks succeed.
 - In `end_to_end` mode, a single array is submitted of size `num_datasets * RUNS * NUM_CONFIGS`.
 
-**How long will my jobs take?**
+How long will my jobs take?
 With `num_input_records_to_sample=25000`
 - For the baseline config, the longest job typically finishes within 80 minutes. Total wall time estimate: `60 * RUNS` minutes.
 - For the `dp` config, the longest job typically finishes within 120 minutes. Total wall time estimate: `120 * RUNS` minutes.

--- a/src/nemo_safe_synthesizer/TIMESERIES_README.md
+++ b/src/nemo_safe_synthesizer/TIMESERIES_README.md
@@ -23,12 +23,12 @@ Time series support enables Safe Synthesizer to generate synthetic tabular data 
 
 ### Key Features
 
-- **Unified grouped architecture**: All time series are processed through a unified grouped architecture. Single-sequence data is automatically treated as a single group via an internal pseudo-group column, enabling consistent processing paths.
-- **Sliding window generation**: Uses a sliding window approach where recently generated records are fed back as context for generating the next batch.
-- **Parallel group generation**: Multiple groups are processed in parallel batches for efficiency, even single-sequence data uses this optimized path.
-- **Time-range based generation**: The number of records generated is determined by the configured time range and interval `(stop_timestamp - start_timestamp) / interval_seconds`, not by a target count.
-- **Chronological constraint enforcement**: Validates that generated timestamps follow the expected interval pattern.
-- **Autocorrelation-based evaluation**: Measures how well the synthetic data preserves temporal patterns from the original data. (ToDo)
+- Unified grouped architecture: All time series are processed through a unified grouped architecture. Single-sequence data is automatically treated as a single group via an internal pseudo-group column, enabling consistent processing paths.
+- Sliding window generation: Uses a sliding window approach where recently generated records are fed back as context for generating the next batch.
+- Parallel group generation: Multiple groups are processed in parallel batches for efficiency, even single-sequence data uses this optimized path.
+- Time-range based generation: The number of records generated is determined by the configured time range and interval `(stop_timestamp - start_timestamp) / interval_seconds`, not by a target count.
+- Chronological constraint enforcement: Validates that generated timestamps follow the expected interval pattern.
+- Autocorrelation-based evaluation: Measures how well the synthetic data preserves temporal patterns from the original data. (ToDo)
 
 ---
 
@@ -47,7 +47,7 @@ Located in `src/nemo_safe_synthesizer/config/time_series.py`, this configuration
 | `start_timestamp` | `str \| int \| None` | `None` | Start timestamp for generation. Defaults to the first timestamp in the training data (validated to be consistent across groups). |
 | `stop_timestamp` | `str \| int \| None` | `None` | Stop timestamp for generation. Defaults to the last timestamp in the training data (validated to be consistent across groups). |
 
-**Validation Rules:**
+Validation Rules:
 - When `is_timeseries=True`, at least one of `timestamp_column` or `timestamp_interval_seconds` must be provided.
 - When `is_timeseries=False`, `timestamp_column` cannot be set.
 - For grouped time series, `group_training_examples_by` (in data config) should also be set.
@@ -88,34 +88,34 @@ Time series preprocessing occurs during training data preparation in `src/nemo_s
 
 ### Processing Steps
 
-1. **Pseudo-Group Column Addition**
+1. Pseudo-Group Column Addition
    - If no `group_training_examples_by` column is specified, a `__pseudo_group__` column is added with all rows set to 0.
    - This unifies the processing of grouped and ungrouped time series through a single code path.
 
-2. **Timestamp Column Creation (if needed)**
+2. Timestamp Column Creation (if needed)
    - If `timestamp_column` is not provided but `timestamp_interval_seconds` is, a synthetic `elapsed_seconds` column is created.
    - Records are indexed sequentially with the specified interval per group.
 
-3. **Validation**
+3. Validation
    - Verifies the timestamp column exists in the data.
    - Checks for missing values in the timestamp column.
 
-4. **Sorting**
+4. Sorting
    - Data is always sorted by group column first, then by timestamp within each group.
    - Even ungrouped data follows this pattern (using the pseudo-group column).
 
-5. **Format Inference and Conversion**
+5. Format Inference and Conversion
    - If `timestamp_format` is not provided, attempts to infer the datetime format using `guess_datetime_format()`.
    - Special format `"elapsed_seconds"` indicates integer elapsed time (not datetime).
    - Validates user-provided format matches the actual data.
    - Converts timestamp column to datetime for processing (then back to string format).
 
-6. **Interval Inference and Validation**
+6. Interval Inference and Validation
    - Collects timestamp statistics for each group.
    - If `timestamp_interval_seconds` is provided, validates that actual intervals match (with 0.1s tolerance).
    - If not provided, infers the interval only if all groups have consistent intervals.
 
-7. **Start/Stop Consistency Validation**
+7. Start/Stop Consistency Validation
    - Validates that all groups have the same start and stop timestamps.
    - If timestamps differ across groups, raises a `DataError`.
    - Sets `start_timestamp` and `stop_timestamp` in config based on validated values.
@@ -145,23 +145,23 @@ The `SequentialExampleAssembler` in `src/nemo_safe_synthesizer/data_processing/a
 
 ### Key Differences from Tabular Assembler
 
-1. **No Shuffling**: Records maintain their original order to preserve temporal relationships.
+1. No Shuffling: Records maintain their original order to preserve temporal relationships.
 
-2. **Single-Group Examples**: Each training example contains records from exactly one group. This ensures the model learns patterns within a group's sequence without cross-group contamination.
+2. Single-Group Examples: Each training example contains records from exactly one group. This ensures the model learns patterns within a group's sequence without cross-group contamination.
 
-3. **Sequential Packing**: Records are packed into training examples sequentially, respecting:
+3. Sequential Packing: Records are packed into training examples sequentially, respecting:
    - Token budget (70-100% of max context length for training, 100% for validation)
    - Group boundaries (one group per example)
    - Dataset boundaries (restart detection when row index decreases for data_fraction > 1)
 
-4. **Pseudo-Group Handling**: When no group column is specified, preprocessing adds a `__pseudo_group__` column so ungrouped time series is treated as a single group. This unifies the grouped and ungrouped code paths.
+4. Pseudo-Group Handling: When no group column is specified, preprocessing adds a `__pseudo_group__` column so ungrouped time series is treated as a single group. This unifies the grouped and ungrouped code paths.
 
-5. **Initial Prefill Extraction**
+5. Initial Prefill Extraction
    - Dictionary mapping each group to its first 3 decoded samples (including pseudo-group for single sequences).
    - Stored in `model_metadata.initial_prefill` for use during generation.
    - Used by `TimeseriesBackend` to seed each group's context.
 
-6. **Train/Test Split**
+6. Train/Test Split
    - Split is done by group boundaries using `grouped_train_test_split`.
    - Entire groups go to train OR validation, never split across.
    - Re-sort after split since GroupShuffleSplit shuffles indices.
@@ -226,17 +226,17 @@ TimeseriesBackend(VllmBackend)
 
 ### Key Concepts
 
-- **Time-Range Based Generation**: The number of records generated is determined by `(stop_timestamp - start_timestamp) / interval_seconds`, not by a target count. The `config.generation.num_records` parameter is used only for progress tracking.
-- **Sliding Window**: Maintains a window of recent records (controlled by `_prefill_context_size`) included in each prompt for context continuity.
-- **Groups from Training**: Groups are the same as those seen during training (from `model_metadata.initial_prefill`).
+- Time-Range Based Generation: The number of records generated is determined by `(stop_timestamp - start_timestamp) / interval_seconds`, not by a target count. The `config.generation.num_records` parameter is used only for progress tracking.
+- Sliding Window: Maintains a window of recent records (controlled by `_prefill_context_size`) included in each prompt for context continuity.
+- Groups from Training: Groups are the same as those seen during training (from `model_metadata.initial_prefill`).
 
 ### Sliding Window Approach
 
-1. **Prefill Initialization**: Start with initial prefill from training data (first 3 records per group).
-2. **Batch Generation**: Generate multiple samples (default 5) per prompt for each active group.
-3. **Response Selection**: Keep the response with the most valid records per group.
-4. **Context Update**: Update sliding window with new valid records.
-5. **Repeat**: Continue until stop timestamp is reached for each group.
+1. Prefill Initialization: Start with initial prefill from training data (first 3 records per group).
+2. Batch Generation: Generate multiple samples (default 5) per prompt for each active group.
+3. Response Selection: Keep the response with the most valid records per group.
+4. Context Update: Update sliding window with new valid records.
+5. Repeat: Continue until stop timestamp is reached for each group.
 
 ### Key Parameters
 
@@ -291,14 +291,14 @@ class GroupState:
 
 ### Stopping Conditions
 
-**Per-Group Stopping:**
-- **Completion (success)**: A group completes when any generated record has timestamp >= `stop_timestamp`.
-- **Failure (low valid fraction)**: A group fails after `config.generation.patience` consecutive batches where invalid fraction >= `config.generation.invalid_fraction_threshold`. Failed groups produce no synthetic data.
+Per-Group Stopping:
+- Completion (success): A group completes when any generated record has timestamp >= `stop_timestamp`.
+- Failure (low valid fraction): A group fails after `config.generation.patience` consecutive batches where invalid fraction >= `config.generation.invalid_fraction_threshold`. Failed groups produce no synthetic data.
 
-**Global Stopping:**
-- **Natural completion**: All groups processed (pending and active lists empty).
-- **No records**: Too many consecutive batches with no valid records globally.
-- **Target reached**: Target number of records reached (for progress tracking).
+Global Stopping:
+- Natural completion: All groups processed (pending and active lists empty).
+- No records: Too many consecutive batches with no valid records globally.
+- Target reached: Target number of records reached (for progress tracking).
 
 ### Progress Checkpoints
 
@@ -324,15 +324,15 @@ def extract_and_validate_timeseries_records(
 ) -> tuple[list[dict], list[str], list[tuple[str, str]]]:
 ```
 
-**Validation Steps:**
+Validation Steps:
 1. Parse JSON and validate against schema.
 2. Check for large number issues.
 3. Verify timestamp column exists.
 4. Parse timestamp using the specified format.
-5. **If interval_seconds is provided**: Validate sequential increment.
+5. If interval_seconds is provided: Validate sequential increment.
    - Handles day rollovers (adds 24h offset when timestamp wraps).
    - Rejects records if interval doesn't match expected step.
-6. **Early termination**: Stops at first invalid record (streaming validation).
+6. Early termination: Stops at first invalid record (streaming validation).
 
 ### 2. Batch-Level Chronological Validation (timeseries_backend.py)
 
@@ -355,7 +355,7 @@ def _is_chronological_for_group(self, records: list[dict], group_state: GroupSta
     return True
 ```
 
-**Key Design Decision**: If records don't continue from the group's last timestamp, all records in that response are moved to `invalid_records` with an "Out-of-order time step" error, and the response is discarded. This is done per-group during `_process_group_result()`.
+Key Design Decision: If records don't continue from the group's last timestamp, all records in that response are moved to `invalid_records` with an "Out-of-order time step" error, and the response is discarded. This is done per-group during `_process_group_result()`.
 
 ---
 
@@ -365,30 +365,30 @@ def _is_chronological_for_group(self, records: list[dict], group_state: GroupSta
 
 Located in `src/nemo_safe_synthesizer/evaluation/components/autocorrelation_similarity.py`.
 
-**Purpose**: Measures how well the synthetic data preserves temporal autocorrelation patterns from the reference data.
+Purpose: Measures how well the synthetic data preserves temporal autocorrelation patterns from the reference data.
 
-**Algorithm:**
+Algorithm:
 
-1. **Compute ACF vectors** for each numeric column:
+1. Compute ACF vectors for each numeric column:
    - Mean-center the data.
    - Calculate autocorrelation for lags 1 to `max_lag`.
    - Clip values to [-1, 1].
 
-2. **Calculate distance** between reference and synthetic ACF:
+2. Calculate distance between reference and synthetic ACF:
    - MAE: Mean Absolute Error.
    - Euclidean: L2 norm.
 
-3. **Normalize and score**:
+3. Normalize and score:
    - Normalize by realistic max distance.
    - Use RMS of normalized differences across columns.
    - Final score = 1 - RMS (higher is better).
 
-**Evaluation Modes:**
+Evaluation Modes:
 
-- **Global**: Computes ACF over entire dataset.
-- **Per-Group**: Computes ACF per group, averages scores.
+- Global: Computes ACF over entire dataset.
+- Per-Group: Computes ACF per group, averages scores.
 
-**Auto-Enable**: When `is_timeseries=True`, autocorrelation similarity is automatically computed even without explicit evaluation config.
+Auto-Enable: When `is_timeseries=True`, autocorrelation similarity is automatically computed even without explicit evaluation config.
 
 ### Integration with Multimodal Report
 
@@ -463,63 +463,63 @@ time_series:
 
 ### 1. Unified Grouped Architecture
 
-**Decision**: All time series (including single-sequence) use the grouped architecture via a pseudo-group column.
+Decision: All time series (including single-sequence) use the grouped architecture via a pseudo-group column.
 
-**Rationale**:
+Rationale:
 - Single code path simplifies maintenance and testing.
 - Single-sequence is just 1 group, no special-casing needed.
 - Parallel generation optimizations apply to all cases.
 
 ### 2. Multiple Samples per Prompt
 
-**Decision**: Generate 5 samples per prompt, keep the best one.
+Decision: Generate 5 samples per prompt, keep the best one.
 
-**Rationale**:
+Rationale:
 - Time series generation is more constrained than tabular.
 - Multiple samples increase the chance of getting a valid continuation.
 - Best sample = most valid records (longer valid sequence is better).
 
 ### 3. Parallel Group Generation
 
-**Decision**: Process multiple groups simultaneously in the same batch.
+Decision: Process multiple groups simultaneously in the same batch.
 
-**Rationale**:
+Rationale:
 - GPU utilization is maximized.
 - Independent groups have no cross-dependencies.
 - Reduces total wall-clock time significantly.
 
 ### 4. Consistent Start/Stop Across Groups
 
-**Decision**: Require all groups to have identical start and stop timestamps.
+Decision: Require all groups to have identical start and stop timestamps.
 
-**Rationale**:
+Rationale:
 - Simplifies generation logic (fixed expected_records per group).
 - Many real-world applications have synchronized sensors.
 - Future: Could relax this for asynchronous time series.
 
 ### 5. Random Token Budget for Training
 
-**Decision**: Sample token budget from [70%, 100%] of max for training examples.
+Decision: Sample token budget from [70%, 100%] of max for training examples.
 
-**Rationale**:
+Rationale:
 - Prevents overfitting to fixed sequence lengths.
 - Creates variable-length examples for robustness.
 - 100% used for validation for consistency.
 
 ### 6. Single-Group Examples
 
-**Decision**: Each training example contains records from exactly one group.
+Decision: Each training example contains records from exactly one group.
 
-**Rationale**:
+Rationale:
 - Ensures model learns patterns within a group's sequence.
 - Prevents cross-group contamination during training.
 - Sequence continuation across example boundaries is natural.
 
 ### 7. Time-Range Based Generation
 
-**Decision**: Number of records is determined by time range and interval, not target count.
+Decision: Number of records is determined by time range and interval, not target count.
 
-**Rationale**:
+Rationale:
 - Ensures complete time coverage for each group.
 - `num_records` parameter is only for progress tracking.
 - Groups complete when stop timestamp is reached.
@@ -528,16 +528,16 @@ time_series:
 
 ## Next Steps
 
-- **Support for variable/irregular intervals** — Planned via `timestamp_validation_mode` (see below).
+- Support for variable/irregular intervals — Planned via `timestamp_validation_mode` (see below).
 - More testing on datasets and different models
 - Compare NSS to other models
 - Add more unit tests
 
 ### Timestamp Validation Mode (Planned)
 
-> ⚠️ **Not Yet Implemented** — This section describes planned functionality.
+> ⚠️ Not Yet Implemented — This section describes planned functionality.
 
-The `timestamp_validation_mode` parameter controls how timestamps are handled during training and generation. This is particularly useful for **time series with varying/irregular intervals** where enforcing a fixed interval is not possible.
+The `timestamp_validation_mode` parameter controls how timestamps are handled during training and generation. This is particularly useful for time series with varying/irregular intervals where enforcing a fixed interval is not possible.
 
 | Mode | Training Behavior | Generation Behavior | Use Case |
 |------|-------------------|---------------------|----------|

--- a/tools/binaries/README.md
+++ b/tools/binaries/README.md
@@ -21,8 +21,8 @@ bash tools/binaries/bootstrap_tools.sh
 
 Tools are defined in `tools.yaml` with two categories:
 
-1. **Simple binary tools** - Defined entirely in YAML with download URLs
-2. **Custom scripts** - Complex tools that need custom installation logic
+1. Simple binary tools - Defined entirely in YAML with download URLs
+2. Custom scripts - Complex tools that need custom installation logic
 
 ### tools.yaml Structure
 
@@ -57,8 +57,8 @@ custom_scripts:
 
 ## Supported Platforms
 
-- **macOS (darwin)**: arm64, amd64
-- **Linux**: arm64, amd64
+- macOS (darwin): arm64, amd64
+- Linux: arm64, amd64
 
 ## Adding a New Tool
 


### PR DESCRIPTION
Followup to #77. Strip decorative `**bold**` from most markdown files not in docs/. Code identifiers get backticks; plain English stays bare; bold inside code blocks is untouched. Some of the skills added in #77 explicitly ask to not do this so this is just catching a few things that didn't get seen then. (i have a _terrible_ time reading markdown that has a ton of formatting like that and the agents really want to do it).