### PR TITLE
chore(ci): move copyright-check to MR only, dev-wheel disable

### DIFF
--- a/.github/workflows/copyright-check.yml
+++ b/.github/workflows/copyright-check.yml
@@ -17,9 +17,7 @@ name: Copyright check
 on:
   push:
     branches:
-      - main
       - "pull-request/[0-9]+"
-      - "deploy-release/*"
 
 jobs:
   pre-flight:

--- a/.github/workflows/dev-wheel.yml
+++ b/.github/workflows/dev-wheel.yml
@@ -22,9 +22,10 @@
 name: "Dev Wheel"
 
 on:
-  push:
-    branches:
-      - main
+  # Disabled due to connectivity issues
+  # push:
+  #   branches:
+  #    - main
   workflow_dispatch:
 
 defaults:


### PR DESCRIPTION
* Move copyright-check to MRs only
* Disable the dev-wheel job that always fails