### PR TITLE
ci(hooks): enforce --signoff on git commit

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+    "hooks": {
+        "PreToolUse": [
+            {
+                "matcher": "Bash",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": ".cursor/hooks/enforce-signoff.sh"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -15,6 +15,10 @@
     ],
     "beforeShellExecution": [
       {
+        "command": ".cursor/hooks/enforce-signoff.sh",
+        "matcher": "git commit"
+      },
+      {
         "command": ".cursor/hooks/audit.sh"
       }
     ],

--- a/.cursor/hooks/enforce-signoff.sh
+++ b/.cursor/hooks/enforce-signoff.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# Blocks `git commit` without --signoff/-s. Cursor exit code 2 = deny action.
+# The agentMessage tells the agent to retry with --signoff.
+
+json_input=$(cat)
+command=$(echo "$json_input" | jq -r '.command // empty')
+
+if echo "$command" | grep -qE '^git commit' && ! echo "$command" | grep -qE '(--signoff| -[a-zA-Z]*s)'; then
+    echo '{"exitCode": 2, "agentMessage": "All commits require DCO sign-off. Re-run with --signoff (or -s)."}'
+    exit 2
+fi
+
+exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,8 @@ Common commands: `make test` (unit tests), `make format` (ruff + copyright), `ma
 
 Feature branches off `main`. Branch names often include an issue number prefix (e.g., `<author>/123-short-name`).
 
+All commits require DCO sign-off. Always use `git commit --signoff` (or `-s`) -- never write the `Signed-off-by` trailer manually.
+
 For testing, building, syncing, bootstrapping, and other workflows, see the matching skill or `.claude/commands/` file.
 
 ## Module Map


### PR DESCRIPTION
## Summary

- Add a `beforeShellExecution` hook (Cursor) and `PreToolUse` hook (Claude Code) that block `git commit` without `--signoff`/`-s`
- Hook returns `agentMessage` so the agent self-corrects automatically
- Add DCO sign-off one-liner to AGENTS.md for editors without hook support (Windsurf, etc.)

## Motivation

Agent committed with a manually-written `Signed-off-by` that didn't match the git config identity, causing DCO check failure on PR #127. This hook prevents that class of error at the tool level.

## Hook test results

| Input | Expected | Result |
|-------|----------|--------|
| `git commit -m "test"` | Block (exit 2) | exit 2 + agentMessage |
| `git commit --signoff -m "test"` | Allow (exit 0) | exit 0 |
| `git commit -s -m "test"` | Allow (exit 0) | exit 0 |
| `git commit -sm "test"` | Allow (exit 0) | exit 0 |
| `git commit --amend --signoff --no-edit` | Allow (exit 0) | exit 0 |
| `git commit --amend --no-edit` | Block (exit 2) | exit 2 |
| `git commit -a -m "test"` | Block (exit 2) | exit 2 |
| `git status` | Allow (exit 0) | exit 0 |
| `{}` (no command field) | Allow (exit 0) | exit 0 |

## Test plan

- [ ] In Cursor, run `git commit -m "test"` -- should be blocked with agentMessage
- [ ] In Cursor, run `git commit -s -m "test"` -- should proceed
- [ ] DCO check passes on this PR