### PR TITLE
fix: add missing copyright header and harden copyright tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,12 +38,12 @@ repos:
 
   - repo: local
     hooks:
-      - id: copyright-check
-        name: Check copyright headers
-        entry: python tools/lint/copyright_fixer.py --check .
+      - id: copyright-fix
+        name: Fix copyright headers
+        entry: uv run --script tools/lint/copyright_fixer.py .
         language: system
         pass_filenames: false
-        types: [python]
+        files: '\.(py|sh|md|yaml|yml)$'
 
       - id: ty
         name: Run ty typechecks

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ format: ## Format the code
 lint: ## Lint the code
 	bash tools/lint/ruff-lint.sh
 	bash tools/lint/run-ty-check.sh
-	python tools/lint/copyright_fixer.py --check .
+	uv run --script tools/lint/copyright_fixer.py --check .
 
 
 ### TESTING ###

--- a/tools/diff-lockfile.py
+++ b/tools/diff-lockfile.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env -S uv run
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
 """diff-lockfile: compare uv.lock between git refs and report dependency changes.
 
 Parses two versions of a uv.lock file (base ref vs head ref) and categorizes

--- a/tools/lint/copyright_fixer.py
+++ b/tools/lint/copyright_fixer.py
@@ -1,6 +1,6 @@
+#!/usr/bin/env -S uv run --script
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-#!/usr/bin/env -S uv run --script
 #
 # /// script
 # dependencies = [
@@ -13,7 +13,7 @@
 """
 Copyright header fixer for Safe Synthesizer.
 
