### PR TITLE
chore: add .vscode/settings.json to prepend ~/.local/bin to terminal PATH

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "terminal.integrated.env.linux": {
+        "PATH": "${env:HOME}/.local/bin:${env:PATH}"
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a repo-wide `.vscode/settings.json` that prepends `$HOME/.local/bin` to `PATH` for Cursor/VS Code integrated terminals and agent shells
- Ensures tools installed via `uv tool install`, `pipx`, or direct download to `~/.local/bin` are discoverable without relying on shell init files
- Force-added since `.vscode/` is in `.gitignore`, matching the existing `.vscode/extensions.json` precedent

## Context

Cursor agent shells (`bash -c` invocations) inherit a minimal system PATH that lacks `~/.local/bin`. This means tools like `direnv`, `uv` (when installed to `~/.local/bin`), and other user-local binaries are not found. The `terminal.integrated.env.linux` setting applies to both interactive terminals and agent tool-call shells.

## Test plan

- [ ] Open the repo in Cursor, open a terminal, run `echo "$PATH" | tr ":" "\n" | grep ".local/bin"` -- should show `$HOME/.local/bin`
- [ ] Verify `direnv` and other `~/.local/bin` tools are found via `command -v direnv`

Made with [Cursor](https://cursor.com)