### PR TITLE
ci: upgrade GitHub Actions for Node.js 24 compatibility

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -42,7 +42,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         ref: ${{ inputs.ref || github.ref }}
         fetch-depth: ${{ inputs.fetch-depth }}
@@ -70,13 +70,13 @@ runs:
 
     - name: Set up Python ${{ inputs.python-version }}
       if: inputs.python-version != ''
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Set up Python from .python-version
       if: inputs.python-version == ''
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version-file: ".python-version"
 


### PR DESCRIPTION
## Summary

Upgrades all GitHub Actions to versions compatible with the Node.js 24 runtime, which GitHub is rolling out as the new runner default.

**Action upgrades:**
- `actions/checkout`: any version → `v6`
- `actions/upload-artifact`: any version → `v6`
- `actions/download-artifact`: any version → `v7`
- `actions/github-script`: any version → `v8`
- `actions/setup-python`: any version → `v6`

Mirrors: https://github.com/NVIDIA/Megatron-LM/commit/1d5e68b0749f0fc075250fae4e36081d972379a8

## Test plan
- [ ] Verify CI pipelines pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)