### PR TITLE
chore: modernize typing syntax with ruff UP006/UP007

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -29,6 +29,7 @@ exclude = [
     "unsloth_compiled_cache"
     ]
 
+target-version = "py311"
 line-length = 120
 indent-width = 4
 
@@ -36,7 +37,7 @@ indent-width = 4
 # Enable Pyflakes (`F`) and a subset of the pycodestyle (`E`)  codes by default.
 # Unlike Flake8, Ruff doesn't enable pycodestyle warnings (`W`) or
 # McCabe complexity (`C901`) by default.
-select = ["E4", "E7", "E9", "F", "W291", "W292", "W293", "I001", "I002"]
+select = ["E4", "E7", "E9", "F", "W291", "W292", "W293", "I001", "I002", "UP006", "UP007"]
 ignore = []
 
 # Allow fix for all enabled rules (when `--fix`) is provided.

--- a/script/slurm/collect_nss_results.py
+++ b/script/slurm/collect_nss_results.py
@@ -30,9 +30,9 @@ import csv
 import re
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Optional
 
-COLUMNS: List[str] = [
+COLUMNS: list[str] = [
     "exp_setting",
     "file_name",
     "dataset_name",
@@ -63,7 +63,7 @@ def _safe_lower(text: Optional[str]) -> str:
     return (text or "").lower()
 
 
-def parse_summary_block(file_text: str) -> Dict[str, str]:
+def parse_summary_block(file_text: str) -> dict[str, str]:
     """Parse the SafeSynthesizer summary block into a dict of raw string values.
 
     Returns an empty dict if the block is not present.
@@ -74,7 +74,7 @@ def parse_summary_block(file_text: str) -> Dict[str, str]:
     if not header_indices:
         return {}
     start_idx = header_indices[-1] + 1
-    values: Dict[str, str] = {}
+    values: dict[str, str] = {}
     for i in range(start_idx, len(lines)):
         line = lines[i]
         # Block lines are indented by two spaces followed by key: value
@@ -143,7 +143,7 @@ def build_row(
     root_dir: Path,
     file_path: Path,
     file_text: str,
-) -> Dict[str, str]:
+) -> dict[str, str]:
     """Build a CSV row for the given file contents."""
     values = parse_summary_block(file_text)
     dataset = parse_dataset_name(file_text) or ""
@@ -176,7 +176,7 @@ def build_row(
         "evaluation_time",
     ]
 
-    row: Dict[str, str] = {col: "" for col in COLUMNS}
+    row: dict[str, str] = {col: "" for col in COLUMNS}
     row["exp_setting"] = determine_exp_setting(root_dir, file_path)
     row["file_name"] = file_path.name
     row["dataset_name"] = dataset
@@ -293,7 +293,7 @@ def is_low_valid_rate_failure(out_text: str, err_text: str) -> bool:
     return any(tok in lowered_out for tok in tokens) or any(tok in lowered_err for tok in tokens)
 
 
-def fill_timing_metrics_from_text(row: Dict[str, str], text: str) -> None:
+def fill_timing_metrics_from_text(row: dict[str, str], text: str) -> None:
     """Parse *_time_sec fields from arbitrary text and populate row timing columns if missing."""
     if not text:
         return
@@ -378,12 +378,12 @@ def extract_error_message(err_text: str) -> Optional[str]:
     return None
 
 
-def collect_rows(root_dir: Path, skip_incomplete: bool = False) -> List[Dict[str, str]]:
-    rows: List[Dict[str, str]] = []
+def collect_rows(root_dir: Path, skip_incomplete: bool = False) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
     # Scan all .out files; include two-stage and e2e runs uniformly.
     # Training-only logs (slurm_train*.out) are ignored unless their matching .err shows an ERROR.
     all_out_files = sorted(root_dir.rglob("*.out"))
-    candidates: List[Path] = []
+    candidates: list[Path] = []
     for p in all_out_files:
         if p.name.startswith("slurm_train"):
             err_path = p.with_suffix(".err")
@@ -407,7 +407,7 @@ def collect_rows(root_dir: Path, skip_incomplete: bool = False) -> List[Dict[str
     return rows
 
 
-def write_csv(rows: List[Dict[str, str]], output_path: Path) -> None:
+def write_csv(rows: list[dict[str, str]], output_path: Path) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=COLUMNS)
@@ -416,7 +416,7 @@ def write_csv(rows: List[Dict[str, str]], output_path: Path) -> None:
             writer.writerow({k: row.get(k, "") for k in COLUMNS})
 
 
-def parse_args(argv: List[str]) -> argparse.Namespace:
+def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Collect SafeSynthesizer metrics from .out logs into a CSV")
     parser.add_argument(
         "--root",
@@ -438,7 +438,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: List[str]) -> int:
+def main(argv: list[str]) -> int:
     args = parse_args(argv)
     root_dir: Path = args.root
     if not root_dir.exists() or not root_dir.is_dir():

--- a/src/nemo_safe_synthesizer/artifacts/base/fields.py
+++ b/src/nemo_safe_synthesizer/artifacts/base/fields.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 from functools import cached_property
-from typing import Any, Union
+from typing import Any
 
 from pydantic import BaseModel, Field
 
@@ -73,7 +73,7 @@ class FieldFeatures(BaseModel):
     Number of times space character (' ') appears in field's values.
     """
 
-    classification: Union[dict, None] = Field(default=None)
+    classification: dict | None = Field(default=None)
     """
     Classification information, based on labels detected in field's values.
     """

--- a/src/nemo_safe_synthesizer/artifacts/base/manifest.py
+++ b/src/nemo_safe_synthesizer/artifacts/base/manifest.py
@@ -4,7 +4,7 @@
 import dataclasses
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 
 class ManifestStatus(StrEnum):
@@ -50,30 +50,30 @@ class ArtifactManifest:
     error_message: Optional[str] = None
     error_trace: Optional[str] = None
 
-    manifest: Dict[str, Any] = field(default_factory=dict)
+    manifest: dict[str, Any] = field(default_factory=dict)
 
     @property
-    def fields(self) -> Dict[str, list]:
+    def fields(self) -> dict[str, list]:
         return self.manifest.get("fields", {})
 
     @property
-    def types(self) -> List[dict]:
+    def types(self) -> list[dict]:
         return self.manifest.get("types", [])
 
     @fields.setter
-    def fields(self, value: Dict[str, list]) -> None:
+    def fields(self, value: dict[str, list]) -> None:
         self.manifest["fields"] = value
 
     @property
-    def data_check_results(self) -> List[Dict[str, Any]]:
+    def data_check_results(self) -> list[dict[str, Any]]:
         return self.manifest.get("data_check_results", [])
 
     @data_check_results.setter
-    def data_check_results(self, value: List[Dict[str, Any]]) -> None:
+    def data_check_results(self, value: list[dict[str, Any]]) -> None:
         self.manifest["data_check_results"] = value
 
     def add_feature(self, name: str, value: Any):
         self.manifest[name] = value
 
-    def dict(self) -> Dict[str, Any]:
+    def dict(self) -> dict[str, Any]:
         return {key: value for key, value in dataclasses.asdict(self).items() if value is not None}

--- a/src/nemo_safe_synthesizer/config/types.py
+++ b/src/nemo_safe_synthesizer/config/types.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal, TypeAlias, Union
+from typing import Literal, TypeAlias
 
 __all__ = [
     "AUTO_STR",
@@ -38,13 +38,13 @@ OptionalAutoInt: TypeAlias = AutoStrL | int | None
 OptionalAutoFloat: TypeAlias = AutoStrL | float | None
 OptionalAutoBool: TypeAlias = AutoStrL | bool | None
 
-OptionalListOrStr = Union[str, list[str]] | None
-OptionalListOrInt = Union[int, list[int]] | None
+OptionalListOrStr = str | list[str] | None
+OptionalListOrInt = int | list[int] | None
 
 OptionalStrList: TypeAlias = list[str] | None
 OptionalIntList: TypeAlias = list[int] | None
 
-OptionalDictNestedStr = dict[str, Union[str, dict, list]] | None
+OptionalDictNestedStr = dict[str, str | dict | list] | None
 OptionalStrDict = dict[str, str] | None
 
 PathLike: TypeAlias = str | Path

--- a/src/nemo_safe_synthesizer/configurator/parameter.py
+++ b/src/nemo_safe_synthesizer/configurator/parameter.py
@@ -12,7 +12,7 @@ for Pydantic v2 models.
 import operator
 import typing
 from dataclasses import dataclass
-from typing import Any, Callable, Generic, Sequence, Type, TypeVar, get_args
+from typing import Any, Callable, Generic, Sequence, TypeVar, get_args
 
 from pydantic import BaseModel, GetCoreSchemaHandler, model_serializer
 from pydantic_core import core_schema
@@ -274,7 +274,7 @@ ValidNoneType = TypeVar("ValidNoneType", ValidNoneParam, None)
 
 def _convert_val_type_to_param(
     value: Any,
-    type_: Type,
+    type_: type,
     name: str | None = None,
 ) -> Parameter[DataT]:
     """

--- a/src/nemo_safe_synthesizer/data_processing/actions/data_actions.py
+++ b/src/nemo_safe_synthesizer/data_processing/actions/data_actions.py
@@ -18,7 +18,6 @@ from typing import (
     Literal,
     Optional,
     Protocol,
-    Type,
     TypeVar,
     Union,
     cast,
@@ -74,7 +73,7 @@ class ValidateBatchPhase(str, Enum):
     VALIDATE_BATCH = "validate_batch"
 
 
-FunctionPhase = Union[ProcessPhase, ValidateBatchPhase]
+FunctionPhase = ProcessPhase | ValidateBatchPhase
 
 
 BaseModelT = TypeVar("BaseModelT", bound=BaseModel)
@@ -232,7 +231,7 @@ class BaseAction(BaseModel, ABC):
     def set_state(self, state_obj: BaseModel) -> None:
         self._ctx.state[self.hash()] = state_obj.model_dump_json()
 
-    def get_state(self, state_obj_type: Type[BaseModelT]) -> BaseModelT:
+    def get_state(self, state_obj_type: type[BaseModelT]) -> BaseModelT:
         state_obj_json = self._ctx.state[self.hash()]
         return state_obj_type.model_validate(json.loads(state_obj_json))
 
@@ -583,7 +582,7 @@ class DatetimeCol(ColAction):
 
 class CategoricalCol(ColAction):
     type_: Literal["categorical"] = "categorical"
-    values: list[Union[str, int, float]]
+    values: list[str | int | float]
 
     def _validate_batch(self, batch: pd.DataFrame, df: pd.DataFrame) -> pd.Series:
         return batch[self.name].isin(self.values)
@@ -613,13 +612,13 @@ the actions before they register with `__subclasses__`. Currently all the action
 are in this module, however, so that isn't an issue.
 """
 ActionT = Annotated[BaseAction, Field(discriminator="type_")]
-ActionT.__origin__ = Union[tuple(concrete_subclasses(BaseAction))]  # type: ignore
+ActionT.__origin__ = Union[tuple(concrete_subclasses(BaseAction))]  # type: ignore  # noqa: UP007
 
 GenerateActionT = Annotated[GenerateAction, Field(discriminator="type_")]
-GenerateActionT.__origin__ = Union[tuple(concrete_subclasses(GenerateAction))]  # type: ignore
+GenerateActionT.__origin__ = Union[tuple(concrete_subclasses(GenerateAction))]  # type: ignore  # noqa: UP007
 
 ColT = Annotated[ColAction, Field(discriminator="type_")]
-ColT.__origin__ = Union[tuple(concrete_subclasses(ColAction))]  # type: ignore
+ColT.__origin__ = Union[tuple(concrete_subclasses(ColAction))]  # type: ignore  # noqa: UP007
 
 
 class ActionExecutor(BaseModel):

--- a/src/nemo_safe_synthesizer/data_processing/actions/dates.py
+++ b/src/nemo_safe_synthesizer/data_processing/actions/dates.py
@@ -7,7 +7,7 @@ from collections import Counter
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from random import randint
-from typing import Dict, Iterable, Iterator, List, Optional, Set, Tuple, Union, cast
+from typing import Iterable, Iterator, Optional, cast
 
 import pandas as pd
 
@@ -125,7 +125,7 @@ def strptime_extra(date_string: str, fmt: str) -> datetime:
     return dt
 
 
-def date_component_permutations() -> List[Tuple[str, str, str, str, str]]:
+def date_component_permutations() -> list[tuple[str, str, str, str, str]]:
     """Returns a list of string formats by component type. Each permutation is
     indexed by y, m, d, hms, tz and can be passed into component formatter from
     ``date_component_orders``.
@@ -133,7 +133,7 @@ def date_component_permutations() -> List[Tuple[str, str, str, str, str]]:
     return list(itertools.product(*component_formats.values()))  # type:ignore
 
 
-def gen_date_str_fmt_permutations() -> Set[str]:
+def gen_date_str_fmt_permutations() -> set[str]:
     """Returns a list of unique date string format permutations"""
     return {order(*str_fmt) for str_fmt in date_component_permutations() for order in date_component_orders}
 
@@ -157,10 +157,10 @@ class TokenizedStr:
     and component seperators.
     """
 
-    components: List[Tuple[str, Tuple[int, int]]]
+    components: list[tuple[str, tuple[int, int]]]
     """A list of components and their string index mapped from the source string"""
 
-    seperators: List[str]
+    seperators: list[str]
     """A list of component seperators. Zipping this list with ``components`` yields
     the original string.
     """
@@ -172,7 +172,7 @@ class TokenizedStr:
         """
         return " ".join([s for s, _ in self.components])
 
-    def assemble_str_from_components(self, new_components: List[str]) -> str:
+    def assemble_str_from_components(self, new_components: list[str]) -> str:
         """Given a new set of components, rebuild the string with formatting preserved.
 
         Args:
@@ -292,14 +292,14 @@ def maybe_match(date, format) -> Optional[datetime]:
 
 def parse_date(
     input_date: str,
-    date_str_fmts: Union[List[str], Set[str]] = date_str_fmt_permutations,
+    date_str_fmts: list[str] | set[str] = date_str_fmt_permutations,
 ) -> Optional[ParsedDate]:
     return next(parse_date_multiple(input_date, date_str_fmts), None)
 
 
 def parse_date_multiple(
     input_date: str,
-    date_str_fmts: Union[List[str], Set[str]] = date_str_fmt_permutations,
+    date_str_fmts: list[str] | set[str] = date_str_fmt_permutations,
 ) -> Iterator[ParsedDate]:
     tokenized_date = tokenize_date_str(input_date)
 
@@ -370,7 +370,7 @@ def infer_from_series(date_series: Iterable[str]) -> Optional[str]:
 def fit_and_transform_dates(
     df: pd.DataFrame,
     inplace: bool = False,
-) -> Tuple[Dict[str, Dict[str, str]], pd.DataFrame]:
+) -> tuple[dict[str, dict[str, str]], pd.DataFrame]:
     date_min_dict = {}
     object_cols = [col for col, col_type in df.dtypes.iteritems() if col_type == "object"]
     result_df = df.copy() if not inplace else df
@@ -395,7 +395,7 @@ def fit_and_transform_dates(
     return date_min_dict, result_df
 
 
-def transform_dates(dates: Dict[str, Dict[str, str]], df: pd.DataFrame) -> pd.DataFrame:
+def transform_dates(dates: dict[str, dict[str, str]], df: pd.DataFrame) -> pd.DataFrame:
     result_df = df.copy()
     for col, details in dates.items():
         _dates = pd.to_datetime(result_df[col], format=details["format"], errors="coerce")

--- a/src/nemo_safe_synthesizer/data_processing/actions/distributions.py
+++ b/src/nemo_safe_synthesizer/data_processing/actions/distributions.py
@@ -67,7 +67,7 @@ class DatetimeDistribution(BaseModel, ABC):
     @abstractmethod
     def sample_datetimes(self, num_records: int) -> list[datetime]: ...
 
-    def sample(self, num_records: int) -> Union[list[datetime], list[str]]:
+    def sample(self, num_records: int) -> list[datetime] | list[str]:
         samples = self.sample_datetimes(num_records)
         return self._apply_universal_params(samples)
 
@@ -136,7 +136,7 @@ class DatetimeUniformDistribution(DatetimeDistribution):
 
 
 DistributionT = Annotated[Distribution, Field(discriminator="distribution_type")]
-DistributionT.__origin__ = Union[tuple(Distribution.__subclasses__())]  # type: ignore
+DistributionT.__origin__ = Union[tuple(Distribution.__subclasses__())]  # type: ignore  # noqa: UP007
 
 DatetimeDistributionT = Annotated[DatetimeDistribution, Field(discriminator="distribution_type")]
-DatetimeDistributionT.__origin__ = Union[tuple(DatetimeDistribution.__subclasses__())]  # type: ignore
+DatetimeDistributionT.__origin__ = Union[tuple(DatetimeDistribution.__subclasses__())]  # type: ignore  # noqa: UP007

--- a/src/nemo_safe_synthesizer/data_processing/actions/utils.py
+++ b/src/nemo_safe_synthesizer/data_processing/actions/utils.py
@@ -15,7 +15,6 @@ from typing import (
     Hashable,
     Literal,
     Optional,
-    Type,
     TypeVar,
     Union,
 )
@@ -188,7 +187,7 @@ class ExpressionSource(DataSource):
 
 
 DataSourceT = Annotated[DataSource, Field(discriminator="type_")]
-DataSourceT.__origin__ = Union[tuple(DataSource.__subclasses__())]  # type: ignore
+DataSourceT.__origin__ = Union[tuple(DataSource.__subclasses__())]  # type: ignore  # noqa: UP007
 
 
 def is_abstract(c: Any) -> bool:
@@ -200,11 +199,11 @@ def is_abstract(c: Any) -> bool:
     return inspect.isabstract(c) or ABC in c.__bases__
 
 
-def all_subclasses(klass: Type[T]) -> set[Type[T]]:
+def all_subclasses(klass: type[T]) -> set[type[T]]:
     """
     Grab all of the recursive subclasses of `klass`.
     """
-    subclasses: set[Type[T]] = set()
+    subclasses: set[type[T]] = set()
     subclass_queue = [klass]
     while subclass_queue:
         parent = subclass_queue.pop()
@@ -215,7 +214,7 @@ def all_subclasses(klass: Type[T]) -> set[Type[T]]:
     return subclasses
 
 
-def concrete_subclasses(klass: Type[T]) -> set[Type[T]]:
+def concrete_subclasses(klass: type[T]) -> set[type[T]]:
     """
     Find all the subclasses of `klass`, then filter out the abstract
     subclasses.

--- a/src/nemo_safe_synthesizer/data_processing/records/base.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/base.py
@@ -6,7 +6,7 @@
 import re
 from abc import ABC, abstractmethod
 from numbers import Number
-from typing import Iterable, List, Union
+from typing import Iterable
 
 from .value_path import (
     ValuePath,
@@ -33,7 +33,7 @@ DELIM = "."
 WORD_TOKENIZER = re.compile(r"(?!\d)\w+", re.IGNORECASE)
 
 
-def tokenize_on_upper(data: str) -> List[str]:
+def tokenize_on_upper(data: str) -> list[str]:
     if not data:
         return []
     out = []
@@ -51,7 +51,7 @@ def tokenize_on_upper(data: str) -> List[str]:
     return out
 
 
-def tokenize_header(field: str) -> List[str]:
+def tokenize_header(field: str) -> list[str]:
     out = []
     # NOTE(jm): for the purposes of header tokenization, we
     # don't consider `_` to be a word character, so we just
@@ -83,7 +83,7 @@ class KVPair:
     def __init__(
         self,
         field: str,
-        value: Union[str, Number],
+        value: str | Number,
         scalar_type: str,
         array_count: int,
         value_path: ValuePath,

--- a/src/nemo_safe_synthesizer/data_processing/records/fragment.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/fragment.py
@@ -9,7 +9,6 @@ import uuid
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Tuple, Union
 
 from ...pii_replacer.ner.entity import Score
 from ...pii_replacer.ner.predictor import NERPrediction
@@ -58,7 +57,7 @@ class MetadataFragment:
     def gretel_fragment_datetime(self) -> datetime:
         return datetime.fromtimestamp(self.gretel_fragment_epoch)
 
-    def add_field_data(self, field_name: str, metadata_type: str, field_data: Union[dict, List]):
+    def add_field_data(self, field_name: str, metadata_type: str, field_data: dict | list):
         """
         Adds field data by type to the model_metadata fragment
         Args:
@@ -117,11 +116,11 @@ def fragment_for_record(gretel_id: str, fragment_name: str) -> MetadataFragment:
 
 
 def predictions_to_dict(
-    predictions: List[NERPrediction],
+    predictions: list[NERPrediction],
     *,
     high_score: float = Score.HIGH,
     med_score: float = Score.MED,
-) -> Tuple[dict, dict]:
+) -> tuple[dict, dict]:
     """
     Reduces a list of prediction results into a single dict by field key. Also
     creates an entity mapping to easily find entity data about a record.
@@ -179,9 +178,9 @@ def predictions_to_dict(
 
 def fragment_from_ner_predictions(
     fragment_name: str,
-    predictions: List[NERPrediction],
+    predictions: list[NERPrediction],
     gretel_id: str,
-) -> Tuple[MetadataFragment, dict]:
+) -> tuple[MetadataFragment, dict]:
     epoch = time.time()
     fragment = MetadataFragment(
         gretel_id=gretel_id,
@@ -196,7 +195,7 @@ def fragment_from_ner_predictions(
     return fragment, ent_map
 
 
-def build_ner_metadata(preds: List[dict]) -> Metadata:
+def build_ner_metadata(preds: list[dict]) -> Metadata:
     preds = [NERPrediction.from_dict(p) for p in preds]
     fragment, ent_map = fragment_from_ner_predictions(
         "ner",
@@ -208,7 +207,7 @@ def build_ner_metadata(preds: List[dict]) -> Metadata:
     return meta.as_dict()
 
 
-def create_ner_api_response(records: List[dict], predictions: List[dict], pure_dict: bool = False) -> List[dict]:
+def create_ner_api_response(records: list[dict], predictions: list[dict], pure_dict: bool = False) -> list[dict]:
     out = [
         {"data": record, "model_metadata": build_ner_metadata(prediction)}
         for record, prediction in zip(records, predictions)

--- a/src/nemo_safe_synthesizer/data_processing/records/json_record.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/json_record.py
@@ -9,7 +9,7 @@ of automatic processing and field-level tracking done
 """
 
 from itertools import chain, starmap
-from typing import Optional, Tuple
+from typing import Optional
 
 from . import base
 from .value_path import (
@@ -51,7 +51,7 @@ def flatten(raw, array_marker=base.ARRAY_POS):
     return raw
 
 
-def remove_gretel_array_markers(data: str) -> Tuple[str, int, base.ValuePath]:
+def remove_gretel_array_markers(data: str) -> tuple[str, int, base.ValuePath]:
     array_count = 0
     parts = data.split(base.NESTING_DELIM)
     path_items = []

--- a/src/nemo_safe_synthesizer/data_processing/records/value_path.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/value_path.py
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import string
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
-ValuePathItem = Union[str, int]
-ValuePath = Tuple[ValuePathItem, ...]
+ValuePathItem = str | int
+ValuePath = tuple[ValuePathItem, ...]
 """
 A tuple representing a path to a value in a document.
 Each item in the tuple represents name of the nested field or array.
@@ -65,7 +65,7 @@ def value_path_to_json_path(path: ValuePath) -> str:
 class InvalidPath(Exception): ...
 
 
-def unflatten(data: Dict[ValuePath, Any]) -> Optional[Union[dict, list]]:
+def unflatten(data: dict[ValuePath, Any]) -> dict | list | None:
     result = None
     for key, value in data.items():
         try:
@@ -87,7 +87,7 @@ def _ensure_dict_key(result: dict, item: str):
         result[item] = None
 
 
-def _unflatten_path(result: Optional[Union[dict, list]], path: ValuePath, value: Any) -> Union[dict, list]:
+def _unflatten_path(result: dict | list | None, path: ValuePath, value: Any) -> dict | list:
     # Note: result will be a list when working with an array at this level of
     # the path, and thus the first element of path is an integer. Otherwise
     # working with an object at this level of the path, result will be a dict
@@ -117,7 +117,7 @@ def _unflatten_path(result: Optional[Union[dict, list]], path: ValuePath, value:
         return result
 
 
-def _unflatten_recursive(result: Union[dict, list], prev_item: ValuePathItem, items: List[ValuePathItem], value: Any):
+def _unflatten_recursive(result: dict | list, prev_item: ValuePathItem, items: list[ValuePathItem], value: Any):
     # Note: result will be a list when working with an array at this level of
     # the path, and thus the first element of path is an integer. Otherwise
     # working with an object at this level of the path, result will be a dict

--- a/src/nemo_safe_synthesizer/data_processing/stats.py
+++ b/src/nemo_safe_synthesizer/data_processing/stats.py
@@ -3,7 +3,6 @@
 
 import math
 from dataclasses import dataclass
-from typing import Union
 
 
 @dataclass
@@ -29,7 +28,7 @@ class RunningStatistics(Statistics):
     for the entire dataset to be loaded into memory.
     """
 
-    def update(self, x: Union[int, float]) -> None:
+    def update(self, x: int | float) -> None:
         """Update statistics with new value `x`."""
         self.count += 1
         self.min = min(self.min, x)

--- a/src/nemo_safe_synthesizer/llm/utils.py
+++ b/src/nemo_safe_synthesizer/llm/utils.py
@@ -4,7 +4,7 @@
 import gc
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator, Literal, Tuple, Union
+from typing import TYPE_CHECKING, Any, Generator, Literal, Union
 
 import torch
 from accelerate import infer_auto_device_map, init_empty_weights
@@ -172,7 +172,7 @@ def get_device_map(
     return device_map
 
 
-def count_trainable_params(model: PeftModel) -> Tuple[int, int]:
+def count_trainable_params(model: PeftModel) -> tuple[int, int]:
     """Determines the number of trainable and overall params of a model.
 
     Returns:

--- a/src/nemo_safe_synthesizer/pii_replacer/data_editor/environment.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/data_editor/environment.py
@@ -6,7 +6,7 @@ import random
 import re
 from datetime import date, datetime, timedelta
 from functools import partial
-from typing import Any, Callable, List, Optional, Union
+from typing import Any, Callable, Optional
 
 import dateutil.parser
 import jinja2
@@ -41,7 +41,7 @@ def lookup_locales(value: str) -> Optional[list[str]]:
     return locales if locales else None
 
 
-def tld(value: Union[str, pycountry.db.Data]) -> str:
+def tld(value: str | pycountry.db.Data) -> str:
     if isinstance(value, str):
         value = lookup_country(value)
     value = value.alpha_2.lower()
@@ -142,7 +142,7 @@ class Faker:
     def _fake_without_seed(self, instance_seed: Optional[SeedType] = None) -> VanillaFaker:
         return self._fake
 
-    def __call__(self, locale: Optional[List[str]] = None, seed: Optional[SeedType] = None):
+    def __call__(self, locale: Optional[list[str]] = None, seed: Optional[SeedType] = None):
         if locale is None:
             locale = self._fake.locales
         if seed is None:
@@ -320,7 +320,7 @@ class Environment:
             globals={"__tmp_literal": template_str},
         )
 
-    def _get_delta(self, base: Union[date, datetime, str]) -> timedelta:
+    def _get_delta(self, base: date | datetime | str) -> timedelta:
         if isinstance(base, str):
             base = dateutil.parser.parse(base)
         elif isinstance(base, date):
@@ -332,9 +332,9 @@ class Environment:
 
     def date_shift(
         self,
-        value: Union[date, datetime, str],
-        min_offset: Union[date, datetime, timedelta, str, int] = "-30y",
-        max_offset: Union[date, datetime, timedelta, str, int] = "today",
+        value: date | datetime | str,
+        min_offset: date | datetime | timedelta | str | int = "-30y",
+        max_offset: date | datetime | timedelta | str | int = "today",
     ) -> datetime:
         """
         Pick a random date from interval. Interval defined by input value
@@ -356,9 +356,9 @@ class Environment:
 
     def date_time_shift(
         self,
-        value: Union[date, datetime, str],
-        min_offset: Union[date, datetime, timedelta, str, int] = "-30y",
-        max_offset: Union[date, datetime, timedelta, str, int] = "now",
+        value: date | datetime | str,
+        min_offset: date | datetime | timedelta | str | int = "-30y",
+        max_offset: date | datetime | timedelta | str | int = "now",
     ) -> datetime:
         """
         Pick a random datetime from interval. Interval defined by input value
@@ -378,10 +378,10 @@ class Environment:
         fake_date = fake_date - delta
         return fake_date
 
-    def date_format(self, value: Union[date, datetime, str], format: str = "%Y-%m-%d"):
+    def date_format(self, value: date | datetime | str, format: str = "%Y-%m-%d"):
         return self.date_time_format(value, format=format)
 
-    def date_time_format(self, value: Union[date, datetime, str], format: str = "%Y-%m-%d %H:%M:%S"):
+    def date_time_format(self, value: date | datetime | str, format: str = "%Y-%m-%d %H:%M:%S"):
         if isinstance(value, str):
             value = dateutil.parser.parse(value)
         return value.strftime(format)

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/custom.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/custom.py
@@ -30,7 +30,7 @@ import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from re import Pattern
-from typing import List, Optional, Union
+from typing import Optional
 
 import yaml
 
@@ -44,10 +44,10 @@ logger = get_logger(__name__)
 
 score_map = {"low": Score.LOW, "med": Score.MED, "high": Score.HIGH}
 
-PatternListType = List[re.Pattern]
+PatternListType = list[re.Pattern]
 
 
-def _str_to_pattern(data: Union[str, List[str]]) -> PatternListType:
+def _str_to_pattern(data: str | list[str]) -> PatternListType:
     if isinstance(data, str):
         return [re.compile(data)]
 
@@ -67,8 +67,8 @@ class CustomRegexPattern:
 
     score: str
     regex: str
-    header_match: Optional[Union[str, List[str]]] = field(default_factory=list)
-    header_skip: Optional[Union[str, List[str]]] = field(default_factory=list)
+    header_match: Optional[str | list[str]] = field(default_factory=list)
+    header_skip: Optional[str | list[str]] = field(default_factory=list)
 
     # set after init
     regex_compiled: re.Pattern = None
@@ -108,10 +108,10 @@ class CustomRegexPattern:
 class CustomRegexPredictor:
     namespace: str
     name: str
-    patterns: List[CustomRegexPattern]
+    patterns: list[CustomRegexPattern]
 
     @classmethod
-    def from_config(cls, name: str, namespace: str, patterns: List[dict]):
+    def from_config(cls, name: str, namespace: str, patterns: list[dict]):
         _patterns = [CustomRegexPattern(**p) for p in patterns]
         return cls(name=name, namespace=namespace, patterns=_patterns)
 
@@ -139,7 +139,7 @@ def _namespace_from_config(config: dict) -> str:
 #####################
 
 
-def get_regex_predictors_from_config(config: dict) -> Optional[List[RegexPredictor]]:
+def get_regex_predictors_from_config(config: dict) -> Optional[list[RegexPredictor]]:
     out_predictors = []
     namespace = _namespace_from_config(config)
 
@@ -177,7 +177,7 @@ def _process_phrase_list_file(config: dict, builder: PhraseMatcherBuilder) -> Ph
     return builder
 
 
-def get_phrase_predictors_from_config(config: dict) -> Optional[List[RegexPredictor]]:
+def get_phrase_predictors_from_config(config: dict) -> Optional[list[RegexPredictor]]:
     out_predictors = []
     namespace = _namespace_from_config(config)
 
@@ -215,11 +215,11 @@ def _yaml_to_dict(file_path: str) -> dict:
     return config_dict
 
 
-def get_regex_predictors_from_yaml(file_path: str) -> List[RegexPredictor]:
+def get_regex_predictors_from_yaml(file_path: str) -> list[RegexPredictor]:
     return get_regex_predictors_from_config(_yaml_to_dict(file_path))
 
 
-def get_phrase_predictors_from_yaml(file_path: str) -> List[RegexPredictor]:
+def get_phrase_predictors_from_yaml(file_path: str) -> list[RegexPredictor]:
     return get_phrase_predictors_from_config(_yaml_to_dict(file_path))
 
 
@@ -228,7 +228,7 @@ def get_phrase_predictors_from_yaml(file_path: str) -> List[RegexPredictor]:
 #####################
 
 
-def get_predictors_from_yaml(file_path: str) -> List[Predictor]:
+def get_predictors_from_yaml(file_path: str) -> list[Predictor]:
     out = []
     parsing_fns = (get_regex_predictors_from_yaml, get_phrase_predictors_from_yaml)
     for fn in parsing_fns:

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/datetime.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/datetime.py
@@ -5,7 +5,7 @@ import itertools
 import math
 from dataclasses import dataclass
 from datetime import datetime
-from typing import List, Optional, Tuple, Union
+from typing import Optional
 
 from dateparser import parse
 from dateparser.date import get_date_from_timestamp
@@ -117,8 +117,8 @@ class BirthDateContext(BaseContext):
 
 
 def _parse_dates(
-    value: Union[str, int, float], scalar_type: Optional[str] = None
-) -> Optional[List[Tuple[str, datetime]]]:
+    value: str | int | float, scalar_type: Optional[str] = None
+) -> Optional[list[tuple[str, datetime]]]:
     if scalar_type == "number" and isinstance(value, str):
         # TODO(PROD-276): this is necessary, as our regex predictors change values from kv_pair
         #  to strings, so we need to use "scalar_type" field to figure out if the
@@ -178,7 +178,7 @@ class DateTime(Predictor):
         super().__init__(name)
         self._context = DateTimeContext(LABELS)
 
-    def evaluate(self, in_record: JSONRecord) -> List[NERPrediction]:
+    def evaluate(self, in_record: JSONRecord) -> list[NERPrediction]:
         """
         Given a single record determine if any
         entities are represented.

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/factory.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/factory.py
@@ -8,7 +8,7 @@ import os
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from enum import StrEnum
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from ...data_processing.records.base import normalize_labels
 from ...observability import get_logger
@@ -52,7 +52,7 @@ class NERPipelineType(StrEnum):
 
 
 class LabelSetPredictorFilter(PredictorFilter):
-    def __init__(self, included_labels: Set[str]):
+    def __init__(self, included_labels: set[str]):
         self._included_labels = normalize_labels(included_labels)
 
     def should_include(self, predictor: Predictor) -> bool:
@@ -92,13 +92,13 @@ class NERFactoryBase(ABC):
         *,
         predictor_filter: Optional[PredictorFilter] = None,
         record_count: Optional[int] = None,
-    ) -> Union[NER, NERParallel]: ...
+    ) -> NER | NERParallel: ...
 
 
 class NERFactory(NERFactoryBase):
     def __init__(
         self,
-        custom_predictors: Optional[List[Predictor]] = None,
+        custom_predictors: Optional[list[Predictor]] = None,
         *,
         parallel: bool = True,
         use_nlp: bool = False,
@@ -118,7 +118,7 @@ class NERFactory(NERFactoryBase):
         *,
         predictor_filter: Optional[PredictorFilter] = None,
         record_count: Optional[int] = None,
-    ) -> Union[NER, NERParallel]:
+    ) -> NER | NERParallel:
         if self._parallel:
             return self._create_parallel_ner(predictor_filter, record_count)
 
@@ -128,7 +128,7 @@ class NERFactory(NERFactoryBase):
         self,
         predictor_filter: Optional[PredictorFilter] = None,
         record_count: Optional[int] = None,
-    ) -> Union[NER, NERParallel]:
+    ) -> NER | NERParallel:
         """
         Determines an optimal number of NER workers and creates NERParallel.
 
@@ -186,7 +186,7 @@ class NERFactory(NERFactoryBase):
 
 
 class StaticNERFactory(NERFactoryBase):
-    def __init__(self, ner: Union[NER, NERParallel]):
+    def __init__(self, ner: NER | NERParallel):
         self._ner = ner
 
     def create(
@@ -194,7 +194,7 @@ class StaticNERFactory(NERFactoryBase):
         *,
         predictor_filter: Optional[PredictorFilter] = None,
         record_count: Optional[int] = None,
-    ) -> Union[NER, NERParallel]:
+    ) -> NER | NERParallel:
         return self._ner
 
 
@@ -206,6 +206,6 @@ class NERBundle:
 
     factory: NERFactoryBase = field(default_factory=NERFactory)
 
-    custom_labels: List[str] = field(default_factory=list)
+    custom_labels: list[str] = field(default_factory=list)
 
     field_label_condition: FieldLabelCondition = field(default_factory=FieldLabelCondition)

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/fasttext.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/fasttext.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import Union
-
 from .models import (
     ModelManifest,
     ObjectRef,
@@ -103,7 +101,7 @@ num_chars = frozenset(
 )
 
 
-def char_check(method: Union[all, any], query: str, check_set: frozenset):
+def char_check(method: all | any, query: str, check_set: frozenset):
     return method(map(lambda s: s in query, check_set))
 
 

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/labels.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/labels.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 import re
-from typing import Iterator, List, Pattern, Set
+from typing import Iterator, Pattern
 
 from ...data_processing.records.base import normalize_label, normalize_labels
 from ...observability import get_logger
@@ -13,7 +13,7 @@ from .entity import Entity
 logger = get_logger(__name__)
 
 
-def get_built_in_labels() -> List[str]:
+def get_built_in_labels() -> list[str]:
     labels = [normalize_label(key) for key in Entity.__members__.keys()]
 
     # FIXME(pm): This is hacky way to prioritize email_address transform, so that
@@ -30,11 +30,11 @@ class LabelEvaluator:
     One notable example is expanding wildcards from the label config (e.g. ``acme/*`` or ``*``).
     """
 
