### PR TITLE
fix(llm): resolve SmolLM2 bos_token_id out-of-range CUDA crash

### DIFF
--- a/src/nemo_safe_synthesizer/generation/AGENTS.md
+++ b/src/nemo_safe_synthesizer/generation/AGENTS.md
@@ -55,7 +55,7 @@ In `GenerationBatches.add_batch()`:
 ## Gotchas
 
 - `_resolve_temperature()` — forces `temperature=0.0` when `do_sample=False`; raises if `do_sample=False` and `temperature > 0`.
-- `need_special_token_outputs` — `True` when processor is not `TabularDataProcessor` (VllmBackend) or not `TimeSeriesDataProcessor` (TimeseriesBackend). When True: `skip_special_tokens=False`, `include_stop_str_in_output=True`, `ignore_eos=True`. Needed for GroupedDataProcessor BOS/EOS.
+- `need_special_token_outputs` — `True` when processor is not `TabularDataProcessor` (VllmBackend) or not `TimeSeriesDataProcessor` (TimeseriesBackend). When True: `skip_special_tokens=False`, `include_stop_str_in_output=True`. `ignore_eos` is always `False` (native EOS stopping). Needed for GroupedDataProcessor BOS/EOS.
 - Timeseries single valid response — `_retain_single_valid_response()` keeps only the response with the most valid records per batch; others trimmed for sliding-window continuity.
 - `typical_p` — wrapped as `TypicalLogitsWarperWrapper` (logits processor) because vLLM lacks native typical sampling.
 - `num_beams` — mapped to `beam_width` only when `x > 1`; otherwise `(None, None)` (excluded from SamplingParams).

--- a/src/nemo_safe_synthesizer/llm/metadata.py
+++ b/src/nemo_safe_synthesizer/llm/metadata.py
@@ -759,6 +759,7 @@ class SmolLM2(ModelMetadata):
                 f"Rope scaling factor {rope_scaling_factor} is not supported for SmolLM2 due to longer default context lengths. Ignoring."
             )
 
+        im_start_id = tokenizer.convert_tokens_to_ids("<|im_start|>")
         super().__init__(
             autoconfig=config,
             instruction=DEFAULT_INSTRUCTION,
@@ -768,7 +769,7 @@ class SmolLM2(ModelMetadata):
                 add_eos_token_to_prompt=False,
                 tokenizer=tokenizer,
                 bos_token="<|im_start|>",
-                bos_token_id=151644,
+                bos_token_id=im_start_id,
                 name=model_name_or_path,
             ),
             model_name_or_path=model_name_or_path,

--- a/tests/llm/test_metadata.py
+++ b/tests/llm/test_metadata.py
@@ -134,7 +134,7 @@ MODEL_INIT_SCENARIOS = [
         expected_add_bos=False,
         expected_add_eos=False,
         expected_bos_token="<|im_start|>",
-        expected_bos_token_id=151644,
+        expected_bos_token_id=1,
         custom_max_position_embeddings=8192,
     ),
     ModelInitScenario(
@@ -297,6 +297,8 @@ def mock_tokenizer():
     tokenizer.bos_token_id = 1
     tokenizer.eos_token = "</s>"
     tokenizer.eos_token_id = 2
+    _token_ids = {"<|im_start|>": 1, "<|im_end|>": 2}
+    tokenizer.convert_tokens_to_ids = lambda tok: _token_ids.get(tok, 0)
     return tokenizer
 
 


### PR DESCRIPTION
## Summary

the smoke tests pr #76 uses smollm2 for testing. during one of many rebases and changes to that branch, somewhere along the way we lost the following change.

- `SmolLM2` metadata hardcoded `bos_token_id=151644` (copied from the `Llama32` class), but all SmolLM2 models have a 49152-token vocab where `<|im_start|>`; token id `151644` caused a CUDA `vectorized_gather_kernel` oob during tests.
- Fix: look up the actual `<|im_start|>` token ID from the tokenizer via `convert_tokens_to_ids` at init time instead of hardcoding it.
- Also corrects stale `generation/AGENTS.md` that said `ignore_eos=True` (now always `False` after #265).



## Test plan

- [x] `pytest tests/llm/` -- 52 passed
- [x] `pytest tests/smoke/test_full_pipeline_gpu.py::test_full_pipeline_smollm2` -- passes (was CUDA crash before)
