### PR TITLE
chore(ci): add a tag based release mechanism

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,7 +15,7 @@ This directory contains GitHub Actions workflows for CI/CD automation.
 | [conventional-commit.yml](conventional-commit.yml) | PRs                                   | Validates PR titles follow conventional commit format |
 | [copyright-check.yml](copyright-check.yml)         | Push to `main`/`pull-request/*`        | Validates NVIDIA copyright headers on Python files   |
 | [docs.yml](docs.yml)                               | Push to `main` (docs paths)           | Builds and deploys documentation to GitHub Pages     |
-| [internal-release.yml](internal-release.yml)       | Manual dispatch                       | Builds and publishes wheel to NVIDIA Artifactory     |
+| [internal-release.yml](internal-release.yml)       | Tag push (`v[0-9]*`), manual dispatch | Builds and publishes wheel to Artifactory or PyPI    |
 | [release.yml](release.yml)                         | Manual dispatch                       | Builds and publishes package to PyPI (production)    |
 | [secrets-detector.yml](secrets-detector.yml)       | PRs                                   | Scans for accidentally committed secrets             |
 
@@ -74,12 +74,19 @@ flowchart LR
         slackNotify[Slack Notification]
     end
 
+    subgraph internalRelease [Internal Release]
+        buildWheelInt[Build Wheel]
+        publishArtifactory[Publish to Artifactory/PyPI]
+    end
+
     push --> ci & gpu
     cpb --> gpu & copyright
     pr --> ci & conventional & secrets
     manual --> release
+    tag[Tag push v[0-9]*] --> internalRelease
 
     buildWheel --> publishPyPI --> ghRelease --> slackNotify
+    buildWheelInt --> publishArtifactory
 
     conventional -.->|reuses| FW-CI-templates
     secrets -.->|reuses| FW-CI-templates
@@ -170,18 +177,35 @@ Validates that Python files have proper NVIDIA copyright headers.
 
 ## Internal Release Workflow
 
-The `internal-release.yml` workflow builds a wheel and publishes it to NVIDIA Artifactory. Use this for testing the release process or distributing internal builds.
+The `internal-release.yml` workflow builds a wheel and publishes it to NVIDIA Artifactory or PyPI.
+
+### Triggers
+
+**Tag push (automatic):** Pushing a `v[0-9]*` tag (e.g. `git tag v0.2.0 && git push --tags`) automatically builds and publishes to Artifactory. This is the primary release mechanism.
+
+**Manual dispatch:** Go to Actions > Internal Release and run with:
+- `release-ref`: Branch, tag, or commit SHA to build (defaults to `main`)
+- `publish-target`: `artifactory` (default) or `pypi`
 
 ### How to Publish Internally
 
-Via GitHub Actions:
+Tag-based (recommended):
+
+```bash
+git tag v0.2.0
+git push --tags
+```
+
+This triggers the workflow automatically and publishes to Artifactory.
+
+Via GitHub Actions (manual):
 
 1. Go to Actions > Internal Release
 2. Click Run workflow
-3. Enter the branch, tag, or commit SHA to build (defaults to `main`)
-4. The workflow builds the wheel, uploads it as an artifact, and publishes to Artifactory
+3. Enter the branch, tag, or commit SHA to build
+4. Select publish target (`artifactory` or `pypi`)
 
-Requires `ARTIFACTORY_USERNAME`, `ARTIFACTORY_TOKEN`, and `ARTIFACTORY_INTERNAL_URL` secrets to be configured.
+Requires `ARTIFACTORY_USERNAME`, `ARTIFACTORY_TOKEN`, and `ARTIFACTORY_INTERNAL_URL` secrets for Artifactory; `TWINE_USERNAME` and `TWINE_PASSWORD` for PyPI.
 
 Locally (via Makefile):
 

--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -13,15 +13,26 @@
 # limitations under the License.
 
 # ---------------------------------------------------------------------------
