### PR TITLE
docs: document /sync as on-demand GPU test trigger

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,6 +17,7 @@ Ensure that the following pass:
 - [ ] `make test` passes locally
 - [ ] `make test-e2e` passes locally
 - [ ] `make test-ci-container` passes locally (recommended)
+- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)
 
 ## Pre-Merge Checklist
 

--- a/.github/copy-pr-bot.yaml
+++ b/.github/copy-pr-bot.yaml
@@ -8,8 +8,13 @@
 # self-hosted runners. Trusted PRs are automatically copied to pull-request/*
 # branches, which trigger CI workflows via push events.
 #
-# - auto_sync_draft: false  → Draft PRs won't auto-trigger CI (saves GPU resources)
-# - auto_sync_ready: true   → Ready-for-review PRs auto-trigger CI
+# - auto_sync_draft: false  -- Draft PRs won't auto-trigger CI (saves GPU resources)
+# - auto_sync_ready: true   -- Ready-for-review PRs auto-trigger CI on every push
+#
+# On-demand runs: comment `/sync` on any open PR to trigger a GPU test run
+# immediately without pushing a new commit. The bot pushes the current HEAD to
+# pull-request/<number>, which fires gpu-tests.yml and posts the GPU CI Status
+# check result back to the PR. Useful for draft PRs or re-running flaky tests.
 
 enabled: true
 auto_sync_draft: false

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -33,6 +33,16 @@ Configuration: [`.github/copy-pr-bot.yaml`](../copy-pr-bot.yaml)
 
 CPU checks (`ci-checks.yml`) run on GitHub-hosted `ubuntu-latest` runners and use standard `pull_request` triggers.
 
+### On-demand GPU test runs
+
+To trigger a GPU test run on an open PR without waiting for the auto-sync, comment `/sync` on the PR. copy-pr-bot will push the current HEAD to `pull-request/<number>`, which fires `gpu-tests.yml` and posts the `GPU CI Status` check result back to the PR -- the same check as the automatic trigger.
+
+Use `/sync` when:
+
+- The PR is a draft (auto-sync is disabled for drafts)
+- You want to re-run after a flaky failure without pushing a new commit
+- You want a GPU test result before marking the PR ready for review
+
 ## Workflow Diagram
 
 ```mermaid
@@ -126,11 +136,13 @@ The `gpu-tests.yml` workflow runs on pushes to `main` and `pull-request/*` branc
 
 The `changes` (Detect Changes) job always runs, including on `workflow_dispatch`. `dorny/paths-filter` outputs `true` for all filters when there is no base commit to diff against, so the E2E job always runs on a manual dispatch. The job must not be conditionally skipped: a skipped `needs` dependency causes downstream jobs to be skipped even when their own `if` condition would pass.
 
-To trigger manually:
+To trigger manually from the CLI (produces a run but not a PR status check):
 
 ```bash
 gh workflow run gpu-tests.yml --ref <branch-name>
 ```
+
+To trigger from the PR UI and get a status check result, use `/sync` -- see [On-demand GPU test runs](#on-demand-gpu-test-runs) above.
 
 ### Runners
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -431,6 +431,18 @@ make test-ci-container
 uv run pytest tests/cli/test_run.py
 ```
 
+### GPU E2E Tests (CI)
+
+GPU E2E tests run on NVIDIA self-hosted A100 runners and require the copy-pr-bot setup -- they cannot run on a local machine unless you have a compatible GPU environment.
+
+When you open a ready-for-review PR, copy-pr-bot automatically triggers a GPU test run. For draft PRs, or to re-run after a flaky failure, comment `/sync` on the PR. The bot will push the current HEAD to `pull-request/<number>`, fire `gpu-tests.yml`, and post the `GPU CI Status` check result back to the PR.
+
+To trigger from the CLI instead (no PR status check):
+
+```bash
+gh workflow run gpu-tests.yml --ref <your-branch>
+```
+
 ### Test Requirements
 
 Before submitting a PR:


### PR DESCRIPTION
## Summary

- Documents the copy-pr-bot `/sync` comment command as the way to trigger an on-demand GPU test run from a PR
- Adds a new subsection in `CONTRIBUTING.md` under Testing explaining auto-trigger vs `/sync`
- Adds `/sync` usage and when-to-use guidance to `workflows/README.md`
- Adds a GPU CI status checklist item to the PR template (alongside the existing `make test-e2e` local item)
- Expands `copy-pr-bot.yaml` comments to explain `auto_sync_ready`, `auto_sync_draft`, and `/sync`

## Test plan

- [ ] Verify `/sync` comment on a draft PR triggers `gpu-tests.yml` and posts `GPU CI Status`

Made with [Cursor](https://cursor.com)