-    def __init__(self, explicit_labels: Set[str], label_regexes: List[Pattern]):
+    def __init__(self, explicit_labels: set[str], label_regexes: list[Pattern]):
         self._explicit_labels = normalize_labels(explicit_labels)
         self._label_regexes = label_regexes
 
-    def filter_labels(self, labels: List[str]) -> Iterator[str]:
+    def filter_labels(self, labels: list[str]) -> Iterator[str]:
         """
         Filters provided list of labels against configured labels and label regexes.
 
@@ -64,18 +64,18 @@ class LabelEvaluator:
                 if self._matches_any_regex(label):
                     yield label
 
-    def any_label_configured(self, labels: List[str]) -> bool:
+    def any_label_configured(self, labels: list[str]) -> bool:
         # checks if there is any item in the filtered list
         return next(self.filter_labels(labels), None) is not None
 
     def _matches_any_regex(self, label: str):
         return any(regex.match(label) for regex in self._label_regexes)
 
-    def explicit_lables(self) -> Set[str]:
+    def explicit_lables(self) -> set[str]:
         return self._explicit_labels
 
     @classmethod
-    def create_from_config(cls, config_labels: List[str]) -> LabelEvaluator:
+    def create_from_config(cls, config_labels: list[str]) -> LabelEvaluator:
         """
         Loads labels defined by the user in the config.
 
