### PR TITLE
fix(holdout): setting test size to 0 for holdout

### DIFF
--- a/src/nemo_safe_synthesizer/holdout/holdout.py
+++ b/src/nemo_safe_synthesizer/holdout/holdout.py
@@ -44,6 +44,9 @@ def naive_train_test_split(df, test_size, random_state=None) -> DataFrameOptiona
         Tuple of ``(train_df, test_df)``, or ``(train_df, None)`` if the
         split produces no test set.
     """
+    if test_size == 0:
+        return df.reset_index(drop=True), None
+
     train, test = train_test_split(df, test_size=test_size, random_state=random_state)
     if test is None:
         return train, None

--- a/tests/holdout/test_holdout.py
+++ b/tests/holdout/test_holdout.py
@@ -10,6 +10,7 @@ from nemo_safe_synthesizer.holdout.holdout import (
     HOLDOUT_TOO_SMALL_ERROR,
     INPUT_DATA_TOO_SMALL_ERROR,
     Holdout,
+    naive_train_test_split,
 )
 
 
@@ -84,6 +85,12 @@ def test_zero_holdout(df):
 def test_zero_max_holdout(df):
     holdout = Holdout(SafeSynthesizerParameters.from_params(holdout=0.05, max_holdout=0))
     train, test = holdout.train_test_split(df)
+    assert len(train) == 200
+    assert test is None
+
+
+def test_naive_train_test_split_zero_int_test_size(df):
+    train, test = naive_train_test_split(df, test_size=0)
     assert len(train) == 200
     assert test is None
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
Added an early return in naive_train_test_split when test_size == 0, bypassing sklearn's train_test_split which rejects 0 as an invalid value.

Also added test for `naive_train_test_split`

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [x] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #172 