-# Internal release: build a wheel and publish to NVIDIA Artifactory.
+# Tag-based release: build a wheel and publish on every v[0-9]* tag push.
+# Also available as a manual dispatch with a configurable publish target.
+#
+# Tag push on a v[0-9]* tag (e.g. `git tag v0.2.0 && git push --tags`):
+#   - Automatically publishes to NVIDIA Artifactory.
+#
+# Manual dispatch:
+#   - publish-target=artifactory (default): publishes to NVIDIA Artifactory.
+#   - publish-target=pypi: publishes to PyPI (production releases).
+#
 # Version is determined from git tags via uv-dynamic-versioning.
-# Tag a commit (e.g. `git tag v0.2.0`) before running this workflow.
-# Production releases to PyPI use release.yml (FW-CI-templates).
+# For full production PyPI releases (with GitHub release + Slack), use release.yml.
 # ---------------------------------------------------------------------------
 
 name: "Internal Release"
 
 on:
+  push:
+    tags:
+      - 'v[0-9]*'
   workflow_dispatch:
     inputs:
       release-ref:
@@ -29,6 +40,14 @@ on:
         required: true
         default: main
         type: string
+      publish-target:
+        description: Where to publish the wheel
+        required: true
+        default: artifactory
+        type: choice
+        options:
+          - artifactory
+          - pypi
 
 defaults:
   run:
@@ -36,30 +55,36 @@ defaults:
 
 jobs:
   publish:
-    name: Build and publish to Artifactory
+    name: Build and publish wheel
     runs-on: linux-amd64-cpu4
-    env:
-      TWINE_REPOSITORY_URL: ${{ secrets.ARTIFACTORY_INTERNAL_URL }}
     steps:
       - name: checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.release-ref }}
+          ref: ${{ inputs.release-ref || github.ref }}
           fetch-depth: 0
 
       - name: Setup Python environment
         uses: ./.github/actions/setup-python-env
         with:
-          ref: ${{ inputs.release-ref }}
+          ref: ${{ inputs.release-ref || github.ref }}
           fetch-depth: 0
           bootstrap-tools: "false"
 
-      - name: Build and publish
+      - name: Build and publish to Artifactory
+        if: github.event_name == 'push' || inputs.publish-target == 'artifactory'
         run: make publish-internal
         env:
           TWINE_REPOSITORY_URL: ${{ secrets.ARTIFACTORY_INTERNAL_URL }}
           TWINE_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.ARTIFACTORY_TOKEN }}
+
+      - name: Build and publish to PyPI
+        if: github.event_name == 'workflow_dispatch' && inputs.publish-target == 'pypi'
+        run: make publish-pypi
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
 
       - name: Show built version
         id: version

--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,22 @@ endif
 		dist/*.whl
 	@echo "published: $$(ls dist/*.whl)"
 
+.PHONY: publish-pypi
+publish-pypi: build-wheel ## Build and publish wheel to PyPI. Uses TWINE_USERNAME and TWINE_PASSWORD env vars.
+ifndef TWINE_USERNAME
+	$(error TWINE_USERNAME is not set. For PyPI token auth, set TWINE_USERNAME=__token__.)
+endif
+ifndef TWINE_PASSWORD
+	$(error TWINE_PASSWORD is not set. For PyPI token auth, set TWINE_PASSWORD=<your-pypi-token>.)
+endif
+	@echo "~~~~~~"
+	@echo "uploading to PyPI"
+	uvx twine upload \
+		--non-interactive \
+		--verbose \
+		dist/*.whl
+	@echo "published: $$(ls dist/*.whl)"
+
 
 ### NMP SYNCHRONIZATION ###
 


### PR DESCRIPTION
# Summary
* Allows tagging publish to occur on release

## Pre-Review Checklist

Ensure that the following pass:

- [ ] `make format && make check` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)

## Pre-Merge Checklist

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>