@@ -84,7 +84,7 @@ class LabelEvaluator:
         """
 
         explicit_labels = set([])
-        label_regexes: List[Pattern] = []
+        label_regexes: list[Pattern] = []
 
         for label in config_labels:
             if "*" not in label:

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/metadata.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/metadata.py
@@ -7,7 +7,7 @@ from dataclasses import asdict, dataclass
 from dataclasses import field as Field
 from enum import StrEnum
 from math import ceil
-from typing import List, Optional, Set, Union
+from typing import Optional
 
 from ...data_processing.records.json_record import JSONRecord
 from .ner import NER, PipelineResult
@@ -33,7 +33,7 @@ class EntityMetadata:
     approx_cardinality: int
     """How many distinct values there were for this entity type."""
 
-    sources: List[str]
+    sources: list[str]
     """A list of unique sources that contributed predictions
     to the entity summary.
     """
@@ -89,16 +89,16 @@ class FieldMetadata:
     either transforms or synthesizer, for one reason or another.
     """
 
-    entities: List[EntityMetadata] = Field(default_factory=list)
+    entities: list[EntityMetadata] = Field(default_factory=list)
     """List of entities detected in values of this field."""
 
-    types: List[TypeMetadata] = Field(default_factory=list)
+    types: list[TypeMetadata] = Field(default_factory=list)
     """List of types detected in values of this field."""
 
