### PR TITLE
ci: add workflow to strip template boilerplate from PR bodies

### DIFF
--- a/.github/workflows/clean-pr-body.yml
+++ b/.github/workflows/clean-pr-body.yml
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Clean PR Body
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  clean-pr-body:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Strip template boilerplate from PR body
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr_number = context.payload.pull_request.number;
+            const body = context.payload.pull_request.body || '';
+
+            // 1. Strip HTML comments that start at the beginning of a line,
+            //    preserving inline references like `<!-- -->` in code spans.
+            let stripped = body.replace(/^[ \t]*<!--[\s\S]*?-->[ \t]*\n?/gm, '');
+
+            // 2. Extract only the Summary section (# Summary or ## Summary),
+            //    dropping checklists and other template sections.
+            let summary;
+            const summaryWithNext = stripped.match(/^#{1,2}\s+Summary\s*\n([\s\S]*?)(?=\n#{1,2}\s)/m);
+            if (summaryWithNext) {
+              summary = summaryWithNext[1];
+            } else {
+              // Summary is the last/only heading -- take everything after it.
+              const summaryToEnd = stripped.match(/^#{1,2}\s+Summary\s*\n([\s\S]*)/m);
+              summary = summaryToEnd ? summaryToEnd[1] : stripped;
+            }
+
+            // If no Summary heading at all, take everything before checklist headings.
+            if (!summaryWithNext && !stripped.match(/^#{1,2}\s+Summary/m)) {
+              const beforeChecklist = stripped.match(/^([\s\S]*?)(?=\n#{1,2}\s+(?:Pre-Review|Pre-Merge|Other Notes))/m);
+              summary = beforeChecklist ? beforeChecklist[1] : stripped;
+            }
+
+            // 3. Collect unique git trailers from the full body.
+            const trailerRe = /^(Signed-off-by|Co-authored-by):\s+.+$/gm;
+            const seen = new Set();
+            const trailers = [];
+            for (const [line] of stripped.matchAll(trailerRe)) {
+              if (!seen.has(line)) {
+                seen.add(line);
+                trailers.push(line);
+              }
+            }
+
+            // 4. Remove trailers and GitHub separator lines from summary text.
+            summary = summary
+              .split('\n')
+              .filter(l => !l.match(/^(Signed-off-by|Co-authored-by):\s+/) && l.trim() !== '---------')
+              .join('\n')
+              .replace(/\n{3,}/g, '\n\n')
+              .trim();
+
+            let cleaned = summary;
+            if (trailers.length) cleaned += '\n\n' + trailers.join('\n');
+
+            if (cleaned !== body.trim()) {
+              await github.rest.pulls.update({
+                owner,
+                repo,
+                pull_number: pr_number,
+                body: cleaned,
+              });
+              core.info(`Cleaned PR #${pr_number} body to Summary + trailers`);
+            } else {
+              core.info(`PR #${pr_number} body already clean`);
+            }


### PR DESCRIPTION
## Summary

The PR template uses HTML comments and checklist sections for author guidance. GitHub's squash-merge copies the full PR body into the commit message, polluting git history with template boilerplate.

This workflow fires once when a PR is opened, extracts only the Summary section content (plus git trailers), and writes the cleaned body back via the GitHub API. The template stays intact in the editor when creating the PR; after submission, the body shows only what matters for the commit message.

The extraction regex was tested against all 11 affected commits in the repo history. It handles: multi-line HTML comments, inline `<!-- -->` in code spans (preserved), `# Summary` and `## Summary` headings, trailer deduplication, and GitHub separator lines.

## Test plan

- [ ] Open a test PR using the template and verify the workflow trims the body to Summary + trailers
- [ ] Verify inline `<!-- -->` in code spans is not stripped
- [ ] Verify a PR without a Summary heading still gets a reasonable body