### PR TITLE
fix(test): DP tests selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,11 +177,13 @@ test-ci-slow: ## Run slow tests in CI with coverage
 	pushd $(NSS_ROOT_PATH) && \
 	$(PYTEST_CMD) $(PYTEST_CI_OPTS) $(NSS_ROOT_PATH)/tests -m "slow"
 
+E2E_TEST_FILE := $(NSS_ROOT_PATH)/tests/e2e/test_safe_synthesizer.py
+
 .PHONY: test-gpu-integration
 test-gpu-integration: ## Run GPU integration tests
 	pushd $(NSS_ROOT_PATH) && \
-	$(PYTEST_CMD) $(NSS_ROOT_PATH)/tests/e2e/ -k "gpu_integration and not e2e and default" && \
-	$(PYTEST_CMD) $(NSS_ROOT_PATH)/tests/e2e/ -k "gpu_integration and not e2e and dp"
+	$(PYTEST_CMD) $(E2E_TEST_FILE) -k default && \
+	$(PYTEST_CMD) $(E2E_TEST_FILE) -k dp
 
 # Please modify these based on updating the e2e tests for NMP CI
 .PHONY: test-e2e
@@ -191,13 +193,28 @@ test-e2e: test-e2e-default test-e2e-dp ## Run all e2e tests (requires CUDA)
 test-e2e-default: ## Run default e2e tests (requires CUDA)
 # -n 0 is a workaround to run the tests in a single process.
 	pushd $(NSS_ROOT_PATH) && \
-	$(PYTEST_CMD) -n 0 $(NSS_ROOT_PATH)/tests/e2e/ -k "e2e and default"
+	$(PYTEST_CMD) -n 0 $(E2E_TEST_FILE) -k default
 
 .PHONY: test-e2e-dp
 test-e2e-dp: ## Run dp e2e tests (requires CUDA)
 # -n 0 is a workaround to run the tests in a single process.
 	pushd $(NSS_ROOT_PATH) && \
-	$(PYTEST_CMD) -n 0 $(NSS_ROOT_PATH)/tests/e2e/ -k "e2e and dp"
+	$(PYTEST_CMD) -n 0 $(E2E_TEST_FILE) -k dp
+
+.PHONY: test-e2e-collect
+test-e2e-collect: ## Dry-run: show which tests e2e/gpu targets select (requires CUDA deps)
+	@echo "--- test-e2e-default ---"
+	-@cd $(NSS_ROOT_PATH) && \
+	$(PYTEST_CMD) -n 0 $(E2E_TEST_FILE) -k default -o "addopts=" --collect-only -qq -p no:warnings 2>/dev/null
+	@echo "--- test-e2e-dp ---"
+	-@cd $(NSS_ROOT_PATH) && \
+	$(PYTEST_CMD) -n 0 $(E2E_TEST_FILE) -k dp -o "addopts=" --collect-only -qq -p no:warnings 2>/dev/null
+	@echo "--- test-gpu-integration (default) ---"
+	-@cd $(NSS_ROOT_PATH) && \
+	$(PYTEST_CMD) $(E2E_TEST_FILE) -k default -o "addopts=" --collect-only -qq -p no:warnings 2>/dev/null
+	@echo "--- test-gpu-integration (dp) ---"
+	-@cd $(NSS_ROOT_PATH) && \
+	$(PYTEST_CMD) $(E2E_TEST_FILE) -k dp -o "addopts=" --collect-only -qq -p no:warnings 2>/dev/null
 
 ### CONTAINER-BASED TESTING ###
 


### PR DESCRIPTION
pytest combines -m and -k flags with OR semantics.

a test is selected if it matches the marker expression OR the keyword expression. The Makefile e2e targets use both flags intending AND, which causes unrelated test_dataset_config.py tests to be selected.