-    field_labels: List[str] = Field(default_factory=list)
+    field_labels: list[str] = Field(default_factory=list)
     """Labels detected for this field."""
 
-    field_attributes: List[FieldAttribute] = Field(default_factory=list)
+    field_attributes: list[FieldAttribute] = Field(default_factory=list)
     """Attributes detected for this field."""
 
     def dict(self):
@@ -112,7 +112,7 @@ class EntitySummary:
     label: str
     """Name of the entity or label."""
 
-    fields: List[str]
+    fields: list[str]
     """Fields containing the entity or label."""
 
     count: int
@@ -124,7 +124,7 @@ class EntitySummary:
     using an HLL datastructure.
     """
 
-    sources: List[str]
+    sources: list[str]
     """A list of unique sources that contributed predictions
     to the entity summary.
     """
@@ -135,13 +135,13 @@ class EntitySummary:
 
 @dataclass(frozen=True)
 class FieldsMetadata:
-    fields: List[FieldMetadata] = Field(default_factory=list)
+    fields: list[FieldMetadata] = Field(default_factory=list)
     """
     List of fields in the dataset.
     Note: This list is ordered in the same order that original dataset was ordered.
     """
 
-    entities: List[EntitySummary] = Field(default_factory=list)
+    entities: list[EntitySummary] = Field(default_factory=list)
     """List of entities in the dataset. Unique by entity label and score."""
 
 
@@ -183,13 +183,13 @@ class MetadataService:
 
     def __init__(
         self,
-        ner: Union[NER, NERParallel],
+        ner: NER | NERParallel,
         field_label_condition: FieldLabelCondition = None,
     ):
         self.ner = ner
         self.dataset_metadata_tracker = _DatasetMetadataTracker(field_label_condition=field_label_condition)  # noqa: F821
 
-    def add_field_names(self, field_names: List[str]):
+    def add_field_names(self, field_names: list[str]):
         """
         Adds names of all fields that should be tracked.
         This is necessary to track fields that can be present in the dataset,
