### PR TITLE
fix(logging): remove two sets of spurious vLLM errors

### DIFF
--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -33,7 +33,72 @@ from ..utils import all_equal_type, load_json
 
 logger = get_logger(__name__)
 
-os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "1"
+if torch.cuda.is_available():
+    _gpu_count = torch.cuda.device_count()
+    if _gpu_count <= 1:
+        os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+    else:
+        os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "1")
+else:
+    # When CUDA is unavailable, avoid triggering CUDA initialization and
+    # default to disabling vLLM v1 multiprocessing.
+    os.environ.setdefault("VLLM_ENABLE_V1_MULTIPROCESSING", "0")
+
+
+def _is_redis_available() -> bool:
+    """Return True if the ``redis`` package is importable."""
+    try:
+        import redis  # noqa: F401 # type: ignore[unresolved-import]
+
+        return True
+    except ImportError:
+        return False
+
+
+class _NoopRemoteCacheBackend:
+    """No-op stand-in for ``RedisRemoteCacheBackend``.
+
+    All reads return ``None``; all writes are silently dropped.
+    """
+
+    def get(self, key: str) -> bytes | None:
+        return None
+
+    def put(self, key: str, data: bytes) -> None:
+        pass
+
+
+def _install_noop_remote_cache_backends() -> None:
+    """Replace the Inductor ``RemoteAutotuneCache`` backend with a no-op.
+
+    ``torch.compile`` uses ``RemoteAutotuneCache`` (backed by Redis) to share
+    autotuning results across processes.  When the ``redis`` package is not
+    installed the default backend raises at construction time, which breaks
+    ``torch.compile`` in environments that never intended to run Redis.
+
+    This function patches *only* ``RemoteAutotuneCache`` -- the single
+    Redis-backed cache that surfaces errors during normal Safe-Synthesizer
+    runs.  Other Redis caches (``RemoteFxGraphCache``,
+    ``RemoteBundledAutotuneCache``, etc.) are left untouched so they keep
+    working if a future dependency pulls in ``redis``.
+
+    The override is skipped entirely when ``redis`` *is* importable, leaving
+    the default backend intact and avoiding any ``torch.compile`` performance
+    regression.
+    """
+    if _is_redis_available():
+        return
+
+    try:
+        from torch._inductor.remote_cache import RemoteAutotuneCache
+
+        RemoteAutotuneCache.backend_override_cls = _NoopRemoteCacheBackend  # type: ignore[invalid-assignment]
+        logger.debug("Installed no-op backend for RemoteAutotuneCache (redis unavailable)")
+    except ImportError:
+        pass
+
+
+_install_noop_remote_cache_backends()
 
 
 class VllmBackend(GeneratorBackend):

--- a/tests/generation/test_vllm_backend.py
+++ b/tests/generation/test_vllm_backend.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for the VllmBackend class private methods."""
+"""Unit tests for the VllmBackend class private methods and module-level side effects."""
 
 from unittest.mock import MagicMock, patch
 
@@ -452,3 +452,71 @@ class TestTransformKwargsToSamplingParams:
         result = backend._transform_kwargs_to_sampling_params(kwargs={}, api_mapping={})
 
         assert result == {}
+
+
+class TestNoopRemoteCacheBackend:
+    """Tests for the _NoopRemoteCacheBackend and conditional installation logic."""
+
+    def test_noop_backend_get_returns_none(self):
+        from nemo_safe_synthesizer.generation.vllm_backend import _NoopRemoteCacheBackend
+
+        backend = _NoopRemoteCacheBackend()
+        assert backend.get("any-key") is None
+
+    def test_noop_backend_put_is_silent(self):
+        from nemo_safe_synthesizer.generation.vllm_backend import _NoopRemoteCacheBackend
+
+        backend = _NoopRemoteCacheBackend()
+        backend.put("key", b"data")  # should not raise
+
+    def test_install_skipped_when_redis_available(self):
+        """When redis is importable, the override must not be installed."""
+        pytest.importorskip("torch._inductor.remote_cache")
+        from torch._inductor.remote_cache import RemoteAutotuneCache
+
+        from nemo_safe_synthesizer.generation.vllm_backend import (
+            _install_noop_remote_cache_backends,
+        )
+
+        original = RemoteAutotuneCache.backend_override_cls
+        try:
+            RemoteAutotuneCache.backend_override_cls = None
+            with patch("nemo_safe_synthesizer.generation.vllm_backend._is_redis_available", return_value=True):
+                _install_noop_remote_cache_backends()
+            assert RemoteAutotuneCache.backend_override_cls is None
+        finally:
+            RemoteAutotuneCache.backend_override_cls = original
+
+    def test_install_applies_when_redis_unavailable(self):
+        """When redis is not importable, RemoteAutotuneCache gets the no-op backend."""
+        pytest.importorskip("torch._inductor.remote_cache")
+        from torch._inductor.remote_cache import RemoteAutotuneCache
+
+        from nemo_safe_synthesizer.generation.vllm_backend import (
+            _install_noop_remote_cache_backends,
+            _NoopRemoteCacheBackend,
+        )
+
+        original = RemoteAutotuneCache.backend_override_cls
+        try:
+            RemoteAutotuneCache.backend_override_cls = None
+            with patch("nemo_safe_synthesizer.generation.vllm_backend._is_redis_available", return_value=False):
+                _install_noop_remote_cache_backends()
+            assert RemoteAutotuneCache.backend_override_cls is _NoopRemoteCacheBackend
+        finally:
+            RemoteAutotuneCache.backend_override_cls = original
+
+    def test_is_redis_available_returns_false_when_missing(self):
+        """_is_redis_available returns False when redis cannot be imported."""
+        from nemo_safe_synthesizer.generation.vllm_backend import _is_redis_available
+
+        with patch.dict("sys.modules", {"redis": None}):
+            assert _is_redis_available() is False
+
+    def test_is_redis_available_returns_true_when_present(self):
+        """_is_redis_available returns True when redis is importable."""
+        from nemo_safe_synthesizer.generation.vllm_backend import _is_redis_available
+
+        fake_redis = MagicMock()
+        with patch.dict("sys.modules", {"redis": fake_redis}):
+            assert _is_redis_available() is True


### PR DESCRIPTION
# Summary
    * Removes these Redis errors that shoot out in all modes
    * Runs vLLM conditionally in a multiprocess mode. The
    multiprocess mode has a bug where it emits that log message
    about shutdown

## Pre-Review Checklist

Ensure that the following pass:

- [x] `make format && make lint` or via prek validation.
- [x] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>