-Scans Python files and adds SPDX copyright headers where missing.
+Scans source files and adds SPDX copyright headers where missing.
 """
 
 import os
@@ -30,14 +30,19 @@ app = typer.Typer(name="copyright-fixer", help="Copyright fixer tool for Safe Sy
 # --- constants ---
 
 _CURRENT_YEAR = datetime.now().year
-_HEADER = (
+
+_EXTENSIONS = frozenset({".py", ".sh", ".md", ".yaml", ".yml"})
+
+# Comment-style headers by file type
+_HASH_HEADER = (
     f"# SPDX-FileCopyrightText: Copyright (c) 2025-{_CURRENT_YEAR} NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n"
     "# SPDX-License-Identifier: Apache-2.0\n"
-    "\n"
 )
 
-
-_EXTENSIONS = frozenset({".py"})
+_HTML_HEADER = (
+    f"<!-- SPDX-FileCopyrightText: Copyright (c) 2025-{_CURRENT_YEAR} NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->\n"
+    "<!-- SPDX-License-Identifier: Apache-2.0 -->\n"
+)
 
 # Cheap substring checks — no regex needed
 _HEADER_MARKERS = (
@@ -115,30 +120,36 @@ def _read_head(path: str, nbytes: int = 512) -> str:
 
 
 def _collect_files_from_dir(root: str) -> list[str]:
-    """Collect .py files under *root*, respecting .gitignore and ruff excludes."""
+    """Collect files under *root* matching _EXTENSIONS, respecting .gitignore and ruff excludes."""
     repo = _get_repo(root)
 
     if repo is not None:
         repo_root = str(repo.working_tree_dir)
         ruff_excludes = _load_ruff_excludes(repo_root)
-        # git ls-files honours .gitignore automatically; paths are relative to repo root
         raw = repo.git.ls_files("--cached", "--others", "--exclude-standard", "-z", "--", root)
         git_files = [f for f in raw.split("\0") if f]
-        py_files = [os.path.join(repo_root, f) for f in git_files if os.path.splitext(f)[1] in _EXTENSIONS]
+        target_files = [os.path.join(repo_root, f) for f in git_files if os.path.splitext(f)[1] in _EXTENSIONS]
     else:
         ruff_excludes = _load_ruff_excludes(None)
-        # Fallback: plain os.walk when git is unavailable
-        py_files = []
+        target_files = []
         for dirpath, _, filenames in os.walk(root):
             for fname in filenames:
                 if os.path.splitext(fname)[1] in _EXTENSIONS:
-                    py_files.append(os.path.join(dirpath, fname))
+                    target_files.append(os.path.join(dirpath, fname))
 
-    # Additionally filter out ruff-excluded paths
     if ruff_excludes:
-        py_files = [f for f in py_files if not _is_ruff_excluded(os.path.relpath(f, root), ruff_excludes)]
+        target_files = [f for f in target_files if not _is_ruff_excluded(os.path.relpath(f, root), ruff_excludes)]
 
-    return py_files
+    return target_files
+
+
+def _get_header_for_ext(ext: str) -> str:
+    """Return the appropriate copyright header for the given file extension."""
+    if ext in {".py", ".sh", ".yaml", ".yml"}:
+        return _HASH_HEADER + "\n"
+    if ext == ".md":
+        return _HTML_HEADER + "\n"
+    return _HASH_HEADER + "\n"
 
 
 def _add_header(filepath: str) -> bool:
@@ -154,12 +165,20 @@ def _add_header(filepath: str) -> bool:
     if _has_header(content[:512]):
         return False
 
-    # Handle shebang
+    ext = os.path.splitext(filepath)[1]
+
     if content.startswith("#!"):
         newline_pos = content.index("\n") + 1
-        new_content = content[:newline_pos] + _HEADER + content[newline_pos:]
+        header = _get_header_for_ext(ext)
+        new_content = content[:newline_pos] + header + content[newline_pos:]
+    elif ext == ".md" and (content.startswith("---\n") or content.startswith("---\r\n")):
+        header = _HASH_HEADER
+        # Insert copyright as YAML comments right after opening ---
+        sep = "---\r\n" if content.startswith("---\r\n") else "---\n"
+        new_content = sep + header + content[len(sep):]
     else:
-        new_content = _HEADER + content
+        header = _get_header_for_ext(ext)
+        new_content = header + content
 
     with open(filepath, "w", encoding="utf-8") as f:
         f.write(new_content)
@@ -188,7 +207,7 @@ def update_license_headers(
     ),
     check: bool = typer.Option(False, "--check", help="Check only, don't modify files. Exit 1 if headers are missing."),
 ) -> None:
-    """Add SPDX copyright headers to Python files missing them.
+    """Add SPDX copyright headers to files missing them.
 
     Accepts a single directory (scans recursively) or a list of individual
     files.  When no argument is provided, scans the current directory.

--- a/tools/lint/filter_ty_exclusions.py
+++ b/tools/lint/filter_ty_exclusions.py
@@ -1,7 +1,6 @@
+#!/usr/bin/env python3
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-
-#!/usr/bin/env python3
 """Filter files against ty exclusions from pyproject.toml."""
 
 import fnmatch


### PR DESCRIPTION
## Summary

- Add missing SPDX copyright header to `tools/diff-lockfile.py` (fixes `copyright-check` CI failure on main from [run 22243311695](https://github.com/NVIDIA-NeMo/Safe-Synthesizer/actions/runs/22243311695/job/64351782499))
- Align shebang/SPDX ordering to NVIDIA convention (shebang first) in `copyright_fixer.py` and `filter_ty_exclusions.py` -- researched TensorRT, TensorRT-LLM, apex, cuda-python, and DataDesigner for the canonical order
- Extend `copyright_fixer.py` to handle `.sh`, `.md`, `.yaml`, `.yml` files with extension-aware comment styles (`#` vs `<!-- -->`) and Markdown YAML frontmatter support
- Switch pre-commit copyright hook from check-only to auto-fix mode (consistent with ruff hooks), use `uv run --script` for reliable dependency resolution, and broaden file trigger to all supported extensions
- Update Makefile `lint` target to use `uv run --script` for consistency

## Test plan

- [ ] CI `copyright-check` job passes on this branch
- [ ] `uv run --script tools/lint/copyright_fixer.py --check .` exits 0
- [ ] `pre-commit run copyright-fix --all-files` auto-fixes any missing headers
- [ ] Verify shebang ordering matches NVIDIA convention in changed files


Made with [Cursor](https://cursor.com) (can you tell the tone is quite different?)