@@ -205,10 +205,10 @@ class MetadataService:
 
     def predict(
         self,
-        records: List[JSONRecord],
+        records: list[JSONRecord],
         min_score: float = 0.0,
         timings_only: bool = False,
-        include_labels: Optional[Set[str]] = None,
+        include_labels: Optional[set[str]] = None,
     ) -> PipelineResult:
         # potential improvements here
         # - if a field is already classified as something on a field level -> do we skip doing NER on that field?

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/model.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/model.py
@@ -5,7 +5,7 @@
 """This module provides an interface to Nemo Safe Synthesizer Pii Replacer NER functionality."""
 
 import re
-from typing import Pattern, Tuple
+from typing import Pattern
 
 from ...data_processing.records.fragment import create_ner_api_response
 from ...pii_replacer.ner.entity import Score
@@ -20,7 +20,7 @@ INPUT_ERR = "Input data must be a string, dict, or a list of either"
 _source_validator = re.compile(r"[A-Za-z_]{2,15}$")
 
 
-def _parse_custom_source(source: str) -> Tuple[str, str]:
+def _parse_custom_source(source: str) -> tuple[str, str]:
     """Return a namespace, name str tuple"""
     parts = source.split("/")
     if len(parts) != 2:

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/models.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/models.py
@@ -9,7 +9,7 @@ import time
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from ...observability import get_logger
 
@@ -65,7 +65,7 @@ class ModelManifest:
     version: str
     """Model version"""
 
-    sources: List[ObjectRef]
+    sources: list[ObjectRef]
     """A list of pickled objects to load into memory."""
 
     visibility: Visibility
@@ -125,13 +125,13 @@ class CacheManager:
     __instance = None
     """Used to hold a singleton of ``CacheManager``"""
 
-    _cache: Dict[str, Dict[str, Any]]
+    _cache: dict[str, dict[str, Any]]
     """Holds model object values in memory. Key by ``ModelManifest.key`` by ``ObjectRef.key``"""
 
-    _manifests: Dict[str, ModelManifest]
+    _manifests: dict[str, ModelManifest]
     """Contains each registered model manifest"""
 
-    timings: Dict[str, float]
+    timings: dict[str, float]
     """Holds timings for each model manifest. Keyed by ``ModelManifest.model``"""
 
     @staticmethod

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/ner.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/ner.py
@@ -12,7 +12,7 @@ import time
 from collections import defaultdict
 from dataclasses import dataclass
 from dataclasses import field as dataclasses_field
