### PR TITLE
fix: add .copyrightignore and align make format/lint with pre-commit

### DIFF
--- a/.copyrightignore
+++ b/.copyrightignore
@@ -1,0 +1,21 @@
+# Files and directories excluded from SPDX copyright header checks.
+
+# Standard community / documentation files
+CHANGELOG.md
+CITATION.md
+CODE_OF_CONDUCT.md
+CONTRIBUTING.md
+PULL_REQUEST_TEMPLATE.md
+README.md
+SECURITY.md
+THIRD_PARTY.md
+design.md
+
+# AI / IDE / CI configuration directories
+.agent/
+.claude/
+.cursor/
+.github/
+
+# AI assistant config files
+CLAUDE.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -293,21 +293,25 @@ Before submitting a PR:
 
 ### Formatting
 
-We use [Ruff](https://docs.astral.sh/ruff/) for code formatting and import sorting. The formatter runs on changed files against the `main` branch.
+We use [Ruff](https://docs.astral.sh/ruff/) for code formatting and linting auto-fix, plus a copyright header fixer. `make format` mutates files — it runs the same fixers as pre-commit.
 
 ```bash
-# Format code and sort imports
+# Format code, auto-fix lint issues, and add missing copyright headers
 make format
 ```
 
 ### Linting and Type Checking
 
-We use [Ruff](https://docs.astral.sh/ruff/) for linting and [ty](https://github.com/astral-sh/ty) for type checking. Both run on changed files against `main`.
+We use [Ruff](https://docs.astral.sh/ruff/) for linting and [ty](https://github.com/astral-sh/ty) for type checking. `make lint` is read-only — it reports errors without modifying files.
 
 ```bash
-# Run ruff linter (with auto-fix) and ty type checker
+# Check linting, type errors, and missing copyright headers (no auto-fix)
 make lint
 ```
+
+### Copyright Headers
+
+All source files (`.py`, `.sh`, `.yaml`, `.yml`, `.md`) require SPDX copyright headers. `make format` adds them automatically. Files excluded from this requirement (community files like `README.md`, config directories like `.github/`) are listed in `.copyrightignore` at the repo root.
 
 ### Pre-commit Hooks
 
@@ -317,7 +321,7 @@ We recommend setting up pre-commit hooks to catch formatting, linting, and type 
 prek install
 ```
 
-This installs hooks that run Ruff (format + lint), ty type checking, and uv lock verification on each commit.
+This installs hooks that run Ruff (format + lint), copyright header fixer, ty type checking, and uv lock verification on each commit.
 
 ## Documentation
 

--- a/Makefile
+++ b/Makefile
@@ -127,13 +127,16 @@ docs-deploy: ## Deploy the documentation site to GitHub Pages
 
 
 ### CODE QUALITY ###
+# `make format` mutates files (same fixers as pre-commit).
+# `make lint` is read-only (same checks as CI).
 
 .PHONY: format
-format: ## Format the code
+format: ## Format the code (ruff format + fix + copyright headers)
 	bash tools/format/format.sh
+	uv run --script tools/lint/copyright_fixer.py .
 
 .PHONY: lint
-lint: ## Lint the code
+lint: ## Lint the code (read-only checks)
 	bash tools/lint/ruff-lint.sh
 	bash tools/lint/run-ty-check.sh
 	uv run --script tools/lint/copyright_fixer.py --check .

--- a/tools/format/format.sh
+++ b/tools/format/format.sh
@@ -63,14 +63,14 @@ if [ "$CHECK_MODE" = true ]; then
     # shellcheck disable=SC2086
     $RUFF format --check "$NSS_ROOT_PATH" $filtered_files
     # shellcheck disable=SC2086
-    $RUFF check --select I "$NSS_ROOT_PATH" $filtered_files
+    $RUFF check "$NSS_ROOT_PATH" $filtered_files
     # shellcheck disable=SC2086
     uv run --script tools/lint/copyright_fixer.py --check $filtered_files
 else
     # shellcheck disable=SC2086
     $RUFF format "$NSS_ROOT_PATH" $filtered_files
     # shellcheck disable=SC2086
-    $RUFF check --select I --fix "$NSS_ROOT_PATH" $filtered_files
+    $RUFF check --fix "$NSS_ROOT_PATH" $filtered_files
     # shellcheck disable=SC2086
     uv run --script tools/lint/copyright_fixer.py $filtered_files
 fi

--- a/tools/lint/copyright_fixer.py
+++ b/tools/lint/copyright_fixer.py
@@ -33,6 +33,8 @@ _CURRENT_YEAR = datetime.now().year
 
 _EXTENSIONS = frozenset({".py", ".sh", ".md", ".yaml", ".yml"})
 
+_COPYRIGHT_IGNORE_FILE = ".copyrightignore"
+
 # Comment-style headers by file type
 _HASH_HEADER = (
     f"# SPDX-FileCopyrightText: Copyright (c) 2025-{_CURRENT_YEAR} NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n"
@@ -99,6 +101,40 @@ def _is_ruff_excluded(relpath: str, excludes: list[str]) -> bool:
     return False
 
 
+def _load_copyright_excludes(repo_root: str | None) -> list[str]:
+    """Load exclude patterns from .copyrightignore at the repo root."""
+    if repo_root is None:
+        return []
+    ignore_path = os.path.join(repo_root, _COPYRIGHT_IGNORE_FILE)
+    if not os.path.isfile(ignore_path):
+        return []
+    with open(ignore_path, encoding="utf-8") as fh:
+        return [line.strip() for line in fh if line.strip() and not line.startswith("#")]
+
+
+def _is_copyright_excluded(relpath: str, patterns: list[str]) -> bool:
+    """Return True if the file matches any .copyrightignore pattern.
+
+    Pattern semantics (gitignore-like):
+      - Trailing ``/`` matches any path component (directory).
+      - Patterns without ``/`` match the file's basename anywhere in the tree.
+      - Patterns containing ``/`` (but not trailing) match from repo root.
+    """
+    p = Path(relpath)
+    for pat in patterns:
+        if pat.endswith("/"):
+            dirname = pat.rstrip("/")
+            if dirname in p.parts:
+                return True
+        elif "/" in pat:
+            if fnmatch(relpath, pat):
+                return True
+        else:
+            if fnmatch(p.name, pat):
+                return True
+    return False
+
+
 # --- core helpers ---
 
 
@@ -120,25 +156,31 @@ def _read_head(path: str, nbytes: int = 512) -> str:
 
 
 def _collect_files_from_dir(root: str) -> list[str]:
-    """Collect files under *root* matching _EXTENSIONS, respecting .gitignore and ruff excludes."""
+    """Collect files under *root* matching _EXTENSIONS, respecting .gitignore, ruff excludes, and .copyrightignore."""
     repo = _get_repo(root)
 
     if repo is not None:
         repo_root = str(repo.working_tree_dir)
         ruff_excludes = _load_ruff_excludes(repo_root)
+        copyright_excludes = _load_copyright_excludes(repo_root)
         raw = repo.git.ls_files("--cached", "--others", "--exclude-standard", "-z", "--", root)
         git_files = [f for f in raw.split("\0") if f]
         target_files = [os.path.join(repo_root, f) for f in git_files if os.path.splitext(f)[1] in _EXTENSIONS]
     else:
         ruff_excludes = _load_ruff_excludes(None)
+        copyright_excludes = _load_copyright_excludes(None)
         target_files = []
         for dirpath, _, filenames in os.walk(root):
             for fname in filenames:
                 if os.path.splitext(fname)[1] in _EXTENSIONS:
                     target_files.append(os.path.join(dirpath, fname))
 
-    if ruff_excludes:
-        target_files = [f for f in target_files if not _is_ruff_excluded(os.path.relpath(f, root), ruff_excludes)]
+    target_files = [
+        f
+        for f in target_files
+        if not _is_copyright_excluded(rel := os.path.relpath(f, root), copyright_excludes)
+        and not (ruff_excludes and _is_ruff_excluded(rel, ruff_excludes))
+    ]
 
     return target_files
 
@@ -192,7 +234,17 @@ def _resolve_targets(paths: list[Path]) -> tuple[list[str], str | None]:
         root = str(paths[0].resolve())
         return _collect_files_from_dir(root), root
 
-    files = [str(p.resolve()) for p in paths if p.is_file() and os.path.splitext(str(p))[1] in _EXTENSIONS]
+    repo = _get_repo(str(paths[0].resolve()))
+    repo_root = str(repo.working_tree_dir) if repo else None
+    copyright_excludes = _load_copyright_excludes(repo_root)
+
+    files = [
+        str(p.resolve())
+        for p in paths
+        if p.is_file()
+        and os.path.splitext(str(p))[1] in _EXTENSIONS
+        and not _is_copyright_excluded(str(p), copyright_excludes)
+    ]
     return files, None
 
 

--- a/tools/lint/ruff-lint.sh
+++ b/tools/lint/ruff-lint.sh
@@ -46,4 +46,4 @@ else
 fi
 
 # shellcheck disable=SC2086
-$RUFF check --fix $filtered_files # no quotes around $filtered_files to preserve newlines
+$RUFF check $filtered_files # no quotes around $filtered_files to preserve newlines


### PR DESCRIPTION
## Summary

- **`make lint` was failing** because the copyright fixer had no exclusion list for community markdown files (`README.md`, `CHANGELOG.md`, etc.) and dot-config directories (`.agent/`, `.claude/`, `.cursor/`, `.github/`). Pre-commit worked because it runs in fix mode, silently adding headers rather than failing.
- **Adds `.copyrightignore`** — a gitignore-style file at the repo root where exclusions are declared. Supports bare filenames (`README.md`), directory patterns (`.github/`), and path globs. No Python code changes needed to add future exclusions.
- **Aligns `make format` / `make lint` / pre-commit** so they use the same fixers with the same scope:
  - `make format` now mutates (ruff format + full ruff check --fix + copyright fix on whole repo) — same behavior as pre-commit.
  - `make lint` is now read-only (ruff check without --fix, ty check, copyright --check) — safe for CI.
  - Previously `ruff-lint.sh` ran `ruff check --fix`, mutating files in what should be a check-only command.
- **Adds missing SPDX headers** to 39 project files (docs, tools, scripts) that were missing them.

## Test plan

- [x] `uv run --script tools/lint/copyright_fixer.py --check .` passes (304 files)
- [ ] `make lint` passes on this branch
- [ ] `make format` is idempotent (running twice produces no diff)
- [ ] `pre-commit run --all-files` passes