### PR TITLE
docs: Revise docs home page for clarity and navigation

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ It uses LLM fine-tuning with optional [differential privacy](https://desfontain.
 
     ---
 
-    Learn about the the pipeline steps: replace PII, synthesize data, evaluate.
+    Learn about the pipeline steps: replace PII, synthesize data, evaluate.
 
     [:octicons-arrow-right-24: Product Overview](product-overview/pipeline.md)
 


### PR DESCRIPTION
## Summary

- Simplify intro copy and remove decorative bold to match repo markdown style
- Add hyperlinks to key technologies (differential privacy, Opacus, vLLM)
- Reorder "Next Steps" cards so Getting Started appears first
- Remove inline Quick Example code block (covered by Getting Started guide)
  - Would need to be much more extensive to be useful on the home page (installation, GPU needed, etc.)
- Add a Contact section with links to discussions, issues, and security policy

## Test plan
- [x] Verify `make docs-serve` renders the updated home page correctly
- [x] Confirm all links (external and internal navigation cards) resolve

Made with [Cursor](https://cursor.com)