### PR TITLE
fix: replace faiss with torch + sklearn

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ engine = [
     "pandas>=2.1.3, <3",
     "plotly",
     "ratelimit",
+    "scikit-learn",
     "range_regex>=0.1.0",
     "tenacity==9.1.4",
     "tiktoken>=0.7.0,<1.0",
@@ -119,7 +120,6 @@ cpu = [
   "bitsandbytes==0.49.1",
   "flashinfer-python==0.6.1; sys_platform=='linux'",
   "flashinfer-cubin==0.6.1; sys_platform=='linux'",
-  "faiss-cpu==1.13.2",
   "gliner",
   "kernels>=0.12.1",
   "peft",
@@ -141,7 +141,6 @@ cpu = [
 cu128 = [
   "accelerate",
   "bitsandbytes==0.49.1",
-  "faiss-gpu-cu12==1.13.2; sys_platform == 'linux'",
   "flashinfer-python==0.6.1; sys_platform == 'linux'",
   "flashinfer-cubin==0.6.1; sys_platform == 'linux'",
   "flashinfer-jit-cache==0.6.1+cu128; sys_platform == 'linux'",
@@ -225,10 +224,9 @@ constraint-dependencies = ["torch==2.9.1", "regex==2025.07.34", "pandas<3"]
   flashinfer-jit-cache = [
     { index = "flashinfer-jit-cache", marker = "sys_platform=='linux'", extra="cu128"},
   ]
-   nvidia-cublas-cu12 = [
+  nvidia-cublas-cu12 = [
     { index = "pytorch-cu128" },
   ]
-
   nvidia-cuda-cupti-cu12 = [
     { index = "pytorch-cu128" },
   ]
@@ -297,6 +295,7 @@ name = "nvidia-pypi-public"
 url = "https://pypi.nvidia.com"
 explicit = true
 
+
 [build-system]
 requires = ["hatchling", "uv-dynamic-versioning"]
 build-backend = "hatchling.build"
@@ -334,4 +333,5 @@ exclude = [
     "./src/nemo_safe_synthesizer/pii_replacer/",
     "./tests/",
     "./tools/",
+    "./script/slurm/nss_top.py",
 ]

--- a/pytest.ini
+++ b/pytest.ini
@@ -22,6 +22,7 @@ markers =
     smollm2: SmolLM2 Hub download tests (used by Makefile for process isolation)
     unsloth: Unsloth backend tests (process-isolated from DP tests)
     noautouse: Marker to skip autouse fixtures for specific tests
+    benchmark: Test the performance of the code
 
 # Note: Unit tests (testing single classes/functions with no infrastructure dependencies)
 # do not need markers and are the default test type.

--- a/src/nemo_safe_synthesizer/evaluation/components/attribute_inference_protection.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/attribute_inference_protection.py
@@ -27,15 +27,8 @@ from ...observability import get_logger
 from ..components.component import Component
 from ..data_model.evaluation_dataset import EvaluationDataset
 from ..data_model.evaluation_score import EvaluationScore, PrivacyGrade
+from ..nearest_neighbors import NearestNeighborSearch
 from . import multi_modal_figures as figures
-
-faiss_available = False
-try:
-    import faiss
-
-    faiss_available = True
-except (ImportError, ModuleNotFoundError):
-    pass
 
 logger = get_logger(__name__)
 
@@ -77,10 +70,6 @@ class AttributeInferenceProtection(Component):
         evaluation_dataset: EvaluationDataset, config: SafeSynthesizerParameters | None = None
     ) -> AttributeInferenceProtection:
         """Run the attribute inference attack and return the protection score."""
-        if not faiss_available:
-            logger.info("FAISS is not available, skipping Attribute Inference Attack.")
-            return AttributeInferenceProtection(score=EvaluationScore())
-
         quasi_identifier_count = config.evaluation.quasi_identifier_count if config else QUASI_IDENTIFIER_COUNT
 
         score, col_accuracy_df = AttributeInferenceProtection._aia(
@@ -276,23 +265,17 @@ class AttributeInferenceProtection(Component):
                     df_train_use, df_synth_use
                 )
 
-        # If all tabular, just use FAISS to get NN
+        # If all tabular, use nearest neighbor search (torch CUDA or sklearn CPU fallback)
         if len(text_columns) == 0:
-            # Create the faiss index on the synthetic data
-            dim = df_synth_norm.shape[1]
-            index = faiss.IndexFlatL2(dim)  # ty: ignore[possibly-unbound-attribute]
-
-            # This usage matches documentation. Specifying n= and x= parameters as
-            # the type annotation for IndexFlatL2.add suggests seems unnecessary, possibly related
-            # to swig handling that ty is not aware of. Similar for other faiss calls below
-            # which are using swig-generated code.
-            index.add(np.float32(np.ascontiguousarray(np.array(df_synth_norm))))  # ty: ignore[missing-argument]
+            # Create the nearest neighbors index on the synthetic data
+            nn = NearestNeighborSearch(n_neighbors=k)
+            nn.fit(np.ascontiguousarray(np.array(df_synth_norm)).astype(np.float32))
 
             # Get nearest neighbors to this attack record
-            _, indexes = index.search(np.float32(np.ascontiguousarray(np.array(df_train_norm))), k)  # ty: ignore[missing-argument]
+            _, indexes = nn.kneighbors(np.ascontiguousarray(np.array(df_train_norm)).astype(np.float32))
             synth_rows = pd.DataFrame()
-            for index in indexes:
-                synth_rows = pd.concat([synth_rows, df_synth.iloc[index].copy()])
+            for idx_row in indexes:
+                synth_rows = pd.concat([synth_rows, df_synth.iloc[idx_row].copy()])
             return synth_rows
 
         # If all text, just use Sentence Transformer to get NN
@@ -339,14 +322,11 @@ class AttributeInferenceProtection(Component):
             corpus_ids.append(corpus_id)
             synth_NN = pd.concat([synth_NN, pd.DataFrame([df_synth_norm.iloc[int(corpus_id)]])], ignore_index=True)
 
-        # Now get the tabular similarity for these 1000 NN
-
-        dim = synth_NN.shape[1]
-        index = faiss.IndexFlatL2(dim)  # ty: ignore[possibly-unbound-attribute]
-        index.add(np.float32(np.ascontiguousarray(np.array(synth_NN))))  # ty: ignore[missing-argument]
-        dists, indexes = index.search(np.float32(np.ascontiguousarray(np.array(df_train_norm))), search_synth_k)  # ty: ignore[missing-argument]
+        # Now get the tabular similarity for these 1000 NN using nearest neighbor search
+        nn = NearestNeighborSearch(n_neighbors=search_synth_k)
+        nn.fit(np.ascontiguousarray(np.array(synth_NN)).astype(np.float32))
+        dists, indexes = nn.kneighbors(np.ascontiguousarray(np.array(df_train_norm)).astype(np.float32))
         # Scale the Euclidean distance to [0,1]
-        dists = np.sqrt(dists)
         max_dist = np.amax(dists)
         if max_dist > 0:
             dist_scaled = dists / max_dist
@@ -354,8 +334,8 @@ class AttributeInferenceProtection(Component):
             dist_scaled = dists
         tab_dist = {}
         for i in range(search_synth_k):
-            index = indexes[0][i]
-            tab_dist[index] = dist_scaled[0][i]
+            idx = indexes[0][i]
+            tab_dist[idx] = dist_scaled[0][i]
 
         # Now get the hybrid distance
 

--- a/src/nemo_safe_synthesizer/evaluation/components/membership_inference_protection.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/membership_inference_protection.py
@@ -21,17 +21,9 @@ from ...config.parameters import SafeSynthesizerParameters
 from ...evaluation.components.component import Component
 from ...evaluation.data_model.evaluation_dataset import EvaluationDataset
 from ...evaluation.data_model.evaluation_score import EvaluationScore, PrivacyGrade
+from ...evaluation.nearest_neighbors import NearestNeighborSearch
 from ...observability import get_logger
 from . import multi_modal_figures as figures
-
-faiss_available = False
-try:
-    import faiss
-
-    faiss_available = True
-except (ImportError, ModuleNotFoundError):
-    pass
-
 
 logger = get_logger(__name__)
 
@@ -79,9 +71,6 @@ class MembershipInferenceProtection(Component):
         evaluation_dataset: EvaluationDataset, config: SafeSynthesizerParameters | None = None
     ) -> MembershipInferenceProtection:
         """Run the membership inference attack and return the protection score."""
-        if not faiss_available:
-            return MembershipInferenceProtection(score=EvaluationScore())
-
         score, attack_sum_df, tps_values, fps_values = MembershipInferenceProtection.mia(
             df_train=evaluation_dataset.reference,
             df_synth=evaluation_dataset.output,
@@ -249,7 +238,7 @@ class MembershipInferenceProtection(Component):
         df_train_norm: pd.DataFrame,
         df_test_norm: pd.DataFrame,
         df_synth_norm: pd.DataFrame,
-        index: faiss.IndexFlatL2 | None,  # ty: ignore[possibly-unbound-attribute]
+        nn_index: NearestNeighborSearch | None,
         run: int,
         text_cnt: int,
         tabular_cnt: int,
@@ -263,14 +252,14 @@ class MembershipInferenceProtection(Component):
 
         Builds an attack dataset from a slice of training rows mixed with
         test rows, computes nearest-neighbor distances to the synthetic
-        data (text via semantic search, tabular via FAISS L2), and
+        data (text via semantic search, tabular via L2 nearest neighbor), and
         classifies each record as member or non-member.
 
         Args:
             df_train_norm: Normalized training dataframe.
             df_test_norm: Normalized holdout (test) dataframe.
             df_synth_norm: Normalized synthetic dataframe.
-            index: Pre-built FAISS L2 index over the tabular columns of
+            nn_index: Pre-built NearestNeighborSearch index over the tabular columns of
                 the synthetic data, or ``None`` if no tabular columns exist.
             run: Zero-based run index controlling which training slice to use.
             text_cnt: Number of text columns in the dataset.
@@ -334,18 +323,16 @@ class MembershipInferenceProtection(Component):
                 attacker_data_tabular = real_data.copy()
                 k = 1
 
-            if index is None:
-                raise RuntimeError("faiss index not provided for MIA calculation when expected.")
+            if nn_index is None:
+                raise RuntimeError("Nearest neighbor index not provided for MIA calculation when expected.")
 
-            # This usage matches documentation despite type annotation for
-            # IndexFlatL2.search, possibly related to swig handling that ty is
-            # not aware of. Similar for other calls for faiss indexes.
-            dists, indices = index.search(
-                np.float32(np.ascontiguousarray(np.array(attacker_data_tabular))),
-                len(df_synth_norm),
-            )  # ty: ignore[missing-argument]
+            # Use nearest neighbor search (torch GPU or sklearn CPU fallback) for distance calculation
+            dists, indices = nn_index.kneighbors(
+                np.ascontiguousarray(np.array(attacker_data_tabular)).astype(np.float32),
+                n_neighbors=int(k),
+            )
             # Scale the Euclidean distance to [0,1]
-            dists = np.sqrt(dists)
+            # NearestNeighborSearch.kneighbors() returns L2 distance directly, not squared
             max_dist = np.amax(dists)
             if max_dist > 0:
                 dist_scaled = dists / max_dist
@@ -555,15 +542,14 @@ class MembershipInferenceProtection(Component):
                     df_train_norm, df_test_norm, df_synth_norm = MembershipInferenceProtection._normalize_onehot(
                         df_train_use, df_test, df_synth
                     )
-                # Create the faiss index on the synthetic tabular data
-                dim = df_synth_norm.shape[1]
-                index = faiss.IndexFlatL2(dim)  # ty: ignore[possibly-unbound-attribute]
-                index.add(np.float32(np.ascontiguousarray(np.array(df_synth_norm))))  # ty: ignore[missing-argument]
+                # Create nearest neighbor index on the synthetic tabular data (torch GPU or sklearn CPU fallback)
+                nn_index = NearestNeighborSearch(n_neighbors=len(df_synth_norm))
+                nn_index.fit(np.ascontiguousarray(np.array(df_synth_norm)).astype(np.float32))
             else:
                 df_train_norm = pd.DataFrame()
                 df_test_norm = pd.DataFrame()
                 df_synth_norm = pd.DataFrame()
-                index = None
+                nn_index = None
 
             # Create embeddings for text fields and combine the normalized tabular and the
             # new text embeddings into one dataframe.
@@ -588,7 +574,7 @@ class MembershipInferenceProtection(Component):
                     df_train_norm,
                     df_test_norm,
                     df_synth_norm,
-                    index,
+                    nn_index,
                     i,
                     text_cnt,
                     tabular_cnt,

--- a/src/nemo_safe_synthesizer/evaluation/nearest_neighbors.py
+++ b/src/nemo_safe_synthesizer/evaluation/nearest_neighbors.py
@@ -1,0 +1,156 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Nearest neighbor search abstraction with GPU acceleration support.
+
+This module provides a unified interface for nearest neighbor search that:
+- Uses PyTorch (CUDA) when available for GPU-accelerated search
+- Falls back to sklearn NearestNeighbors for CPU-only environments
+
+Usage:
+    from nemo_safe_synthesizer.evaluation.nearest_neighbors import NearestNeighborSearch
+
+    # Create search index
+    nn = NearestNeighborSearch(n_neighbors=5)
+    nn.fit(data)  # numpy array of shape (n_samples, n_features)
+
+    # Query
+    distances, indices = nn.kneighbors(queries)  # input is numpy array of shape (n_queries, n_features)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+# Must be set BEFORE importing numpy/sklearn (which load OpenBLAS)
+# Cap threads to avoid OpenBLAS crashes on high-core machines (>128 cores)
+# while still allowing some parallelism for large operations
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "8")
+os.environ.setdefault("OMP_NUM_THREADS", "8")
+
+import numpy as np
+import torch
+from sklearn.neighbors import NearestNeighbors
+
+logger = logging.getLogger(__name__)
+
+
+class NearestNeighborSearch:
+    """Unified nearest neighbor search with GPU acceleration support.
+
+    Uses PyTorch (CUDA) when available, falls back to sklearn otherwise.
+    Both backends compute exact brute-force L2 distance for consistency.
+
+    Attributes:
+        n_neighbors: Number of neighbors to return in queries.
+        use_gpu: Whether GPU acceleration is being used.
+    """
+
+    # Cache device detection across all instances
+    _device_checked = False
+    _torch_device: torch.device | None = None
+
+    def __init__(self, n_neighbors: int = 5):
+        """Initialize the nearest neighbor search.
+
+        Args:
+            n_neighbors: Number of neighbors to find in queries.
+        """
+        self.n_neighbors = n_neighbors
+        self._torch_device = self._detect_device()
+        self.use_gpu = self._torch_device is not None
+        self._index = None
+        self._data_t: torch.Tensor | None = None
+
+    @classmethod
+    def _detect_device(cls) -> torch.device | None:
+        """Detect the best available torch device for NN search.
+
+        Cached across all instances. Returns None if no GPU is available,
+        indicating the sklearn CPU fallback should be used.
+
+        Returns:
+            torch.device for CUDA if available, None otherwise.
+        """
+        if cls._device_checked:
+            return cls._torch_device
+
+        if torch.cuda.is_available():
+            cls._torch_device = torch.device("cuda")
+            logger.debug("NearestNeighborSearch using CUDA")
+        else:
+            cls._torch_device = None
+            logger.debug("NearestNeighborSearch using sklearn (CPU)")
+
+        cls._device_checked = True
+        return cls._torch_device
+
+    def fit(self, data: np.ndarray) -> NearestNeighborSearch:
+        """Build the search index from data.
+
+        Args:
+            data: Array of shape (n_samples, n_features) with float32 values.
+
+        Returns:
+            Self for method chaining.
+        """
+        data = np.ascontiguousarray(data, dtype=np.float32)
+
+        if self.use_gpu:
+            self._data_t = torch.from_numpy(data).to(self._torch_device)
+        else:
+            self._index = NearestNeighbors(
+                n_neighbors=self.n_neighbors,
+                algorithm="brute",
+                metric="euclidean",
+            )
+            self._index.fit(data)
+
+        return self
+
+    def kneighbors(self, queries: np.ndarray, n_neighbors: int | None = None) -> tuple[np.ndarray, np.ndarray]:
+        """Find k nearest neighbors for query points.
+
+        Args:
+            queries: Array of shape (n_queries, n_features) with query points.
+            n_neighbors: Number of neighbors to return. If None, uses self.n_neighbors.
+
+        Returns:
+            Tuple of (distances, indices) where:
+            - distances: Array of shape (n_queries, k) with L2 distances
+            - indices: Array of shape (n_queries, k) with indices into the fitted data
+        """
+        if self.use_gpu and self._data_t is None:
+            raise RuntimeError("Must call fit() before kneighbors()")
+        if not self.use_gpu and self._index is None:
+            raise RuntimeError("Must call fit() before kneighbors()")
+
+        k = n_neighbors if n_neighbors is not None else self.n_neighbors
+        queries = np.ascontiguousarray(queries, dtype=np.float32)
+
+        if queries.shape[0] == 0:
+            empty = np.empty((0, k), dtype=np.float32)
+            return empty, np.empty((0, k), dtype=np.int64)
+
+        if self.use_gpu:
+            assert self._data_t is not None
+            queries_t = torch.from_numpy(queries).to(self._torch_device)
+            # torch.cdist computes L2 (p=2) pairwise distances: (n_queries, n_samples)
+            dists_t = torch.cdist(queries_t, self._data_t)
+            topk_dists, topk_idx = torch.topk(dists_t, k, largest=False)
+            distances = topk_dists.cpu().numpy()
+            indices = topk_idx.cpu().numpy()
+        else:
+            assert self._index is not None
+            distances, indices = self._index.kneighbors(queries, n_neighbors=k)
+
+        return distances, indices
+
+    @property
+    def backend_name(self) -> str:
+        """Return the name of the backend being used."""
+        if self._torch_device is None:
+            return "sklearn (CPU)"
+        return f"torch ({self._torch_device.type.upper()})"

--- a/src/nemo_safe_synthesizer/observability.py
+++ b/src/nemo_safe_synthesizer/observability.py
@@ -89,7 +89,6 @@ PACKAGES_TO_SET_TO_WARN = [
     "arrow",
     "bitsandbytes",
     "datasets",
-    "faiss",
     "httpx",
     "matplotlib",
     "nvidia",

--- a/tests/evaluation/components/benchmark_nearest_neighbor.py
+++ b/tests/evaluation/components/benchmark_nearest_neighbor.py
@@ -1,0 +1,426 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Benchmark test comparing nearest neighbor implementations.
+
+This benchmark evaluates the performance difference between:
+- sklearn NearestNeighbors (CPU) - the fallback implementation
+- PyTorch (CUDA/MPS) - the primary GPU-accelerated implementation
+- cuVS (NVIDIA RAPIDS GPU) - comparison only
+- FAISS GPU - comparison only
+
+The NearestNeighborSearch abstraction in nemo_safe_synthesizer.evaluation.nearest_neighbors
+automatically selects the best available backend (torch GPU > sklearn CPU).
+
+Run standalone:
+    uv run --frozen --extra cu128 python tests/evaluation/components/benchmark_nearest_neighbor.py
+"""
+
+import logging
+import os
+
+# Must be set BEFORE importing numpy/sklearn (which load OpenBLAS)
+# Cap threads to avoid OpenBLAS crashes on high-core machines (>128 cores)
+os.environ.setdefault("OPENBLAS_NUM_THREADS", "8")
+os.environ.setdefault("OMP_NUM_THREADS", "8")
+
+import time
+from dataclasses import dataclass
+
+import numpy as np
+import pytest
+import torch
+from sklearn.neighbors import NearestNeighbors
+
+# PyTorch GPU availability (CUDA only — MPS benchmarks show it is slower than sklearn)
+TORCH_DEVICE = torch.device("cuda") if torch.cuda.is_available() else None
+TORCH_GPU_AVAILABLE = TORCH_DEVICE is not None
+
+# Optional cuVS/RAPIDS import (comparison only)
+CUVS_AVAILABLE = False
+cuvs_brute_force = None
+cp = None
+
+try:
+    import cupy as _cp
+    from cuvs.neighbors import brute_force as _cuvs_brute_force
+
+    # Test that cuVS is actually usable (not just that imports work)
+    _test_data = _cp.array([[1.0, 2.0], [3.0, 4.0]], dtype=_cp.float32)
+    _test_query = _cp.array([[1.0, 2.0]], dtype=_cp.float32)
+    _test_index = _cuvs_brute_force.build(_test_data, metric="sqeuclidean")
+    _test_dist, _test_idx = _cuvs_brute_force.search(_test_index, _test_query, 1)
+    _ = _cp.asnumpy(_test_dist)
+    del _test_data, _test_query, _test_index, _test_dist, _test_idx
+
+    cuvs_brute_force = _cuvs_brute_force
+    cp = _cp
+    CUVS_AVAILABLE = True
+except ImportError:
+    logging.info("cuVS not available (ImportError during optional import)")
+    CUVS_AVAILABLE = False
+except (RuntimeError, OSError, Exception):
+    logging.exception("cuVS initialization failed")
+    CUVS_AVAILABLE = False
+
+# Optional FAISS GPU import (comparison only), install with uv pip install faiss-gpu-cu12
+FAISS_GPU_AVAILABLE = False
+faiss = None
+
+try:
+    import faiss as _faiss
+
+    # Check if GPU support is available
+    if _faiss.get_num_gpus() > 0:
+        faiss = _faiss
+        FAISS_GPU_AVAILABLE = True
+    else:
+        logging.info("FAISS installed but no GPU available")
+except ImportError:
+    logging.info("FAISS not available")
+except Exception:
+    logging.exception("FAISS GPU check failed")
+
+
+@dataclass
+class BenchmarkResult:
+    """Results from a nearest neighbor benchmark run."""
+
+    name: str
+    fit_time_sec: float
+    query_time_sec: float
+    total_time_sec: float
+    n_samples: int
+    n_features: int
+    n_queries: int
+    k: int
+
+    def __str__(self) -> str:
+        return (
+            f"{self.name}: fit={self.fit_time_sec:.3f}s, "
+            f"query={self.query_time_sec:.3f}s, total={self.total_time_sec:.3f}s"
+        )
+
+
+def generate_data(n_samples: int, n_features: int, seed: int = 42) -> np.ndarray:
+    """Generate random float32 data for benchmarking."""
+    rng = np.random.default_rng(seed)
+    return rng.standard_normal((n_samples, n_features)).astype(np.float32)
+
+
+def benchmark_sklearn(data: np.ndarray, queries: np.ndarray, k: int = 5) -> BenchmarkResult:
+    """Benchmark sklearn NearestNeighbors with brute force algorithm."""
+    nn = NearestNeighbors(n_neighbors=k, algorithm="brute", metric="euclidean")
+
+    t0 = time.perf_counter()
+    nn.fit(data)
+    fit_time = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    nn.kneighbors(queries)
+    query_time = time.perf_counter() - t0
+
+    return BenchmarkResult(
+        name="sklearn_cpu",
+        fit_time_sec=fit_time,
+        query_time_sec=query_time,
+        total_time_sec=fit_time + query_time,
+        n_samples=data.shape[0],
+        n_features=data.shape[1],
+        n_queries=queries.shape[0],
+        k=k,
+    )
+
+
+def benchmark_torch(data: np.ndarray, queries: np.ndarray, k: int = 5) -> BenchmarkResult | None:
+    """Benchmark PyTorch brute-force nearest neighbors on GPU (CUDA or MPS)."""
+    if not TORCH_GPU_AVAILABLE:
+        return None
+
+    t0 = time.perf_counter()
+    data_t = torch.from_numpy(data).to(TORCH_DEVICE)
+    fit_time = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    queries_t = torch.from_numpy(queries).to(TORCH_DEVICE)
+    dists_t = torch.cdist(queries_t, data_t)
+    torch.topk(dists_t, k, largest=False)
+    torch.cuda.synchronize()
+    query_time = time.perf_counter() - t0
+
+    device_label = TORCH_DEVICE.type  # type: ignore[union-attr]
+    return BenchmarkResult(
+        name=f"torch_{device_label}",
+        fit_time_sec=fit_time,
+        query_time_sec=query_time,
+        total_time_sec=fit_time + query_time,
+        n_samples=data.shape[0],
+        n_features=data.shape[1],
+        n_queries=queries.shape[0],
+        k=k,
+    )
+
+
+def benchmark_cuvs(data: np.ndarray, queries: np.ndarray, k: int = 5) -> BenchmarkResult | None:
+    """Benchmark cuVS brute force nearest neighbors on GPU (comparison only)."""
+    if not CUVS_AVAILABLE:
+        return None
+
+    t0 = time.perf_counter()
+    data_gpu = cp.asarray(data, dtype=cp.float32)
+    queries_gpu = cp.asarray(queries, dtype=cp.float32)
+    fit_time = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    index = cuvs_brute_force.build(data_gpu, metric="sqeuclidean")
+    cuvs_brute_force.search(index, queries_gpu, k)
+    cp.cuda.Stream.null.synchronize()
+    query_time = time.perf_counter() - t0
+
+    return BenchmarkResult(
+        name="cuvs_gpu",
+        fit_time_sec=fit_time,
+        query_time_sec=query_time,
+        total_time_sec=fit_time + query_time,
+        n_samples=data.shape[0],
+        n_features=data.shape[1],
+        n_queries=queries.shape[0],
+        k=k,
+    )
+
+
+def benchmark_faiss_gpu(data: np.ndarray, queries: np.ndarray, k: int = 5) -> BenchmarkResult | None:
+    """Benchmark FAISS GPU for exact L2 nearest neighbors (comparison only)."""
+    if not FAISS_GPU_AVAILABLE:
+        return None
+
+    t0 = time.perf_counter()
+    d = data.shape[1]
+    cpu_index = faiss.IndexFlatL2(d)
+    gpu_index = faiss.index_cpu_to_gpu(faiss.StandardGpuResources(), 0, cpu_index)
+    gpu_index.add(data)
+    fit_time = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    gpu_index.search(queries, k)
+    query_time = time.perf_counter() - t0
+
+    return BenchmarkResult(
+        name="faiss_gpu",
+        fit_time_sec=fit_time,
+        query_time_sec=query_time,
+        total_time_sec=fit_time + query_time,
+        n_samples=data.shape[0],
+        n_features=data.shape[1],
+        n_queries=queries.shape[0],
+        k=k,
+    )
+
+
+def benchmark_abstraction(data: np.ndarray, queries: np.ndarray, k: int = 5) -> BenchmarkResult:
+    """Benchmark the NearestNeighborSearch abstraction (auto-selects best backend)."""
+    from nemo_safe_synthesizer.evaluation.nearest_neighbors import NearestNeighborSearch
+
+    nn = NearestNeighborSearch(n_neighbors=k)
+
+    t0 = time.perf_counter()
+    nn.fit(data)
+    fit_time = time.perf_counter() - t0
+
+    t0 = time.perf_counter()
+    nn.kneighbors(queries)
+    query_time = time.perf_counter() - t0
+
+    return BenchmarkResult(
+        name=f"abstraction ({nn.backend_name})",
+        fit_time_sec=fit_time,
+        query_time_sec=query_time,
+        total_time_sec=fit_time + query_time,
+        n_samples=data.shape[0],
+        n_features=data.shape[1],
+        n_queries=queries.shape[0],
+        k=k,
+    )
+
+
+def run_benchmark(
+    n_samples: int = 100_000,
+    n_features: int = 100,
+    n_queries: int = 1_000,
+    k: int = 5,
+) -> list[BenchmarkResult]:
+    """Run all benchmarks and return results."""
+    print(f"\n{'=' * 60}")
+    print(f"Benchmark: {n_samples:,} samples × {n_features} features")
+    print(f"Queries: {n_queries:,}, k={k}")
+    print("=" * 60)
+
+    data = generate_data(n_samples, n_features, seed=420)
+    queries = generate_data(n_queries, n_features, seed=123)
+
+    results = []
+
+    # sklearn (baseline)
+    result = benchmark_sklearn(data, queries, k)
+    results.append(result)
+    print(f"  {result}")
+
+    # PyTorch GPU if available
+    result = benchmark_torch(data, queries, k)
+    if result:
+        results.append(result)
+        print(f"  {result}")
+    else:
+        print("  torch_gpu: NOT AVAILABLE")
+
+    # cuVS if available (comparison)
+    result = benchmark_cuvs(data, queries, k)
+    if result:
+        results.append(result)
+        print(f"  {result}")
+    else:
+        print("  cuvs_gpu: NOT AVAILABLE")
+
+    # FAISS GPU if available (comparison)
+    result = benchmark_faiss_gpu(data, queries, k)
+    if result:
+        results.append(result)
+        print(f"  {result}")
+    else:
+        print("  faiss_gpu: NOT AVAILABLE")
+
+    # Test the abstraction layer
+    result = benchmark_abstraction(data, queries, k)
+    results.append(result)
+    print(f"  {result}")
+
+    # Print speedup comparison
+    sklearn_time = results[0].total_time_sec
+    print("\n  Speedups vs sklearn:")
+    for r in results[1:]:
+        speedup = sklearn_time / r.total_time_sec if r.total_time_sec > 0 else 0
+        print(f"    {r.name}: {speedup:.1f}×")
+
+    return results
+
+
+# ============================================================================
+# Pytest tests
+# ============================================================================
+
+
+@pytest.mark.benchmark
+def test_benchmark_small_dataset():
+    """Benchmark on small dataset (10k rows) - baseline for comparison."""
+    results = run_benchmark(n_samples=10_000, n_features=100, n_queries=500, k=5)
+
+    # sklearn should complete in reasonable time for small datasets
+    sklearn_result = results[0]
+    assert sklearn_result.total_time_sec < 30, "sklearn too slow on small dataset"
+
+
+@pytest.mark.benchmark
+def test_benchmark_medium_dataset():
+    """Benchmark on medium dataset (50k rows)."""
+    results = run_benchmark(n_samples=50_000, n_features=100, n_queries=500, k=5)
+
+    sklearn_result = results[0]
+    print(f"\nMedium dataset sklearn time: {sklearn_result.total_time_sec:.2f}s")
+
+
+@pytest.mark.benchmark
+def test_benchmark_large_dataset():
+    """Benchmark on large dataset (100k rows) - target size for evaluation."""
+    results = run_benchmark(n_samples=100_000, n_features=100, n_queries=1_000, k=5)
+
+    sklearn_result = results[0]
+    print(f"\nLarge dataset sklearn time: {sklearn_result.total_time_sec:.2f}s")
+
+    # Report all speedups
+    for r in results[1:]:
+        speedup = sklearn_result.total_time_sec / r.total_time_sec if r.total_time_sec > 0 else 0
+        print(f"{r.name} speedup: {speedup:.1f}×")
+
+
+@pytest.mark.benchmark
+@pytest.mark.skipif(not TORCH_GPU_AVAILABLE, reason="No GPU available (CUDA or MPS required)")
+def test_benchmark_gpu_stress():
+    """Benchmark on very large dataset to show GPU benefit."""
+    results = run_benchmark(n_samples=500_000, n_features=100, n_queries=10_000, k=5)
+
+    sklearn_result = results[0]
+    print(f"\nGPU stress test sklearn time: {sklearn_result.total_time_sec:.2f}s")
+
+    # GPU backends should show significant speedup
+    for r in results:
+        if any(label in r.name for label in ("cuda", "mps", "cuvs", "faiss")):
+            speedup = sklearn_result.total_time_sec / r.total_time_sec if r.total_time_sec > 0 else 0
+            print(f"{r.name} speedup: {speedup:.1f}×")
+            # GPU should be at least 5x faster on large data
+            assert speedup > 5, f"Expected GPU to be >5x faster, got {speedup:.1f}x"
+
+
+@pytest.mark.benchmark
+def test_benchmark_typical_aia_mia_workload():
+    """Benchmark typical AIA/MIA evaluation workload.
+
+    Based on actual usage patterns:
+    - Training data: ~5k-50k rows
+    - Synthetic data: ~5k-50k rows
+    - Features: typically 10-50 after normalization
+    - k: 1-10 nearest neighbors
+    """
+    print("\n" + "=" * 60)
+    print("Typical AIA/MIA workload simulation")
+    print("=" * 60)
+
+    # Typical small dataset
+    run_benchmark(n_samples=5_000, n_features=30, n_queries=200, k=5)
+
+    # Typical medium dataset
+    run_benchmark(n_samples=20_000, n_features=30, n_queries=200, k=5)
+
+    # Large dataset (stress test)
+    run_benchmark(n_samples=50_000, n_features=50, n_queries=500, k=5)
+
+    # Realistic maximum: large uncapped synth + multimodal text embeddings + 10k queries
+    # (50k synth rows, 512-dim text embeddings, 10k queries from 2 × 5k test cap)
+    run_benchmark(n_samples=50_000, n_features=512, n_queries=10_000, k=5)
+
+
+# ============================================================================
+# Standalone execution
+# ============================================================================
+
+if __name__ == "__main__":
+    print("Nearest Neighbor Benchmark: sklearn vs PyTorch vs cuVS vs FAISS GPU")
+    print(f"PyTorch GPU available: {TORCH_GPU_AVAILABLE} (device: {TORCH_DEVICE})")
+    print(f"cuVS available: {CUVS_AVAILABLE}")
+    print(f"FAISS GPU available: {FAISS_GPU_AVAILABLE}")
+
+    # Run comprehensive benchmarks
+    print("\n" + "=" * 70)
+    print("COMPREHENSIVE BENCHMARK SUITE")
+    print("=" * 70)
+
+    # Typical AIA/MIA workloads
+    print("\n--- Typical AIA/MIA Workloads ---")
+    results = []
+    results.extend(run_benchmark(n_samples=5_000, n_features=30, n_queries=200, k=5))
+    results.extend(run_benchmark(n_samples=20_000, n_features=30, n_queries=200, k=5))
+    results.extend(run_benchmark(n_samples=50_000, n_features=512, n_queries=10_000, k=5))
+
+    # Stress tests
+    print("\n--- Stress Tests (Large Data) ---")
+    results.extend(run_benchmark(n_samples=50_000, n_features=100, n_queries=500, k=5))
+    results.extend(run_benchmark(n_samples=100_000, n_features=100, n_queries=1_000, k=5))
+
+    # GPU stress test (larger for GPU to show benefit)
+    results.extend(run_benchmark(n_samples=500_000, n_features=100, n_queries=10_000, k=5))
+    results.extend(run_benchmark(n_samples=1_000_000, n_features=200, n_queries=10_000, k=5))
+
+    # Dimension scaling
+    print("\n--- Dimension Scaling (50k samples) ---")
+    for dim in [20, 50, 100, 200]:
+        results.extend(run_benchmark(n_samples=50_000, n_features=dim, n_queries=500, k=5))

--- a/tests/evaluation/components/test_attribute_inference_protection.py
+++ b/tests/evaluation/components/test_attribute_inference_protection.py
@@ -12,18 +12,6 @@ pytest.importorskip(
     reason="sentence_transformers is required for these tests (install with: uv sync --extra cpu)",
 )
 
-# Skip all tests in this module if faiss is not properly available
-# Note: faiss module may exist but lack IndexFlatL2 if improperly installed
-faiss = pytest.importorskip(
-    "faiss",
-    reason="faiss is required for these tests",
-)
-if not hasattr(faiss, "IndexFlatL2"):
-    pytest.skip(
-        "faiss is installed but lacks IndexFlatL2 - likely a stub package (install faiss-cpu or faiss-gpu)",
-        allow_module_level=True,
-    )
-
 from nemo_safe_synthesizer.evaluation.components.attribute_inference_protection import AttributeInferenceProtection
 from nemo_safe_synthesizer.evaluation.data_model.evaluation_dataset import EvaluationDataset
 
@@ -32,6 +20,7 @@ logger = logging.getLogger(__name__)
 
 @pytest.mark.slow
 def test_attribute_inference_protection(train_df_5k, synth_df_5k, test_df):
+    """Test AIA with tabular-only data (sklearn NearestNeighbors path)."""
     evaluation_dataset = EvaluationDataset.from_dataframes(train_df_5k, synth_df_5k, test_df)
     attribute_inference_protection = AttributeInferenceProtection.from_evaluation_dataset(evaluation_dataset)
     logger.info(attribute_inference_protection.col_accuracy_df)
@@ -39,3 +28,42 @@ def test_attribute_inference_protection(train_df_5k, synth_df_5k, test_df):
         attribute_inference_protection.col_accuracy_df is not None
         and not attribute_inference_protection.col_accuracy_df.empty
     )
+
+
+@pytest.mark.slow
+@pytest.mark.requires_gpu
+def test_attribute_inference_protection_mixed_text_tabular(train_df_mixed_5k, synth_df_mixed_5k, test_df_mixed):
+    """Test AIA with mixed text+tabular data (hybrid sklearn + sentence-transformers path).
+
+    This test exercises the hybrid nearest neighbor path that combines:
+    - sentence-transformers for text column similarity
+    - sklearn NearestNeighbors for tabular column similarity
+    - weighted hybrid distance calculation
+    """
+    evaluation_dataset = EvaluationDataset.from_dataframes(train_df_mixed_5k, synth_df_mixed_5k, test_df_mixed)
+    attribute_inference_protection = AttributeInferenceProtection.from_evaluation_dataset(evaluation_dataset)
+
+    logger.info(f"AIA columns evaluated: {attribute_inference_protection.col_accuracy_df}")
+    assert attribute_inference_protection.col_accuracy_df is not None
+    assert not attribute_inference_protection.col_accuracy_df.empty
+
+    # Verify the protection score was computed
+    assert attribute_inference_protection.score is not None
+
+
+@pytest.mark.requires_gpu
+def test_attribute_inference_protection_text_only(train_df_text_only, synth_df_text_only, test_df_text_only):
+    """Test AIA with text-only data (sentence-transformers only, no sklearn).
+
+    This test exercises the text-only nearest neighbor path that uses
+    only sentence-transformers for semantic similarity search.
+    """
+    evaluation_dataset = EvaluationDataset.from_dataframes(train_df_text_only, synth_df_text_only, test_df_text_only)
+    attribute_inference_protection = AttributeInferenceProtection.from_evaluation_dataset(evaluation_dataset)
+
+    logger.info(f"AIA text-only columns evaluated: {attribute_inference_protection.col_accuracy_df}")
+    assert attribute_inference_protection.col_accuracy_df is not None
+    assert not attribute_inference_protection.col_accuracy_df.empty
+
+    # Verify the protection score was computed
+    assert attribute_inference_protection.score is not None

--- a/tests/evaluation/components/test_membership_inference_protection.py
+++ b/tests/evaluation/components/test_membership_inference_protection.py
@@ -17,8 +17,9 @@ from nemo_safe_synthesizer.evaluation.data_model.evaluation_dataset import Evalu
 logger = logging.getLogger(__name__)
 
 
-@pytest.mark.skip(reason="Times out")
-def test_attribute_inference_protection(train_df_5k, synth_df_5k, test_df):
+@pytest.mark.requires_gpu
+def test_membership_inference_protection(train_df_5k, synth_df_5k, test_df):
+    """Test MIA with tabular-only data (sklearn NearestNeighbors path)."""
     evaluation_dataset = EvaluationDataset.from_dataframes(train_df_5k, synth_df_5k, test_df)
     membership_inference_protection = MembershipInferenceProtection.from_evaluation_dataset(evaluation_dataset)
 
@@ -33,3 +34,49 @@ def test_attribute_inference_protection(train_df_5k, synth_df_5k, test_df):
 
     logger.info(membership_inference_protection.fps_values)
     assert len(membership_inference_protection.fps_values) > 0
+
+
+@pytest.mark.requires_gpu
+def test_membership_inference_protection_mixed_text_tabular(train_df_mixed_5k, synth_df_mixed_5k, test_df_mixed):
+    """Test MIA with mixed text+tabular data (hybrid sklearn + sentence-transformers path).
+
+    This test exercises the hybrid nearest neighbor path that combines:
+    - sentence-transformers for text column similarity
+    - sklearn NearestNeighbors for tabular column similarity
+    - weighted hybrid distance calculation
+    """
+    evaluation_dataset = EvaluationDataset.from_dataframes(train_df_mixed_5k, synth_df_mixed_5k, test_df_mixed)
+    membership_inference_protection = MembershipInferenceProtection.from_evaluation_dataset(evaluation_dataset)
+
+    logger.info(f"MIA attack summary: {membership_inference_protection.attack_sum_df}")
+    assert membership_inference_protection.attack_sum_df is not None
+    assert not membership_inference_protection.attack_sum_df.empty
+
+    # Verify TPR/FPR values were computed
+    assert len(membership_inference_protection.tps_values) > 0
+    assert len(membership_inference_protection.fps_values) > 0
+
+    # Verify the protection score was computed
+    assert membership_inference_protection.score is not None
+
+
+@pytest.mark.requires_gpu
+def test_membership_inference_protection_text_only(train_df_text_only, synth_df_text_only, test_df_text_only):
+    """Test MIA with text-only data (sentence-transformers only, no sklearn).
+
+    This test exercises the text-only nearest neighbor path that uses
+    only sentence-transformers for semantic similarity search.
+    """
+    evaluation_dataset = EvaluationDataset.from_dataframes(train_df_text_only, synth_df_text_only, test_df_text_only)
+    membership_inference_protection = MembershipInferenceProtection.from_evaluation_dataset(evaluation_dataset)
+
+    logger.info(f"MIA text-only attack summary: {membership_inference_protection.attack_sum_df}")
+    assert membership_inference_protection.attack_sum_df is not None
+    assert not membership_inference_protection.attack_sum_df.empty
+
+    # Verify TPR/FPR values were computed
+    assert len(membership_inference_protection.tps_values) > 0
+    assert len(membership_inference_protection.fps_values) > 0
+
+    # Verify the protection score was computed
+    assert membership_inference_protection.score is not None

--- a/tests/evaluation/conftest.py
+++ b/tests/evaluation/conftest.py
@@ -166,6 +166,125 @@ def mia_aia_df():
     )
 
 
+def make_mixed_text_tabular_df(seed: int, n: int = 100):
+    """Create a DataFrame with both text columns (>2 spaces avg) and tabular columns.
+
+    This triggers the hybrid text+tabular nearest neighbor path in AIA/MIA evaluation,
+    which uses both sentence-transformers for text similarity and sklearn NearestNeighbors
+    for tabular similarity.
+    """
+    fake = faker.Faker("en_US")
+    fake.seed_instance(seed)
+    random.seed(seed)
+
+    # Text templates with >2 spaces on average (triggers text classification)
+    text_templates = [
+        "The customer {} purchased {} items at the {} store on {}",
+        "Order {} was shipped to {} via {} delivery service today",
+        "Patient {} reported {} symptoms during the {} consultation",
+        "Employee {} completed {} tasks in the {} department this quarter",
+        "Student {} achieved {} points on the {} examination today",
+    ]
+
+    df = pd.DataFrame(
+        {
+            # Numeric columns (tabular)
+            "amount": [round(random.uniform(10.0, 1000.0), 2) for _ in range(n)],
+            "quantity": [random.randint(1, 50) for _ in range(n)],
+            "score": [round(random.uniform(0.0, 100.0), 1) for _ in range(n)],
+            # Categorical columns (tabular)
+            "category": [random.choice(["A", "B", "C", "D"]) for _ in range(n)],
+            "status": [random.choice(["active", "pending", "completed"]) for _ in range(n)],
+            # Text columns (>2 spaces on average - triggers text embedding path)
+            "description": [
+                random.choice(text_templates).format(fake.name(), random.randint(1, 100), fake.company(), fake.date())
+                for _ in range(n)
+            ],
+            "notes": [
+                f"This is a detailed note about {fake.name()} who works at {fake.company()} in {fake.city()}"
+                for _ in range(n)
+            ],
+        }
+    )
+
+    # Add some missing values
+    df.loc[random.sample(list(df.index), k=min(5, n // 20)), "amount"] = np.nan
+    df.loc[random.sample(list(df.index), k=min(3, n // 30)), "category"] = None
+    df.loc[random.sample(list(df.index), k=min(2, n // 50)), "description"] = ""
+
+    return df
+
+
+def make_text_only_df(seed: int, n: int = 100):
+    """Create a DataFrame with only text columns (>2 spaces avg).
+
+    This triggers the text-only nearest neighbor path in AIA/MIA evaluation,
+    which uses only sentence-transformers for similarity (no sklearn).
+    """
+    fake = faker.Faker("en_US")
+    fake.seed_instance(seed)
+    random.seed(seed)
+
+    # All columns have >2 spaces on average to be classified as "text"
+    df = pd.DataFrame(
+        {
+            "description": [
+                f"The customer {fake.name()} purchased {random.randint(1, 100)} items at {fake.company()}"
+                for _ in range(n)
+            ],
+            "notes": [
+                f"This is a detailed note about {fake.name()} who works at {fake.company()} in {fake.city()}"
+                for _ in range(n)
+            ],
+            "summary": [
+                f"Summary for {fake.name()}: completed {random.randint(1, 50)} tasks in {fake.city()} office"
+                for _ in range(n)
+            ],
+        }
+    )
+
+    # Add some empty values (but not too many to break the test)
+    df.loc[random.sample(list(df.index), k=min(2, n // 50)), "description"] = ""
+
+    return df
+
+
+@pytest.fixture
+def train_df_text_only():
+    """Training DataFrame with only text columns (500 rows)."""
+    return make_text_only_df(seed=444, n=500)
+
+
+@pytest.fixture
+def synth_df_text_only():
+    """Synthetic DataFrame with only text columns (500 rows)."""
+    return make_text_only_df(seed=555, n=500)
+
+
+@pytest.fixture
+def test_df_text_only():
+    """Test DataFrame with only text columns (100 rows)."""
+    return make_text_only_df(seed=666, n=100)
+
+
+@pytest.fixture
+def train_df_mixed_5k():
+    """Training DataFrame with mixed text+tabular columns (5000 rows)."""
+    return make_mixed_text_tabular_df(seed=111, n=5000)
+
+
+@pytest.fixture
+def synth_df_mixed_5k():
+    """Synthetic DataFrame with mixed text+tabular columns (5000 rows)."""
+    return make_mixed_text_tabular_df(seed=222, n=5000)
+
+
+@pytest.fixture
+def test_df_mixed():
+    """Test DataFrame with mixed text+tabular columns (100 rows)."""
+    return make_mixed_text_tabular_df(seed=333, n=100)
+
+
 @pytest.fixture
 def mia_aia_df_with_nan_protection():
     """I'm not sure how often we get nans like this

--- a/tests/evaluation/test_nearest_neighbors.py
+++ b/tests/evaluation/test_nearest_neighbors.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for NearestNeighborSearch to verify L2 distance semantics.
+
+Both backends (torch GPU and sklearn CPU) must return true L2 (euclidean) distances,
+not squared euclidean distances. torch.cdist uses p=2 (euclidean) directly;
+sklearn uses euclidean directly. These tests guard that contract.
+"""
+
+import numpy as np
+import pytest
+import torch
+
+from nemo_safe_synthesizer.evaluation.nearest_neighbors import NearestNeighborSearch
+
+
+def _make_known_data() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Build a small dataset with analytically known L2 distances.
+
+    Returns:
+        (data, queries, expected_distances) where expected_distances[i][j]
+        is the L2 distance from queries[i] to its j-th nearest neighbor.
+    """
+    data = np.array(
+        [
+            [0.0, 0.0],  # idx 0
+            [3.0, 4.0],  # idx 1 — distance 5.0 from origin
+            [1.0, 0.0],  # idx 2 — distance 1.0 from origin
+            [0.0, 1.0],  # idx 3 — distance 1.0 from origin
+        ],
+        dtype=np.float32,
+    )
+    queries = np.array([[0.0, 0.0]], dtype=np.float32)
+
+    # Sorted nearest → farthest: idx0 (0.0), idx2 (1.0), idx3 (1.0), idx1 (5.0)
+    expected_distances = np.array([[0.0, 1.0, 1.0, 5.0]], dtype=np.float32)
+    return data, queries, expected_distances
+
+
+class TestNearestNeighborSearchReturnsL2Distances:
+    """Ensure kneighbors returns L2 distances (not squared) on every backend."""
+
+    def test_cpu_backend_returns_l2_distances(self):
+        """Sklearn CPU path must return euclidean distances, not squared."""
+        data, queries, expected = _make_known_data()
+
+        nn = NearestNeighborSearch(n_neighbors=4)
+        # Force CPU regardless of GPU availability
+        nn.use_gpu = False
+        nn.fit(data)
+        distances, _ = nn.kneighbors(queries)
+
+        np.testing.assert_allclose(distances, expected, atol=1e-6)
+
+    def test_torch_path_returns_l2_distances(self):
+        """Torch GPU path must return L2 distances from torch.cdist (p=2, not squared)."""
+        data, queries, expected = _make_known_data()
+
+        # Force the torch path on CPU so no real GPU is needed
+        nn = NearestNeighborSearch.__new__(NearestNeighborSearch)
+        nn.n_neighbors = 4
+        nn.use_gpu = True
+        nn._torch_device = torch.device("cpu")
+        nn._index = None
+        nn._data_t = None
+
+        nn.fit(data)
+        distances, _ = nn.kneighbors(queries)
+
+        np.testing.assert_allclose(distances, expected, atol=1e-6)
+
+    def test_distances_are_not_squared(self):
+        """Explicitly verify returned values differ from squared euclidean.
+
+        The 3-4-5 triangle gives L2=5.0 vs squared=25.0 — an unmistakable gap.
+        """
+        data = np.array([[0.0, 0.0], [3.0, 4.0]], dtype=np.float32)
+        queries = np.array([[0.0, 0.0]], dtype=np.float32)
+
+        nn = NearestNeighborSearch(n_neighbors=2)
+        nn.use_gpu = False
+        nn.fit(data)
+        distances, _ = nn.kneighbors(queries)
+
+        farthest_distance = distances[0, 1]
+        assert farthest_distance == pytest.approx(5.0, abs=1e-6), (
+            f"Expected L2 distance 5.0, got {farthest_distance}. If 25.0, the backend is returning squared distances."
+        )
+        assert farthest_distance != pytest.approx(25.0, abs=1e-3)
+
+    @pytest.mark.requires_gpu
+    def test_real_gpu_backend_returns_l2_distances(self):
+        """When a CUDA GPU is available, verify the real torch CUDA path returns L2 distances."""
+        nn = NearestNeighborSearch(n_neighbors=4)
+        if not nn.use_gpu:
+            pytest.skip("CUDA GPU not available")
+
+        data, queries, expected = _make_known_data()
+        nn.fit(data)
+        distances, _ = nn.kneighbors(queries)
+
+        np.testing.assert_allclose(distances, expected, atol=1e-6)
+
+    def test_higher_dimensional_l2_distances(self):
+        """Verify L2 distances in higher dimensions (not just 2D)."""
+        rng = np.random.RandomState(42)
+        data = rng.randn(50, 10).astype(np.float32)
+        queries = rng.randn(5, 10).astype(np.float32)
+
+        nn = NearestNeighborSearch(n_neighbors=3)
+        nn.use_gpu = False
+        nn.fit(data)
+        distances, indices = nn.kneighbors(queries)
+
+        for i in range(queries.shape[0]):
+            for j in range(3):
+                neighbor_idx = indices[i, j]
+                expected_l2 = np.sqrt(np.sum((queries[i] - data[neighbor_idx]) ** 2))
+                assert distances[i, j] == pytest.approx(expected_l2, rel=1e-5), (
+                    f"Query {i}, neighbor {j}: got {distances[i, j]}, expected L2={expected_l2}"
+                )

--- a/uv.lock
+++ b/uv.lock
@@ -1132,45 +1132,6 @@ wheels = [
 ]
 
 [[package]]
-name = "faiss-cpu"
-version = "1.13.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/c9/671f66f6b31ec48e5825d36435f0cb91189fa8bb6b50724029dbff4ca83c/faiss_cpu-1.13.2-cp310-abi3-macosx_14_0_arm64.whl", hash = "sha256:a9064eb34f8f64438dd5b95c8f03a780b1a3f0b99c46eeacb1f0b5d15fc02dc1", size = 3452776, upload-time = "2025-12-24T10:27:01.419Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/4a/97150aa1582fb9c2bca95bd8fc37f27d3b470acec6f0a6833844b21e4b40/faiss_cpu-1.13.2-cp310-abi3-macosx_14_0_x86_64.whl", hash = "sha256:c8d097884521e1ecaea6467aeebbf1aa56ee4a36350b48b2ca6b39366565c317", size = 7896434, upload-time = "2025-12-24T10:27:03.592Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/d0/0940575f059591ca31b63a881058adb16a387020af1709dcb7669460115c/faiss_cpu-1.13.2-cp310-abi3-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ee330a284042c2480f2e90450a10378fd95655d62220159b1408f59ee83ebf1", size = 11485825, upload-time = "2025-12-24T10:27:05.681Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/e1/a5acac02aa593809f0123539afe7b4aff61d1db149e7093239888c9053e1/faiss_cpu-1.13.2-cp310-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ab88ee287c25a119213153d033f7dd64c3ccec466ace267395872f554b648cd7", size = 23845772, upload-time = "2025-12-24T10:27:08.194Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/7b/49dcaf354834ec457e85ca769d50bc9b5f3003fab7c94a9dcf08cf742793/faiss_cpu-1.13.2-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:85511129b34f890d19c98b82a0cd5ffb27d89d1cec2ee41d2621ee9f9ef8cf3f", size = 13477567, upload-time = "2025-12-24T10:27:10.822Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/6b/12bb4037921c38bb2c0b4cfc213ca7e04bbbebbfea89b0b5746248ce446e/faiss_cpu-1.13.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8b32eb4065bac352b52a9f5ae07223567fab0a976c7d05017c01c45a1c24264f", size = 25102239, upload-time = "2025-12-24T10:27:13.476Z" },
-    { url = "https://files.pythonhosted.org/packages/14/6d/40439a05e4e60a0e889aa68b08ec70f5c8e32901f75f2be25c593a2e050e/faiss_cpu-1.13.2-cp311-cp311-win_amd64.whl", hash = "sha256:7c5944d7807d58fe7244b6aba06be710ee7ed99343365ed92699349efe979f51", size = 18879906, upload-time = "2025-12-24T10:27:19.041Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/f9/b97eadbdd9e00f945d1566c7101382344f504596bfb19219465b0fc61e6e/faiss_cpu-1.13.2-cp311-cp311-win_arm64.whl", hash = "sha256:19508a1badfb36e456c1c8664eeb948349f604db5c7545f277a0126b4a84b080", size = 8548280, upload-time = "2025-12-24T10:27:22.114Z" },
-    { url = "https://files.pythonhosted.org/packages/87/ff/35ed875423200c17bdd594ce921abfc1812ddd21e09355290b9a94e170ab/faiss_cpu-1.13.2-cp312-cp312-win_amd64.whl", hash = "sha256:b82c01d30430dd7b1fa442001b9099735d1a82f6bb72033acdc9206d5ac66a64", size = 18890300, upload-time = "2025-12-24T10:27:24.194Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/3a/bbdf5deaf6feb34b46b469c0a0acd40216c3d3c6ecf5aeb71d56b8a650e3/faiss_cpu-1.13.2-cp312-cp312-win_arm64.whl", hash = "sha256:2c4f696ae76e7c97cbc12311db83aaf1e7f4f7be06a3ffea7e5b0e8ec1fd805b", size = 8553157, upload-time = "2025-12-24T10:27:26.38Z" },
-    { url = "https://files.pythonhosted.org/packages/60/4b/903d85bf3a8264d49964ec799e45c7ffc91098606b8bc9ef2c904c1a56cb/faiss_cpu-1.13.2-cp313-cp313-win_amd64.whl", hash = "sha256:cb4b5ee184816a4b099162ac93c0d7f0033d81a88e7c1291d0a9cc41ec348984", size = 18891330, upload-time = "2025-12-24T10:27:28.806Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/52/5d10642da628f63544aab27e48416be4a7ea25c6b81d8bd65016d8538b00/faiss_cpu-1.13.2-cp313-cp313-win_arm64.whl", hash = "sha256:1243967eeb2298791ff7f3683a4abd2100d7e6ec7542ca05c3b75d47a7f621e5", size = 8553088, upload-time = "2025-12-24T10:27:31.325Z" },
-]
-
-[[package]]
-name = "faiss-gpu-cu12"
-version = "1.13.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "packaging", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/1d/7823598589ba8a67bcaff5fe93d4025991cda04a6ecc93cba862ae89b63a/faiss_gpu_cu12-1.13.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:752fa4044ec10a3a55f4fa0e81472db8915b4fa40bec6166959c69391b3e5142", size = 48399007, upload-time = "2025-12-29T23:26:52.455Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/1d/a8f088944f827cddbdaa0dfe77f486b457f6174dc3a4b6e4cb103a4dac8b/faiss_gpu_cu12-1.13.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:feba45c2271a350de30a1be5e9e1e1b1b43915b5f20975529a9c26cbc0ef1b03", size = 48404863, upload-time = "2025-12-29T23:26:55.548Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/e7/2dec3daa67368c7f2a89549603e56938cf328779b6acf91f6ab98be30f69/faiss_gpu_cu12-1.13.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b491d0201512fcc70f874b166b196acf533183a45057c3be56263cb74be70bc1", size = 48404541, upload-time = "2025-12-29T23:26:59.053Z" },
-]
-
-[[package]]
 name = "faker"
 version = "40.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3131,7 +3092,6 @@ dependencies = [
 cpu = [
     { name = "accelerate", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "bitsandbytes", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "faiss-cpu", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "flashinfer-cubin", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "flashinfer-python", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "gliner", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -3154,7 +3114,6 @@ cpu = [
 cu128 = [
     { name = "accelerate", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "bitsandbytes", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
-    { name = "faiss-gpu-cu12", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "flashinfer-cubin", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "flashinfer-jit-cache", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
     { name = "flashinfer-python", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
@@ -3198,6 +3157,7 @@ engine = [
     { name = "python-stdnum", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'darwin' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128')" },
     { name = "range-regex", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'darwin' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128')" },
     { name = "ratelimit", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'darwin' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128')" },
+    { name = "scikit-learn", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'darwin' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128')" },
     { name = "smart-open", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'darwin' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128')" },
     { name = "tenacity", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'darwin' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128')" },
     { name = "tiktoken", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'darwin' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128') or (sys_platform == 'linux' and extra == 'extra-21-nemo-safe-synthesizer-cpu' and extra == 'extra-21-nemo-safe-synthesizer-cu128')" },
@@ -3264,8 +3224,6 @@ requires-dist = [
     { name = "datasets", specifier = "==4.3.0" },
     { name = "dateparser", marker = "extra == 'engine'" },
     { name = "dython", marker = "extra == 'engine'" },
-    { name = "faiss-cpu", marker = "extra == 'cpu'", specifier = "==1.13.2" },
-    { name = "faiss-gpu-cu12", marker = "sys_platform == 'linux' and extra == 'cu128'", specifier = "==1.13.2" },
     { name = "faker", specifier = ">=20.0" },
     { name = "faker", marker = "extra == 'engine'" },
     { name = "flashinfer-cubin", marker = "sys_platform == 'linux' and extra == 'cpu'", specifier = "==0.6.1" },
@@ -3303,6 +3261,7 @@ requires-dist = [
     { name = "range-regex", marker = "extra == 'engine'", specifier = ">=0.1.0" },
     { name = "ratelimit", marker = "extra == 'engine'" },
     { name = "rich", specifier = ">=14.1.0" },
+    { name = "scikit-learn", marker = "extra == 'engine'" },
     { name = "sentence-transformers", marker = "extra == 'cpu'" },
     { name = "sentence-transformers", marker = "extra == 'cu128'" },
     { name = "setuptools", specifier = ">=80.0.0" },


### PR DESCRIPTION
# Summary

* Use a torch impl with an sklearn fallback

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [x] `make test` passes locally
- [x] `make test-e2e` passes locally
- [x] `make test-ci-container` passes locally (recommended)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New or updated tests for any fix or new behavior
- [x] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

Benchmark results
<details><summary>Click to see benchmark</summary>
<p>

```text
Nearest Neighbor Benchmark: sklearn vs PyTorch vs cuVS vs FAISS GPU
PyTorch GPU available: True (device: cuda)
cuVS available: False
FAISS GPU available: True

======================================================================
COMPREHENSIVE BENCHMARK SUITE
======================================================================

--- Typical AIA/MIA Workloads ---

============================================================
Benchmark: 5,000 samples × 30 features
Queries: 200, k=5
============================================================
  sklearn_cpu: fit=0.000s, query=0.014s, total=0.015s
  torch_cuda: fit=0.190s, query=0.136s, total=0.326s
  cuvs_gpu: NOT AVAILABLE
  faiss_gpu: fit=0.078s, query=0.006s, total=0.084s
  abstraction (torch (CUDA)): fit=0.001s, query=0.001s, total=0.001s

  Speedups vs sklearn:
    torch_cuda: 0.0×
    faiss_gpu: 0.2×
    abstraction (torch (CUDA)): 10.9×

============================================================
Benchmark: 20,000 samples × 30 features
Queries: 200, k=5
============================================================
  sklearn_cpu: fit=0.000s, query=0.005s, total=0.006s
  torch_cuda: fit=0.001s, query=0.001s, total=0.002s
  cuvs_gpu: NOT AVAILABLE
  faiss_gpu: fit=0.076s, query=0.000s, total=0.076s
  abstraction (torch (CUDA)): fit=0.000s, query=0.001s, total=0.001s

  Speedups vs sklearn:
    torch_cuda: 2.6×
    faiss_gpu: 0.1×
    abstraction (torch (CUDA)): 5.0×

============================================================
Benchmark: 50,000 samples × 512 features
Queries: 10,000, k=5
============================================================
  sklearn_cpu: fit=0.006s, query=1.762s, total=1.768s
  torch_cuda: fit=0.012s, query=0.054s, total=0.066s
  cuvs_gpu: NOT AVAILABLE
  faiss_gpu: fit=0.087s, query=0.038s, total=0.126s
  abstraction (torch (CUDA)): fit=0.038s, query=0.053s, total=0.091s

  Speedups vs sklearn:
    torch_cuda: 26.6×
    faiss_gpu: 14.1×
    abstraction (torch (CUDA)): 19.4×

--- Stress Tests (Large Data) ---

============================================================
Benchmark: 50,000 samples × 100 features
Queries: 500, k=5
============================================================
  sklearn_cpu: fit=0.002s, query=0.030s, total=0.032s
  torch_cuda: fit=0.002s, query=0.002s, total=0.003s
  cuvs_gpu: NOT AVAILABLE
  faiss_gpu: fit=0.077s, query=0.001s, total=0.077s
  abstraction (torch (CUDA)): fit=0.012s, query=0.003s, total=0.014s

  Speedups vs sklearn:
    torch_cuda: 9.3×
    faiss_gpu: 0.4×
    abstraction (torch (CUDA)): 2.2×

============================================================
Benchmark: 100,000 samples × 100 features
Queries: 1,000, k=5
============================================================
  sklearn_cpu: fit=0.003s, query=0.105s, total=0.108s
  torch_cuda: fit=0.004s, query=0.006s, total=0.010s
  cuvs_gpu: NOT AVAILABLE
  faiss_gpu: fit=0.079s, query=0.002s, total=0.081s
  abstraction (torch (CUDA)): fit=0.021s, query=0.005s, total=0.026s

  Speedups vs sklearn:
    torch_cuda: 11.3×
    faiss_gpu: 1.3×
    abstraction (torch (CUDA)): 4.2×

============================================================
Benchmark: 500,000 samples × 100 features
Queries: 10,000, k=5
============================================================
  sklearn_cpu: fit=0.011s, query=4.809s, total=4.820s
  torch_cuda: fit=0.019s, query=0.245s, total=0.264s
  cuvs_gpu: NOT AVAILABLE
  faiss_gpu: fit=0.096s, query=0.087s, total=0.184s
  abstraction (torch (CUDA)): fit=0.037s, query=0.225s, total=0.262s

  Speedups vs sklearn:
    torch_cuda: 18.2×
    faiss_gpu: 26.2×
    abstraction (torch (CUDA)): 18.4×

============================================================
Benchmark: 1,000,000 samples × 200 features
Queries: 10,000, k=5
============================================================
  sklearn_cpu: fit=0.041s, query=16.218s, total=16.259s
  torch_cuda: fit=0.064s, query=0.587s, total=0.651s
  cuvs_gpu: NOT AVAILABLE
  faiss_gpu: fit=0.143s, query=0.271s, total=0.413s
  abstraction (torch (CUDA)): fit=0.094s, query=0.565s, total=0.660s

  Speedups vs sklearn:
    torch_cuda: 25.0×
    faiss_gpu: 39.3×
    abstraction (torch (CUDA)): 24.7×

--- Dimension Scaling (50k samples) ---

============================================================
Benchmark: 50,000 samples × 20 features
Queries: 500, k=5
============================================================
  sklearn_cpu: fit=0.001s, query=0.013s, total=0.014s
  torch_cuda: fit=0.000s, query=0.001s, total=0.002s
  cuvs_gpu: NOT AVAILABLE
  faiss_gpu: fit=0.077s, query=0.001s, total=0.077s
  abstraction (torch (CUDA)): fit=0.003s, query=0.002s, total=0.004s

  Speedups vs sklearn:
    torch_cuda: 8.5×
    faiss_gpu: 0.2×
    abstraction (torch (CUDA)): 3.4×

============================================================
Benchmark: 50,000 samples × 50 features
Queries: 500, k=5
============================================================
  sklearn_cpu: fit=0.001s, query=0.018s, total=0.020s
  torch_cuda: fit=0.001s, query=0.001s, total=0.002s
  cuvs_gpu: NOT AVAILABLE
  faiss_gpu: fit=0.077s, query=0.001s, total=0.077s
  abstraction (torch (CUDA)): fit=0.005s, query=0.003s, total=0.008s

  Speedups vs sklearn:
    torch_cuda: 8.9×
    faiss_gpu: 0.3×
    abstraction (torch (CUDA)): 2.5×

============================================================
Benchmark: 50,000 samples × 100 features
Queries: 500, k=5
============================================================
  sklearn_cpu: fit=0.002s, query=0.029s, total=0.031s
  torch_cuda: fit=0.002s, query=0.002s, total=0.004s
  cuvs_gpu: NOT AVAILABLE
  faiss_gpu: fit=0.078s, query=0.001s, total=0.079s
  abstraction (torch (CUDA)): fit=0.011s, query=0.003s, total=0.014s

  Speedups vs sklearn:
    torch_cuda: 8.0×
    faiss_gpu: 0.4×
    abstraction (torch (CUDA)): 2.2×

============================================================
Benchmark: 50,000 samples × 200 features
Queries: 500, k=5
============================================================
  sklearn_cpu: fit=0.002s, query=0.052s, total=0.055s
  torch_cuda: fit=0.003s, query=0.002s, total=0.006s
  cuvs_gpu: NOT AVAILABLE
  faiss_gpu: fit=0.081s, query=0.001s, total=0.082s
  abstraction (torch (CUDA)): fit=0.021s, query=0.002s, total=0.023s

  Speedups vs sklearn:
    torch_cuda: 9.9×
    faiss_gpu: 0.7×
    abstraction (torch (CUDA)): 2.4×
```

</p>
</details>
