### PR TITLE
fix: Add flag so docs-serve Makefile target auto reloads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ bootstrap-nss: .venv ## Bootstrap Python dependencies. Usage: make bootstrap-nss
 
 .PHONY: docs-serve
 docs-serve: ## Serve the documentation site locally with live reload
-	uv run --group docs mkdocs serve
+	uv run --frozen --group docs mkdocs serve --livereload
 
 .PHONY: docs-build
 docs-build: ## Build the documentation site


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary

Fix `make docs-serve` to successfully auto reload on changed files.

There's a bug in `mkdocs` so the documented behavior (auto reload by default) is not accurate. This PR adds `--livereload` as a workaround per https://github.com/mkdocs/mkdocs/issues/4055. Also add `--frozen` for `uv` so it won't uninstall all the other safe synthesizer deps when you use `make docs-serve`.


<!-- Brief description of changes -->

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [X] `make format && make lint` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->

Tested manually on linux kube pod and macbook.
