### PR TITLE
docs: Add docstring guidance for lists and Python Click methods

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -698,6 +698,10 @@ The before/after examples above demonstrate most rules. These additional points 
   ```
 
   Do not use the Sphinx `:meth:` / `:class:` / `:func:` syntax -- it renders as literal text in MkDocs
+- Docstrings on Python Click command methods are used for the --help details on the CLI, so may not fully conform to the general method docstring guidance.
+  They should be written for the CLI user, and not for a developer working on the code.
+  For example, should not include `Args:`, the args are already documented for CLI usage through the `click.options` decorators.
+- Always include a blank line before and after (unless end of docstring) a list of items in docstrings, otherwise it is rendered as part of a paragraph in the API reference.
 
 ### Patterns to avoid
 


### PR DESCRIPTION


<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary

- Clarify that docstrings for Python Click command methods are for the CLI help usage, not for development, so may not follow other docstring guidance, such as including `Args:`
- Add reminder that bulleted lists in docstring must have a blank line before and after, otherwise they will render (very poorly) as a paragraph.
## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `make format && make lint` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

