### PR TITLE
docs: require --signoff for agent git commits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,6 +158,16 @@ make build-wheel        # Build wheel (version from git tag)
 make publish-internal   # Publish to NVIDIA Artifactory
 ```
 
+### Git Commits
+
+Always use `--signoff` (`-s`) when committing:
+
+```bash
+git commit -s -m "message"
+```
+
+This adds a `Signed-off-by` trailer for DCO compliance.
+
 ### Branching
 
 Feature branches off `main`. Branch names often include an issue number prefix (e.g., `<author>/123-short-name`).


### PR DESCRIPTION
## Summary

- Adds a `### Git Commits` subsection under `## Repo Conventions` in `AGENTS.md`
- Instructs all AI agents (Cursor, Claude Code, Windsurf, etc.) to always use `--signoff` (`-s`) when committing, for DCO compliance

## Test plan

- [ ] Verify the new section renders correctly in the AGENTS.md markdown
- [ ] Confirm agents pick up the instruction on next interaction

Made with [Cursor](https://cursor.com)