-from typing import TYPE_CHECKING, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Optional
 
 from ...data_processing.records.json_record import JSONRecord
 from ...data_processing.records.value_path import (
@@ -68,7 +68,7 @@ class NERPrediction:
     def json_path(self):
         return value_path_to_json_path(self.value_path)
 
-    def get_dedupe_key_by_label(self, record: JSONRecord) -> Tuple:
+    def get_dedupe_key_by_label(self, record: JSONRecord) -> tuple:
         """Returns a string that can be used to dedupe
         predictions from different sources.
 
@@ -98,7 +98,7 @@ class NERPrediction:
 
 
 """Represents the prediction results of a pipeline"""
-PipelineResult = List[List[Union[NERPrediction, dict]]]
+PipelineResult = list[list[NERPrediction | dict]]
 
 
 PRECISION = 4
@@ -172,7 +172,7 @@ class NER:
         dict_result: bool = False,
         min_score: float = 0.0,
         timings_only: bool = False,
-        include_labels: Optional[Set[str]] = None,
+        include_labels: Optional[set[str]] = None,
     ) -> PipelineResult:
         """
         Predict entities from a string, list or dictionary object.

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/ner_mp.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/ner_mp.py
@@ -7,7 +7,7 @@ import time
 from dataclasses import dataclass, field
 from itertools import islice
 from threading import BoundedSemaphore
-from typing import Any, Callable, Iterator, List, Optional, Union
+from typing import Any, Callable, Iterator, Optional
 
 import joblib.externals.loky as loky
 
@@ -27,7 +27,7 @@ MAX_CHUNKS = 250
 class _ProcPayload:
     seq: int
     in_data: InData
-    out_data: Union[dict, Timings, PipelineResult] = None
+    out_data: dict | Timings | PipelineResult = None
 
 
 _ner_predictor = None  # type: ner.NER
@@ -69,7 +69,7 @@ def _predict(payload: _ProcPayload, **kwargs) -> _ProcPayload:
         raise e
 
 
-def iter_record_chunks(it: Iterator[Any], batch_size: int) -> Iterator[List[Any]]:
+def iter_record_chunks(it: Iterator[Any], batch_size: int) -> Iterator[list[Any]]:
     while True:
         chunk = islice(it, batch_size)
         chunk_list = list(chunk)
@@ -80,7 +80,7 @@ def iter_record_chunks(it: Iterator[Any], batch_size: int) -> Iterator[List[Any]
 
 @dataclass
 class _ResultData:
-    results: List[_ProcPayload] = field(default_factory=list)
+    results: list[_ProcPayload] = field(default_factory=list)
     lock: BoundedSemaphore = field(default_factory=lambda: BoundedSemaphore(value=MAX_CHUNKS))
     # progress_callback: logging.ProgressCallback = field(
     #     default_factory=lambda: logging.get_progress_callback("Classifying data... ")
@@ -128,7 +128,7 @@ class NERParallel:
         self._initialize_pool()
         self.ner_max_runtime_seconds = ner_max_runtime_seconds
 
-    def predict(self, in_data: InData, **kwargs) -> Union[Timings, PipelineResult]:
+    def predict(self, in_data: InData, **kwargs) -> Timings | PipelineResult:
         """
         Runs NER prediction on the input data.
 

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/nlp.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/nlp.py
@@ -7,7 +7,7 @@ import string
 from dataclasses import dataclass
 from numbers import Number
 from time import perf_counter
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 from ...data_processing.records.base import KVPair
 from ...data_processing.records.json_record import JSONRecord
@@ -139,7 +139,7 @@ class FieldStr:
 
     def spacy_doc_to_ner_prediction(
         self, doc: Doc, source: str, validator: Optional[Callable] = None
-    ) -> List[NERPrediction]:
+    ) -> list[NERPrediction]:
         """Given a prediction document, return an NERPrediction.
 
         This function will apply a set of rules on a Spacy doc and extract predictions
@@ -179,7 +179,7 @@ class FieldStr:
         return preds
 
 
-def _flatten_fields(in_data: List[KVPair]) -> List[FieldStr]:
+def _flatten_fields(in_data: list[KVPair]) -> list[FieldStr]:
     """Prepare input data for NLP usage.
 
     Args:
@@ -214,13 +214,13 @@ def _get_spacy_ent_score(_, ent: Entity) -> float:
 
 class SpacyPredictor(Predictor):
     nlp: Any
-    timings: Dict[str, Number]
+    timings: dict[str, Number]
     default_name: str = "spacy"
 
     def __init__(
         self,
         name: str = None,
-        model: Union[str] = None,
+        model: str = None,
         namespace: Optional[str] = None,
     ):
         if spacy is None:
@@ -262,7 +262,7 @@ class SpacyPredictor(Predictor):
         doc.set_extension(const.NER_SCORE, default=None, force=True)
         return self.nlp(doc.text)
 
-    def evaluate(self, in_data: JSONRecord) -> List[NERPrediction]:
+    def evaluate(self, in_data: JSONRecord) -> list[NERPrediction]:
         fields = _flatten_fields(in_data.kv_pairs)
 
         pred_by_field = []

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/person_name.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/person_name.py
@@ -8,7 +8,7 @@ import io
 import itertools
 import re
 from dataclasses import dataclass, field
-from typing import FrozenSet, Iterable, List
+from typing import Iterable
 
 from flashtext import KeywordProcessor
 
@@ -48,7 +48,7 @@ TOKEN_REGEX = re.compile(r"\b(?!\d)\w+", re.IGNORECASE)
 MAX_STR_LEN = 64
 
 
-def build_name_only_headers(others: Iterable[str]) -> List[Pattern]:
+def build_name_only_headers(others: Iterable[str]) -> list[Pattern]:
     out = []
     for other in others:
         out.append(r"{}.?{}".format("name", other))
@@ -71,12 +71,12 @@ class WordList:
     headers_neg: KeywordProcessor = None  # NOTE: init'd as a FrozenSet then converted
     """A list of header tokens that should not be present to trigger prediction flow"""
 
-    headers_pairs: FrozenSet[str] = field(default_factory=frozenset)
+    headers_pairs: frozenset[str] = field(default_factory=frozenset)
     """A list of words that can be combined with the word 'name', this should
     be used to build additional header pairs for analysis
     """
 
-    parts: FrozenSet[str] = field(default_factory=frozenset)
+    parts: frozenset[str] = field(default_factory=frozenset)
     """These are parts of a name that can be used to match, things like
     Mr., Mrs., etc
     """
@@ -178,7 +178,7 @@ class PersonNamePredictor(Predictor):
                 return True
         return False
 
-    def evaluate(self, in_record: JSONRecord) -> List[NERPrediction]:
+    def evaluate(self, in_record: JSONRecord) -> list[NERPrediction]:
         record_fields = in_record.kv_pairs
         result_set_by_field = [set() for _ in record_fields]
 

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/pipeline.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/pipeline.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from enum import Enum
 from numbers import Number
 from pathlib import Path
-from typing import Dict, Iterator, List, Sequence, Type, Union
+from typing import Iterator, Sequence
 
 from ...observability import get_logger
 from . import person_name
@@ -45,10 +45,10 @@ class PredictionSource(Enum):
 
 
 class Pipeline:
-    predictors: List[Predictor]
-    load_timings: Dict[str, Number]
+    predictors: list[Predictor]
+    load_timings: dict[str, Number]
 
-    def __init__(self, predictors: List[Predictor] = None):
+    def __init__(self, predictors: list[Predictor] = None):
         """A lightweight container class for managing prediction pipelines."""
         self.predictors = predictors or []
         self.load_timings = {}
@@ -56,7 +56,7 @@ class Pipeline:
     def _next_udf_name(self):
         return f"user_defined_predictor_{len(self.predictors) + 1}"
 
-    def add_predictors(self, predictors: Union[Predictor, List[Predictor]]):
+    def add_predictors(self, predictors: Predictor | list[Predictor]):
         if isinstance(predictors, Predictor):
             self.predictors.append(predictors)
         if isinstance(predictors, list):
@@ -106,12 +106,12 @@ class Pipeline:
         self.add_predictors(get_predictors_from_yaml(_path))
 
     @classmethod
-    def from_class_refs(cls, predictors: Sequence[Type[Predictor]]) -> Pipeline:
+    def from_class_refs(cls, predictors: Sequence[type[Predictor]]) -> Pipeline:
         klasses = [p() for p in predictors]
         return cls(klasses)
 
     @property
-    def predictor_list(self) -> List[str]:
+    def predictor_list(self) -> list[str]:
         """Return the list of all namespaced predictors
         currently loaded on the pipeline
         """
@@ -152,7 +152,7 @@ def create_default_ner(full: bool = False) -> NER:
     return NER(pipeline=pipe)
 
 
-def from_source_string_list(*, include: List[str] = None, exclude: List[str] = None) -> Pipeline:
+def from_source_string_list(*, include: list[str] = None, exclude: list[str] = None) -> Pipeline:
     if include and exclude:
         raise ValueError("cannot include and exclude")
 

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/predictor.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/predictor.py
@@ -4,7 +4,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from re import Pattern
-from typing import List, Optional, Tuple, Union
+from typing import Optional
 
 from ...data_processing.records.base import KVPair
 from ...data_processing.records.json_record import JSONRecord
@@ -13,7 +13,7 @@ from .ner import NERPrediction
 DEFAULT_CONTEXT_SPAN_SIZE = 16
 
 
-def _get_neighbor_strings(data: str, start: int, end: int, span: int) -> Tuple[str, str]:
+def _get_neighbor_strings(data: str, start: int, end: int, span: int) -> tuple[str, str]:
     left_mark = start - span
     if left_mark < 0:  # if we use a negative number we'll data from the end of the string
         left_mark = 0
@@ -72,7 +72,7 @@ class ContextSpan:
             to search for any matches from the ``pattern_list`` objects.
     """
 
-    pattern_list: List[Union[str, Pattern]]
+    pattern_list: list[str | Pattern]
     span: int = DEFAULT_CONTEXT_SPAN_SIZE
 
     def is_match(self, data: str, start: int, end: int) -> bool:
@@ -98,7 +98,7 @@ class ContextSpan:
         return False
 
 
-def is_context_matched(data: str, start: int, end: int, spans: List[ContextSpan]) -> bool:
+def is_context_matched(data: str, start: int, end: int, spans: list[ContextSpan]) -> bool:
     for span in spans:
         if span.is_match(data, start, end):
             return True
@@ -155,7 +155,7 @@ class Predictor(ABC):
         self._context = predictor_context
 
     @abstractmethod
-    def evaluate(self, in_data: JSONRecord) -> List[NERPrediction]:
+    def evaluate(self, in_data: JSONRecord) -> list[NERPrediction]:
         """This MUST be implemented by each Predictor"""
         pass
 

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/regex.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/regex.py
@@ -5,7 +5,7 @@ import itertools
 import re
 from collections import defaultdict
 from dataclasses import dataclass, field
-from typing import AnyStr, Dict, List, Optional, Set, Tuple, Union
+from typing import AnyStr, Optional
 from typing import Pattern as PatternType
 
 # We import as RePattern here separately from PatternType
@@ -26,7 +26,7 @@ from .predictor import ContextSpan, Predictor, is_context_matched
 
 def split_header_contexts(
     contexts: list[str | RePattern],
-) -> Tuple[RePattern | None, RePattern | None]:
+) -> tuple[RePattern | None, RePattern | None]:
     """Split a list of strings and RePatterns into two distcit regexes.
 
     Returns (regexes, tokens)
@@ -64,7 +64,7 @@ class Pattern:
         `NERError` if `pattern` is not a string or regex Pattern
     """
 
-    pattern: Union[str, RePattern]
+    pattern: str | RePattern
 
     context_score: Optional[float] = Score.HIGH
     """This is the optimal score that you want to assign when context exists
@@ -80,7 +80,7 @@ class Pattern:
     """If set, do not emit a match if only the raw regex matches without any context
     """
 
-    header_contexts: Optional[List[Union[str, RePattern]]] = field(default_factory=list)
+    header_contexts: Optional[list[str | RePattern]] = field(default_factory=list)
     """A list of strings or regexes that should be used to check the
     name of the field / header for a match. If there are any matches here, then
     the ``context_score`` value will be used as the matched score
@@ -89,7 +89,7 @@ class Pattern:
     header_regexes: Optional[RePattern] = field(init=False, default=None)
     header_tokens: Optional[RePattern] = field(init=False, default=None)
 
-    neg_header_contexts: Optional[List[Union[str, RePattern]]] = field(default_factory=list)
+    neg_header_contexts: Optional[list[str | RePattern]] = field(default_factory=list)
     """A list of strings or regexes that can be used to disqualify a field from being analyzed.
     If used, any matches were will short-circuit processing for a given key/value pair."""
 
@@ -102,7 +102,7 @@ class Pattern:
     of the field name and value
     """
 
-    span_contexts: Optional[Union[ContextSpan, List[ContextSpan]]] = field(default_factory=list)
+    span_contexts: Optional[ContextSpan | list[ContextSpan]] = field(default_factory=list)
     """A list of ``ContextSpan`` instances that will be used, if provided, to
     search surrounding text of a string match for other discrete strings or
     matching regular expressions. See the ``ContextSpan`` usage for more details.
@@ -135,7 +135,7 @@ class RegexPredictor(Predictor):
     def __init__(
         self,
         name: Optional[str] = None,
-        patterns: List[Pattern] = None,
+        patterns: list[Pattern] = None,
         entity: Optional[Entity] = None,
         namespace: Optional[str] = None,
     ):
@@ -164,7 +164,7 @@ class RegexPredictor(Predictor):
         """
         return True
 
-    def filter_by_range_by_score(self, field_matches: Set[NERPrediction]) -> List[NERPrediction]:
+    def filter_by_range_by_score(self, field_matches: set[NERPrediction]) -> list[NERPrediction]:
         """Filter predictions by text range and take max score."""
         by_range = itertools.groupby(
             sorted(field_matches, key=lambda n: n.text),
@@ -173,7 +173,7 @@ class RegexPredictor(Predictor):
 
         return [max(ps, key=lambda p: p.score) for _, ps in by_range]
 
-    def evaluate(self, in_record: JSONRecord, res_by_field=False) -> List[NERPrediction]:
+    def evaluate(self, in_record: JSONRecord, res_by_field=False) -> list[NERPrediction]:
         """
         Given a single record determine if any
         entities are represented.
@@ -285,8 +285,8 @@ class RegexPredictor(Predictor):
 
 @dataclass
 class PhrasePatterns:
-    case: List[str] = field(default_factory=list)
-    no_case: List[str] = field(default_factory=list)
+    case: list[str] = field(default_factory=list)
+    no_case: list[str] = field(default_factory=list)
 
     def to_strings(self):
         return "|".join(self.case), "|".join(self.no_case)
@@ -303,7 +303,7 @@ class PhraseMatcherBuilder:
     mapped per-entity. A list of ``RegexPredictors`` can be exported at any time.
     """
 
-    phrase_patterns: Dict[Union[str, Entity], PhrasePatterns]
+    phrase_patterns: dict[str | Entity, PhrasePatterns]
     """Map all labels to an object that holds a list of phrases to match. An arbitrary
     string or a specified entity can be used. This will determine how the actual ``name``
     param is utilized in the exported ``RegexPredictor`` objects
@@ -317,7 +317,7 @@ class PhraseMatcherBuilder:
         self.name = name
         self.namespace = namespace
 
-    def add_phrase(self, label: Union[str, Entity], phrase: str, case=False):
+    def add_phrase(self, label: str | Entity, phrase: str, case=False):
         """Take a simple phrase and modify it to become a regex"""
         # escape special chars
         phrase = phrase.replace(".", r"\.")
@@ -339,7 +339,7 @@ class PhraseMatcherBuilder:
         else:
             phrase_pattern.no_case.append(phrase)
 
-    def get_predictors(self) -> List[RegexPredictor]:
+    def get_predictors(self) -> list[RegexPredictor]:
         out_predictors = []
         for label, phrase_pattern in self.phrase_patterns.items():
             if isinstance(label, Entity):
@@ -371,7 +371,7 @@ class PhraseMatcherBuilder:
         return out_predictors
 
 
-def phrase_predictors_from_entity_ruler(name: str, er_patterns: List[dict], entity_map: dict) -> List[RegexPredictor]:
+def phrase_predictors_from_entity_ruler(name: str, er_patterns: list[dict], entity_map: dict) -> list[RegexPredictor]:
     """Given a list of Spacy EntityRuler patterns, create
     a phrase matcher predictor.
     """

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/regexes/__init__.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/regexes/__init__.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import Sequence, Type
+from typing import Sequence
 
 from ..regex import RegexPredictor
 from .aba_routing_number import AbaRoutingNumber
@@ -36,7 +36,7 @@ from .us_ssn import US_SSN
 from .us_zipcode import USZipcode
 from .uuid import UUID
 
-rules: Sequence[Type[RegexPredictor]] = (
+rules: Sequence[type[RegexPredictor]] = (
     AbaRoutingNumber,
     CreditCardNumber,
     DomainName,

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/report/metadata.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/report/metadata.py
@@ -3,8 +3,6 @@
 
 from __future__ import annotations
 
-from typing import List
-
 from pydantic.v1 import Field
 
 from ..metadata import (
@@ -50,7 +48,7 @@ class EntityReport(ReportBaseModel):
     approx_distinct_count: int
     f_ratio: float
 
-    sources: List[str]
+    sources: list[str]
     """A list of unique sources that contributed predictions
     to the entity summary.
     """
@@ -96,22 +94,22 @@ class FieldMetadataReport(ReportBaseModel):
     Number of records that didnt' have value for this field.
     """
 
-    labels: List[str]
+    labels: list[str]
     """
     Field-level labels for this field.
     """
 
-    attributes: List[str]
+    attributes: list[str]
     """
     Attributes for this field.
     """
 
-    entities: List[EntityReport] = Field(default_factory=list)
+    entities: list[EntityReport] = Field(default_factory=list)
     """
     Granular information about entities detected in field's values.
     """
 
-    types: List[TypeReport] = Field(default_factory=list)
+    types: list[TypeReport] = Field(default_factory=list)
     """
     Scalar types of values in this field.
     """
@@ -123,7 +121,7 @@ class EntitySummaryReport(ReportBaseModel):
     label: str
     """Name of the entity or label."""
 
-    fields: List[str]
+    fields: list[str]
     """List of fields the entity was seen in."""
 
     count: int
@@ -136,7 +134,7 @@ class EntitySummaryReport(ReportBaseModel):
     the dataset.
     """
 
-    sources: List[str]
+    sources: list[str]
     """A list of unique sources that contributed predictions
     to the entity summary.
     """
@@ -162,10 +160,10 @@ class DatasetMetadataReport(ReportBaseModel):
     Number of records that were used to calculate model_metadata.
     """
 
-    fields: List[FieldMetadataReport] = Field(default_factory=list)
+    fields: list[FieldMetadataReport] = Field(default_factory=list)
     """
     Report about each field in the dataset.
     """
 
-    entities: List[EntitySummaryReport] = Field(default_factory=list)
+    entities: list[EntitySummaryReport] = Field(default_factory=list)
     """Aggregate entity metrics by score by label."""

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/report/results.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/report/results.py
@@ -3,11 +3,11 @@
 
 import json
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from ....data_processing.records.value_path import value_path_to_json_path
 
-Prediction = Dict[str, Any]
+Prediction = dict[str, Any]
 
 
 @dataclass
@@ -21,9 +21,9 @@ class RecordResult:
     """
 
     index: int
-    entities: List[Prediction]
+    entities: list[Prediction]
 
-    def __init__(self, index: int, entities: List[Prediction]):
+    def __init__(self, index: int, entities: list[Prediction]):
         self.index = index
         self.entities = entities
 
@@ -51,7 +51,7 @@ class RecordResultExporter:
         config: Configuration for how to export the predictions.
     """
 
-    _keys_to_export: Dict[str, str]
+    _keys_to_export: dict[str, str]
     """
     A mapping from names in the NERPrediction to names that will be exported.
 
@@ -96,7 +96,7 @@ class RecordResultExporter:
         return exported_entity
 
 
-DatasetPredictions = List[RecordResult]
+DatasetPredictions = list[RecordResult]
 
 
 class DatasetClassifyResults:

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/utils.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/utils.py
@@ -1,15 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import List, Union
-
 from ...data_processing.records.json_record import JSONRecord
 
 """Valid input data includes a str, tuple or dict"""
-InData = Union[str, list, dict, JSONRecord]
+InData = str | list | dict | JSONRecord
 
 
-def input_to_json_records(in_data: InData) -> List[JSONRecord]:
+def input_to_json_records(in_data: InData) -> list[JSONRecord]:
     """Try and convert python objects to a list of Fields"""
     if isinstance(in_data, JSONRecord):
         return [in_data]

--- a/src/nemo_safe_synthesizer/privacy/dp_transformers/dp_utils.py
+++ b/src/nemo_safe_synthesizer/privacy/dp_transformers/dp_utils.py
@@ -8,7 +8,7 @@
 
 import os
 from contextlib import contextmanager
-from typing import Any, Dict, List, Optional, Sequence, Union
+from typing import Any, Optional, Sequence
 
 import opacus
 import pandas as pd
@@ -159,8 +159,8 @@ class DataCollatorForPrivateCausalLanguageModeling(DataCollatorForLanguageModeli
         super().__init__(tokenizer=tokenizer, mlm=False)
 
     def __call__(
-        self, examples: List[Union[List[int], torch.Tensor, Dict[str, torch.Tensor]]]
-    ) -> Dict[str, torch.Tensor]:
+        self, examples: list[list[int] | torch.Tensor | dict[str, torch.Tensor]]
+    ) -> dict[str, torch.Tensor]:
         batch = super().__call__(examples)
 
         if "position_ids" not in batch:
@@ -178,8 +178,8 @@ class DataCollatorForPrivateTokenClassification(DataCollatorForTokenClassificati
         super().__init__(tokenizer=tokenizer)
 
     def __call__(
-        self, examples: List[Union[List[int], torch.Tensor, Dict[str, torch.TensorType]]]
-    ) -> Dict[str, torch.Tensor]:
+        self, examples: list[list[int] | torch.Tensor | dict[str, torch.TensorType]]
+    ) -> dict[str, torch.Tensor]:
         batch = super().__call__(examples)
 
         if "position_ids" not in batch:
@@ -230,15 +230,15 @@ class OpacusDPTrainer(Trainer):
     def __init__(
         self,
         train_dataset: Dataset,
-        model: Union[modeling_utils.PreTrainedModel, torch.nn.Module],
+        model: modeling_utils.PreTrainedModel | torch.nn.Module,
         args=None,
         privacy_args: PrivacyArguments | None = None,
         data_fraction: float | None = None,
         true_dataset_size: int | None = None,
         entity_column_values: list | None = None,
-        callbacks: List[TrainerCallback] | None = None,
+        callbacks: list[TrainerCallback] | None = None,
         secure_mode: bool | None = True,
-        **kwargs: Dict,
+        **kwargs: dict,
     ) -> None:
         self.train_args = args
         self.privacy_args = privacy_args
@@ -394,7 +394,7 @@ class OpacusDPTrainer(Trainer):
     def training_step(
         self,
         model: nn.Module,
-        inputs: Dict[str, Union[torch.Tensor, Any]],
+        inputs: dict[str, torch.Tensor | Any],
         num_items_in_batch=None,
     ) -> torch.Tensor:
         """

--- a/src/nemo_safe_synthesizer/privacy/dp_transformers/linear.py
+++ b/src/nemo_safe_synthesizer/privacy/dp_transformers/linear.py
@@ -11,7 +11,6 @@
 # Convert activations and backprops to float for per-sample gradient
 # computation. During mixed precision training it is possible that the
 # activations and/or backprops are not in full precision.
-from typing import Dict, List
 
 import torch
 import torch.nn as nn
@@ -21,8 +20,8 @@ from opt_einsum import contract
 
 @register_grad_sampler(nn.Linear)
 def compute_linear_grad_sample(
-    layer: nn.Linear, activations: List[torch.Tensor], backprops: torch.Tensor
-) -> Dict[nn.Parameter, torch.Tensor]:
+    layer: nn.Linear, activations: list[torch.Tensor], backprops: torch.Tensor
+) -> dict[nn.Parameter, torch.Tensor]:
     """
     Computes per sample gradients for ``nn.Linear`` layer
 

--- a/src/nemo_safe_synthesizer/sdk/config_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/config_builder.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from typing import Mapping, Self, TypeAlias, TypeVar, Union
+from typing import Mapping, Self, TypeAlias, TypeVar
 
 import pandas as pd
 from pydantic import BaseModel
@@ -26,32 +26,32 @@ logger = get_logger(__name__)
 KT = TypeVar("KT")
 VT = TypeVar("VT")
 
-NSSParameters = Union[
-    DataParameters,
-    EvaluationParameters,
-    GenerateParameters,
-    DifferentialPrivacyHyperparams,
-    TimeSeriesParameters,
-    TrainingHyperparams,
-    SafeSynthesizerParameters,
-    PiiReplacerConfig,
-]
+NSSParameters = (
+    DataParameters
+    | EvaluationParameters
+    | GenerateParameters
+    | DifferentialPrivacyHyperparams
+    | TimeSeriesParameters
+    | TrainingHyperparams
+    | SafeSynthesizerParameters
+    | PiiReplacerConfig
+)
 
-NSSParametersT = Union[
-    type[DataParameters],
-    type[EvaluationParameters],
-    type[GenerateParameters],
-    type[DifferentialPrivacyHyperparams],
-    type[TimeSeriesParameters],
-    type[TrainingHyperparams],
-    type[SafeSynthesizerParameters],
-    type[PiiReplacerConfig],
-]
+NSSParametersT = (
+    type[DataParameters]
+    | type[EvaluationParameters]
+    | type[GenerateParameters]
+    | type[DifferentialPrivacyHyperparams]
+    | type[TimeSeriesParameters]
+    | type[TrainingHyperparams]
+    | type[SafeSynthesizerParameters]
+    | type[PiiReplacerConfig]
+)
 
 
 ParamT = TypeVar("ParamT", bound=NSSParameters)
 DataSource = pd.DataFrame | str
-ParamDict: TypeAlias = dict[str, Union[str, int, float, bool, None, Mapping[KT, VT]]]
+ParamDict: TypeAlias = dict[str, str | int | float | bool | None | Mapping[KT, VT]]
 
 
 class ConfigBuilder(object):

--- a/tests/generation/test_generation.py
+++ b/tests/generation/test_generation.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
-from typing import List, Tuple
 
 import pandas as pd
 import pytest
@@ -28,7 +27,7 @@ from nemo_safe_synthesizer.generation.results import GenerationBatches, Generati
 @pytest.fixture()
 def fixture_stub_batches(
     fixture_mock_processor, fixture_mock_processor_without_valid_records
-) -> Tuple[List[Batch], List[Batch]]:
+) -> tuple[list[Batch], list[Batch]]:
     batch_1 = Batch(fixture_mock_processor)
     batch_1.process(1, "stub")
     batch_1.process(2, "stub")


### PR DESCRIPTION
## Summary

- Enable ruff rules `UP006` (use builtin generics) and `UP007` (use `X | Y` union syntax) and set `target-version = "py311"` in `ruff.toml`
- Auto-fix and manually convert old-style typing across 40 files: `List` -> `list`, `Optional[X]` -> `X | None`, `Dict` -> `dict`, `Union[X, Y]` -> `X | Y`, etc.
- Add `# noqa: UP007` for runtime `Union[tuple(...)]` patterns that require `typing.Union` for dynamic type construction
- Clean up unused typing imports (`Type`, `Union`, `Optional` where no longer referenced)

## Test plan

- [x] `ruff check .` passes with zero violations
- [x] Package imports successfully (`import nemo_safe_synthesizer`)
- [ ] CI passes (lint, unit tests)


Made with [Cursor](https://cursor.com)