### PR TITLE
ci: use self-hosted runners for Artifactory wheel publishing

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -115,6 +115,8 @@ The `gpu-tests.yml` workflow runs on pushes to `main` and `pull-request/*` branc
 | CI Checks | All jobs | `ubuntu-latest` | GitHub-hosted |
 | GPU Tests | GPU E2E Tests | `linux-amd64-gpu-a100-latest-1` | NVIDIA self-hosted GPU (A100) |
 | GPU Tests | Detect Changes, GPU CI Status | `linux-amd64-cpu4` | NVIDIA self-hosted CPU (4-core) |
+| Dev Wheel | All jobs | `linux-amd64-cpu4` | NVIDIA self-hosted CPU (4-core) |
+| Internal Release | All jobs | `linux-amd64-cpu4` | NVIDIA self-hosted CPU (4-core) |
 
 ### Coverage
 

--- a/.github/workflows/dev-wheel.yml
+++ b/.github/workflows/dev-wheel.yml
@@ -39,7 +39,7 @@ jobs:
   changes:
     name: Detect changes
     if: github.event_name != 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     permissions:
       contents: read
       pull-requests: read
@@ -55,7 +55,7 @@ jobs:
     name: Build and publish dev wheel
     needs: changes
     if: ${{ needs.changes.outputs.src == 'true' || github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     steps:
       - name: checkout
         uses: actions/checkout@v6

--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -37,7 +37,7 @@ defaults:
 jobs:
   publish:
     name: Build and publish to Artifactory
-    runs-on: ubuntu-latest
+    runs-on: linux-amd64-cpu4
     env:
       TWINE_REPOSITORY_URL: ${{ secrets.ARTIFACTORY_INTERNAL_URL }}
     steps:


### PR DESCRIPTION
## Summary

- Switch `dev-wheel.yml` and `internal-release.yml` from `ubuntu-latest` to `linux-amd64-cpu4` (NVIDIA self-hosted CPU runner)
- GitHub-hosted runners cannot reach the NVIDIA Artifactory endpoint; self-hosted runners have network access
- Update workflows README runners table to document the change

## Test plan

- [ ] Trigger `Internal Release` workflow via manual dispatch and verify the wheel publishes to Artifactory
- [ ] Merge to `main` and verify `Dev Wheel` workflow succeeds on the next push


Made with [Cursor](https://cursor.com)