### PR TITLE
chore: Add detail to PR process in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -218,8 +218,8 @@ The `main` branch has the following protections:
    - Reviewers may re-open resolved comments with further comments or questions, that's okay and part of the process
    - After responding to all comments and pushing changes to the branch, re-request review with the circular arrow button to the right of the reviewer name
    - Use the Assignees list to indicate who's expected to take the next action on the PR, such as PR author after reviewer leaves comments, or the reviewer after updates have been made
-   - if there is an error or something that requires changes, it's okay to review it and mark it as "requires changes" for explicit feedback. there's cases where we can possible triage by pr status - e.g., PRs that are open and are possibly ready, just need review or approval, vs things that are needing work.
-8. Merge — once approved, your PR will be squash-merged and the branch auto-deleted. please review the git message, which will automatically be set to the first comment in the PR.
+   - Reviewers: If there is an error in the PR or something that requires large changes, review and mark it as "requires changes" for explicit feedback. This can give signal for triaging which PRs are mostly ready or those that require more work.
+8. Merge — once approved, your PR will be squash-merged and the branch auto-deleted. Please review the git message, which will automatically be set to the first comment in the PR.
 
 ### CODEOWNERS
 


### PR DESCRIPTION
# Summary

Add context on the PR process and etiquette with resolving comments, using assignees, and re-requesting review.

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `make format && make lint` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

