### PR TITLE
refactor(llm): centralize model-family metadata initialization

### DIFF
--- a/src/nemo_safe_synthesizer/llm/metadata.py
+++ b/src/nemo_safe_synthesizer/llm/metadata.py
@@ -305,6 +305,7 @@ class ModelMetadata(BaseModel):
     bos_token: ClassVar[str | None] = None
     supports_rope_scaling: ClassVar[bool] = True
     rope_parameters_location_default: ClassVar[Literal["autoconfig", "automodel"]] = "autoconfig"
+    model_name_markers: ClassVar[tuple[str, ...]] = ()
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -417,8 +418,10 @@ class ModelMetadata(BaseModel):
         match cls.bos_token:
             case str() as bos_token:
                 bos_token_id = tokenizer.convert_tokens_to_ids(bos_token)
-                if not isinstance(bos_token_id, int):
-                    raise ValueError(f"Tokenizer did not resolve BOS token {bos_token!r} to an integer token id")
+                unk_token_id = getattr(tokenizer, "unk_token_id", None)
+                resolved_to_unk = isinstance(unk_token_id, int) and bos_token_id == unk_token_id
+                if not isinstance(bos_token_id, int) or resolved_to_unk:
+                    raise ValueError(f"Tokenizer did not resolve required BOS token {bos_token!r}")
                 prompt_kwargs["bos_token"] = bos_token
                 prompt_kwargs["bos_token_id"] = bos_token_id
             case None:
@@ -615,16 +618,19 @@ class ModelMetadata(BaseModel):
     def _resolve_model_class(cls: type["ModelMetadata"], model_name_or_path: Path | str) -> type["ModelMetadata"]:
         """Resolve model name or path to the matching metadata subclass.
 
-        Uses case-insensitive substring matching over the registered subclass
-        names. The returned class is not instantiated; callers such as
-        ``AutoConfigResolver`` use it to inspect class-level metadata.
+        Uses case-insensitive substring matching over each family's declared
+        name markers, falling back to its class name. The returned class is not
+        instantiated; callers such as ``AutoConfigResolver`` use it to inspect
+        class-level metadata.
 
         Raises:
             ValueError: If no registered subclass matches.
         """
         classes = TinyLlama, Qwen, Llama32, SmolLM2, SmolLM3, Mistral, Nemotron, Granite
+        normalized_name = str(model_name_or_path).casefold()
         for class_ in classes:
-            if class_.__name__.lower() in str(model_name_or_path).lower():
+            markers = class_.model_name_markers or (class_.__name__,)
+            if any(marker.casefold() in normalized_name for marker in markers):
                 return class_
         raise ValueError(f"Unknown model name or path: {model_name_or_path}")
 
@@ -794,8 +800,8 @@ class Granite(ModelFamilyMetadata):
 class Llama32(ModelFamilyMetadata):
     """Metadata for Meta Llama 3.2 model family.
 
-    Uses ``<|im_start|>`` as the BOS token and disables automatic
-    BOS/EOS injection in prompts.
+    Uses the tokenizer's native BOS token and disables automatic BOS/EOS
+    injection in prompts.
 
     Args:
         model_name_or_path: HuggingFace model identifier or local path.
@@ -807,7 +813,7 @@ class Llama32(ModelFamilyMetadata):
     prompt_template: ClassVar[str] = "user\n {instruction} {schema} \n assistant\n{prefill}"
     add_bos_token_to_prompt: ClassVar[bool] = False
     add_eos_token_to_prompt: ClassVar[bool] = False
-    bos_token: ClassVar[str | None] = "<|im_start|>"
+    model_name_markers: ClassVar[tuple[str, ...]] = ("llama32", "llama-3.2")
 
     def __init__(
         self,

--- a/src/nemo_safe_synthesizer/llm/metadata.py
+++ b/src/nemo_safe_synthesizer/llm/metadata.py
@@ -391,6 +391,12 @@ class ModelMetadata(BaseModel):
             data["autoconfig"] = autoconfig
         if tokenizer is not None:
             data["tokenizer"] = tokenizer
+        if is_model_family and not metadata_cls.supports_rope_scaling and data.get("rope_scaling") is not None:
+            logger.warning(
+                f"Rope scaling {data['rope_scaling']} is not supported for {metadata_cls.__name__} "
+                "due to longer default context lengths. Ignoring."
+            )
+            data["rope_scaling"] = None
         if rope_scaling_factor is not None and "rope_scaling" not in data:
             data["rope_scaling"] = metadata_cls._rope_scaling_from_factor(rope_scaling_factor)
 

--- a/src/nemo_safe_synthesizer/llm/metadata.py
+++ b/src/nemo_safe_synthesizer/llm/metadata.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import importlib
 from pathlib import Path
-from typing import Any, ClassVar, Literal, cast
+from typing import Any, ClassVar, Literal
 
 from pydantic import (
     BaseModel,

--- a/src/nemo_safe_synthesizer/llm/metadata.py
+++ b/src/nemo_safe_synthesizer/llm/metadata.py
@@ -385,7 +385,10 @@ class ModelMetadata(BaseModel):
         if is_model_family:
             data.setdefault("rope_parameters_location", metadata_cls.rope_parameters_location_default)
         if is_model_family and prompt_config is None:
-            autoconfig, tokenizer = metadata_cls._load_config_and_tokenizer(model_name_or_path, tokenizer)
+            if autoconfig is None or tokenizer is None:
+                loaded_autoconfig, tokenizer = metadata_cls._load_config_and_tokenizer(model_name_or_path, tokenizer)
+                if autoconfig is None:
+                    autoconfig = loaded_autoconfig
             prompt_config = metadata_cls._prompt_config_from_tokenizer(model_name_or_path, tokenizer)
 
         if autoconfig is not None:

--- a/src/nemo_safe_synthesizer/llm/metadata.py
+++ b/src/nemo_safe_synthesizer/llm/metadata.py
@@ -291,14 +291,20 @@ class ModelMetadata(BaseModel):
     or [`from_metadata_json`][nemo_safe_synthesizer.llm.metadata.ModelMetadata.from_metadata_json]
     to construct instances rather than calling the constructor directly.
 
-    To add a model family, define a ``ModelMetadata`` subclass, configure its
-    ``LLMPromptConfig`` from the tokenizer, override ``default_learning_rate``
+    To add a model family, define a ``ModelMetadata`` subclass, set the
+    class-level prompt/RoPE attributes below, override ``default_learning_rate``
     if needed, and add the subclass to ``_resolve_model_class`` in the intended
     match order.
     """
 
     # Learning rate when training.learning_rate is "auto". Override in subclasses.
     default_learning_rate: ClassVar[float] = 0.0005
+    prompt_template: ClassVar[str] = PROMPT_TEMPLATE
+    add_bos_token_to_prompt: ClassVar[bool] = True
+    add_eos_token_to_prompt: ClassVar[bool] = True
+    bos_token: ClassVar[str | None] = None
+    supports_rope_scaling: ClassVar[bool] = True
+    rope_parameters_location_default: ClassVar[Literal["autoconfig", "automodel"]] = "autoconfig"
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
@@ -360,6 +366,77 @@ class ModelMetadata(BaseModel):
     not decode wasted tokens to the full context-window cap."""
 
     tokenizer: PreTrainedTokenizerBase | None = Field(default=None, exclude=True, repr=False)
+
+    def __init__(
+        self,
+        *,
+        model_name_or_path: str,
+        prompt_config: LLMPromptConfig | dict[str, object] | None = None,
+        autoconfig: PretrainedConfig | None = None,
+        tokenizer: PreTrainedTokenizerBase | None = None,
+        rope_scaling_factor: float | int | None = None,
+        **data: object,
+    ) -> None:
+        """Initialize base metadata or a declarative model-family subclass."""
+        metadata_cls = type(self)
+        is_model_family = metadata_cls is not ModelMetadata
+
+        if is_model_family:
+            data.setdefault("rope_parameters_location", metadata_cls.rope_parameters_location_default)
+        if is_model_family and prompt_config is None:
+            autoconfig, tokenizer = metadata_cls._load_config_and_tokenizer(model_name_or_path, tokenizer)
+            prompt_config = metadata_cls._prompt_config_from_tokenizer(model_name_or_path, tokenizer)
+
+        if autoconfig is not None:
+            data["autoconfig"] = autoconfig
+        if tokenizer is not None:
+            data["tokenizer"] = tokenizer
+        if rope_scaling_factor is not None and "rope_scaling" not in data:
+            data["rope_scaling"] = metadata_cls._rope_scaling_from_factor(rope_scaling_factor)
+
+        super().__init__(model_name_or_path=model_name_or_path, prompt_config=prompt_config, **data)
+
+    @classmethod
+    def _prompt_config_from_tokenizer(
+        cls,
+        model_name_or_path: str,
+        tokenizer: PreTrainedTokenizerBase,
+    ) -> LLMPromptConfig:
+        """Build this model family's prompt config from a loaded tokenizer."""
+        prompt_kwargs: dict[str, object] = {
+            "template": cls.prompt_template,
+            "add_bos_token_to_prompt": cls.add_bos_token_to_prompt,
+            "add_eos_token_to_prompt": cls.add_eos_token_to_prompt,
+        }
+        match cls.bos_token:
+            case str() as bos_token:
+                bos_token_id = tokenizer.convert_tokens_to_ids(bos_token)
+                if not isinstance(bos_token_id, int):
+                    raise ValueError(f"Tokenizer did not resolve BOS token {bos_token!r} to an integer token id")
+                prompt_kwargs["bos_token"] = bos_token
+                prompt_kwargs["bos_token_id"] = bos_token_id
+            case None:
+                pass
+        return LLMPromptConfig.from_tokenizer(
+            name=model_name_or_path,
+            tokenizer=tokenizer,
+            **prompt_kwargs,
+        )
+
+    @classmethod
+    def _rope_scaling_from_factor(cls, rope_scaling_factor: float | int) -> float | int | None:
+        """Return the RoPE scaling value to pass into validation for this family."""
+        match cls.supports_rope_scaling, rope_scaling_factor:
+            case True, _:
+                return rope_scaling_factor
+            case False, 0 | 0.0:
+                pass
+            case False, _:
+                logger.warning(
+                    f"Rope scaling factor {rope_scaling_factor} is not supported for {cls.__name__} "
+                    "due to longer default context lengths. Ignoring."
+                )
+        return None
 
     @model_validator(mode="before")
     @classmethod
@@ -502,10 +579,9 @@ class ModelMetadata(BaseModel):
     ) -> tuple[PretrainedConfig, PreTrainedTokenizerBase]:
         """Load ``PretrainedConfig`` and (optionally) ``AutoTokenizer`` for a model.
 
-        Centralises the repeated boilerplate present in every subclass
-        ``__init__``: loading the HuggingFace config and, when no
-        pre-loaded tokenizer is supplied, fetching one via
-        ``AutoTokenizer.from_pretrained``.
+        Centralises the shared HuggingFace loading path for declarative
+        model-family subclasses: loading the config and, when no pre-loaded
+        tokenizer is supplied, fetching one via ``AutoTokenizer.from_pretrained``.
 
         Args:
             model_name_or_path: HuggingFace model identifier or local path.
@@ -668,7 +744,25 @@ def get_base_max_seq_length(config: AutoConfig) -> int:
     return DEFAULT_MAX_SEQ_LENGTH
 
 
-class Granite(ModelMetadata):
+class ModelFamilyMetadata(ModelMetadata):
+    """Base class for declarative model-family metadata subclasses."""
+
+    def __init__(
+        self,
+        model_name_or_path: str,
+        tokenizer: PreTrainedTokenizerBase | None = None,
+        rope_scaling_factor: float | int | None = None,
+        **data,
+    ) -> None:
+        super().__init__(
+            model_name_or_path=model_name_or_path,
+            tokenizer=tokenizer,
+            rope_scaling_factor=rope_scaling_factor,
+            **data,
+        )
+
+
+class Granite(ModelFamilyMetadata):
     """Metadata for IBM Granite model family.
 
     Args:
@@ -678,34 +772,20 @@ class Granite(ModelMetadata):
         **kwargs: Forwarded to [`ModelMetadata`][nemo_safe_synthesizer.llm.metadata.ModelMetadata].
     """
 
+    prompt_template: ClassVar[str] = "user\n {instruction} {schema} \n assistant\n{prefill}"
+    add_bos_token_to_prompt: ClassVar[bool] = False
+
     def __init__(
         self,
         model_name_or_path: str,
         tokenizer: PreTrainedTokenizerBase | None = None,
-        rope_scaling_factor: float | None = None,
+        rope_scaling_factor: float | int | None = None,
         **kwargs,
     ) -> None:
-        config, tokenizer = ModelMetadata._load_config_and_tokenizer(model_name_or_path, tokenizer)
-
-        super().__init__(
-            autoconfig=config,
-            instruction=DEFAULT_INSTRUCTION,
-            prompt_config=LLMPromptConfig.from_tokenizer(
-                name=model_name_or_path,
-                tokenizer=tokenizer,
-                template="user\n {instruction} {schema} \n assistant\n{prefill}",
-                add_bos_token_to_prompt=False,
-                add_eos_token_to_prompt=True,
-            ),
-            model_name_or_path=model_name_or_path,
-            rope_scaling=rope_scaling_factor,  # ty: ignore[invalid-argument-type] -- third-party stub
-            rope_parameters_location="autoconfig",
-            tokenizer=tokenizer,
-            **kwargs,
-        )
+        super().__init__(model_name_or_path, tokenizer=tokenizer, rope_scaling_factor=rope_scaling_factor, **kwargs)
 
 
-class Llama32(ModelMetadata):
+class Llama32(ModelFamilyMetadata):
     """Metadata for Meta Llama 3.2 model family.
 
     Uses ``<|im_start|>`` as the BOS token and disables automatic
@@ -718,37 +798,22 @@ class Llama32(ModelMetadata):
         **kwargs: Forwarded to [`ModelMetadata`][nemo_safe_synthesizer.llm.metadata.ModelMetadata].
     """
 
+    prompt_template: ClassVar[str] = "user\n {instruction} {schema} \n assistant\n{prefill}"
+    add_bos_token_to_prompt: ClassVar[bool] = False
+    add_eos_token_to_prompt: ClassVar[bool] = False
+    bos_token: ClassVar[str | None] = "<|im_start|>"
+
     def __init__(
         self,
         model_name_or_path: str,
         tokenizer: PreTrainedTokenizerBase | None = None,
-        rope_scaling_factor: float | None = None,
+        rope_scaling_factor: float | int | None = None,
         **kwargs,
     ) -> None:
-        config, tokenizer = ModelMetadata._load_config_and_tokenizer(model_name_or_path, tokenizer)
-
-        im_start_id = tokenizer.convert_tokens_to_ids("<|im_start|>")
-        super().__init__(
-            autoconfig=config,
-            instruction=DEFAULT_INSTRUCTION,
-            prompt_config=LLMPromptConfig.from_tokenizer(
-                name=model_name_or_path,
-                tokenizer=tokenizer,
-                template="user\n {instruction} {schema} \n assistant\n{prefill}",
-                bos_token="<|im_start|>",
-                bos_token_id=im_start_id,
-                add_bos_token_to_prompt=False,
-                add_eos_token_to_prompt=False,
-            ),
-            model_name_or_path=model_name_or_path,
-            rope_scaling=rope_scaling_factor,  # ty: ignore[invalid-argument-type] -- third-party stub
-            rope_parameters_location="autoconfig",
-            tokenizer=tokenizer,
-            **kwargs,
-        )
+        super().__init__(model_name_or_path, tokenizer=tokenizer, rope_scaling_factor=rope_scaling_factor, **kwargs)
 
 
-class Mistral(ModelMetadata):
+class Mistral(ModelFamilyMetadata):
     """Metadata for Mistral AI model family.
 
     RoPE scaling is not supported for Mistral models. Any supplied
@@ -762,40 +827,20 @@ class Mistral(ModelMetadata):
     """
 
     default_learning_rate: ClassVar[float] = 0.0001
+    prompt_template: ClassVar[str] = "[INST] {instruction} \n\n {schema} [/INST]{prefill}"
+    supports_rope_scaling: ClassVar[bool] = False
 
     def __init__(
         self,
         model_name_or_path: str,
         tokenizer: PreTrainedTokenizerBase | None = None,
-        rope_scaling_factor: float | None = None,
+        rope_scaling_factor: float | int | None = None,
         **kwargs,
     ) -> None:
-        config, tokenizer = ModelMetadata._load_config_and_tokenizer(model_name_or_path, tokenizer)
-        if rope_scaling_factor:
-            logger.warning(
-                f"Rope scaling factor {rope_scaling_factor} is not supported for Mistral due to longer default context lengths. Ignoring."
-            )
-
-        template = "[INST] {instruction} \n\n {schema} [/INST]{prefill}"
-        super().__init__(
-            autoconfig=config,
-            instruction=DEFAULT_INSTRUCTION,
-            prompt_config=LLMPromptConfig.from_tokenizer(
-                name=model_name_or_path,
-                tokenizer=tokenizer,
-                template=template,
-                add_bos_token_to_prompt=True,
-                add_eos_token_to_prompt=True,
-            ),
-            model_name_or_path=model_name_or_path,
-            rope_scaling=None,
-            rope_parameters_location="autoconfig",
-            tokenizer=tokenizer,  # ty: ignore[invalid-argument-type] -- re-annotated local shadows param type
-            **kwargs,
-        )
+        super().__init__(model_name_or_path, tokenizer=tokenizer, rope_scaling_factor=rope_scaling_factor, **kwargs)
 
 
-class Nemotron(ModelMetadata):
+class Nemotron(ModelFamilyMetadata):
     """Metadata for NVIDIA Nemotron model family.
 
     Args:
@@ -805,34 +850,19 @@ class Nemotron(ModelMetadata):
         **kwargs: Forwarded to [`ModelMetadata`][nemo_safe_synthesizer.llm.metadata.ModelMetadata].
     """
 
+    prompt_template: ClassVar[str] = "[INST] {instruction} \n\n {schema} [/INST]{prefill}"
+
     def __init__(
         self,
         model_name_or_path: str,
         tokenizer: PreTrainedTokenizerBase | None = None,
-        rope_scaling_factor: float | None = None,
+        rope_scaling_factor: float | int | None = None,
         **kwargs,
     ) -> None:
-        config, tokenizer = ModelMetadata._load_config_and_tokenizer(model_name_or_path, tokenizer)
-
-        super().__init__(
-            autoconfig=config,
-            instruction=DEFAULT_INSTRUCTION,
-            prompt_config=LLMPromptConfig.from_tokenizer(
-                template="[INST] {instruction} \n\n {schema} [/INST]{prefill}",
-                add_bos_token_to_prompt=True,
-                add_eos_token_to_prompt=True,
-                tokenizer=tokenizer,
-                name=model_name_or_path,
-            ),
-            model_name_or_path=model_name_or_path,
-            rope_scaling=rope_scaling_factor,  # ty: ignore[invalid-argument-type] -- third-party stub
-            rope_parameters_location="autoconfig",
-            tokenizer=tokenizer,
-            **kwargs,
-        )
+        super().__init__(model_name_or_path, tokenizer=tokenizer, rope_scaling_factor=rope_scaling_factor, **kwargs)
 
 
-class Qwen(ModelMetadata):
+class Qwen(ModelFamilyMetadata):
     """Metadata for Alibaba Qwen model family.
 
     Args:
@@ -842,35 +872,21 @@ class Qwen(ModelMetadata):
         **kwargs: Forwarded to [`ModelMetadata`][nemo_safe_synthesizer.llm.metadata.ModelMetadata].
     """
 
+    # Matched with vllm prompt 2024-12-18
+    prompt_template: ClassVar[str] = "user\n {instruction} {schema} \n assistant\n{prefill}"
+    add_eos_token_to_prompt: ClassVar[bool] = False
+
     def __init__(
         self,
         model_name_or_path: str,
         tokenizer: PreTrainedTokenizerBase | None = None,
-        rope_scaling_factor: float | None = None,
+        rope_scaling_factor: float | int | None = None,
         **kwargs,
     ) -> None:
-        config, tokenizer = ModelMetadata._load_config_and_tokenizer(model_name_or_path, tokenizer)
-
-        super().__init__(
-            autoconfig=config,
-            instruction=DEFAULT_INSTRUCTION,
-            # Matched with vllm prompt 2024-12-18
-            prompt_config=LLMPromptConfig.from_tokenizer(
-                template="user\n {instruction} {schema} \n assistant\n{prefill}",
-                add_bos_token_to_prompt=True,
-                add_eos_token_to_prompt=False,
-                tokenizer=tokenizer,
-                name=model_name_or_path,
-            ),
-            model_name_or_path=model_name_or_path,
-            rope_scaling=rope_scaling_factor,  # ty: ignore[invalid-argument-type] -- third-party stub
-            rope_parameters_location="autoconfig",
-            tokenizer=tokenizer,
-            **kwargs,
-        )
+        super().__init__(model_name_or_path, tokenizer=tokenizer, rope_scaling_factor=rope_scaling_factor, **kwargs)
 
 
-class SmolLM2(ModelMetadata):
+class SmolLM2(ModelFamilyMetadata):
     """Metadata for HuggingFace SmolLM2 model family (e.g. ``SmolLM2-135M``).
 
     RoPE scaling is not supported and any supplied ``rope_scaling_factor``
@@ -883,41 +899,23 @@ class SmolLM2(ModelMetadata):
         **kwargs: Forwarded to [`ModelMetadata`][nemo_safe_synthesizer.llm.metadata.ModelMetadata].
     """
 
+    prompt_template: ClassVar[str] = "user\n {instruction} {schema} \n assistant\n{prefill}"
+    add_bos_token_to_prompt: ClassVar[bool] = False
+    add_eos_token_to_prompt: ClassVar[bool] = False
+    bos_token: ClassVar[str | None] = "<|im_start|>"
+    supports_rope_scaling: ClassVar[bool] = False
+
     def __init__(
         self,
         model_name_or_path: str,
         tokenizer: PreTrainedTokenizerBase | None = None,
-        rope_scaling_factor: float | None = None,
+        rope_scaling_factor: float | int | None = None,
         **kwargs,
     ) -> None:
-        config, tokenizer = ModelMetadata._load_config_and_tokenizer(model_name_or_path, tokenizer)
-        if rope_scaling_factor:
-            logger.warning(
-                f"Rope scaling factor {rope_scaling_factor} is not supported for SmolLM2 due to longer default context lengths. Ignoring."
-            )
-
-        im_start_id = tokenizer.convert_tokens_to_ids("<|im_start|>")  # ty: ignore[unresolved-attribute] -- third-party stub
-        super().__init__(
-            autoconfig=config,
-            instruction=DEFAULT_INSTRUCTION,
-            prompt_config=LLMPromptConfig.from_tokenizer(
-                template="user\n {instruction} {schema} \n assistant\n{prefill}",
-                add_bos_token_to_prompt=False,
-                add_eos_token_to_prompt=False,
-                tokenizer=tokenizer,
-                bos_token="<|im_start|>",
-                bos_token_id=im_start_id,
-                name=model_name_or_path,
-            ),
-            model_name_or_path=model_name_or_path,
-            rope_scaling=None,
-            rope_parameters_location="autoconfig",
-            tokenizer=tokenizer,
-            **kwargs,
-        )
+        super().__init__(model_name_or_path, tokenizer=tokenizer, rope_scaling_factor=rope_scaling_factor, **kwargs)
 
 
-class SmolLM3(ModelMetadata):
+class SmolLM3(ModelFamilyMetadata):
     """Metadata for HuggingFace SmolLM3 model family.
 
     Uses ``<|im_start|>`` as the BOS token.  RoPE scaling is not
@@ -931,47 +929,23 @@ class SmolLM3(ModelMetadata):
         **kwargs: Forwarded to [`ModelMetadata`][nemo_safe_synthesizer.llm.metadata.ModelMetadata].
     """
 
+    prompt_template: ClassVar[str] = "user\n {instruction} {schema} <|im_end|> \n assistant\n{prefill}"
+    add_eos_token_to_prompt: ClassVar[bool] = False
+    # Group-by SFT assumes a BOS token at the start of the prompt.
+    bos_token: ClassVar[str | None] = "<|im_start|>"
+    supports_rope_scaling: ClassVar[bool] = False
+
     def __init__(
         self,
         model_name_or_path: str,
         tokenizer: PreTrainedTokenizerBase | None = None,
-        rope_scaling_factor: float | None = None,
+        rope_scaling_factor: float | int | None = None,
         **kwargs,
     ) -> None:
-        config, tokenizer = ModelMetadata._load_config_and_tokenizer(model_name_or_path, tokenizer)
-
-        # we use the bos token here explicitly for support during group-by SFT.
-        # the groupby assumes there is a bos token at the start of the prompt.
-        bos_token = "<|im_start|>"
-        bos_token_id = tokenizer.convert_tokens_to_ids(bos_token)
-
-        # SmolLM3 uses high theta values (1.5M-5M) so it's important to read from config
-        if rope_scaling_factor:
-            logger.warning(
-                f"Rope scaling factor {rope_scaling_factor} is not supported for SmolLM3 due to longer default context lengths. Ignoring."
-            )
-
-        super().__init__(
-            autoconfig=config,
-            instruction=DEFAULT_INSTRUCTION,
-            prompt_config=LLMPromptConfig.from_tokenizer(
-                template="user\n {instruction} {schema} <|im_end|> \n assistant\n{prefill}",
-                add_bos_token_to_prompt=True,
-                add_eos_token_to_prompt=False,
-                tokenizer=tokenizer,
-                name=model_name_or_path,
-                bos_token=bos_token,
-                bos_token_id=bos_token_id,
-            ),
-            model_name_or_path=model_name_or_path,
-            rope_scaling=None,
-            rope_parameters_location="autoconfig",
-            tokenizer=tokenizer,
-            **kwargs,
-        )
+        super().__init__(model_name_or_path, tokenizer=tokenizer, rope_scaling_factor=rope_scaling_factor, **kwargs)
 
 
-class TinyLlama(ModelMetadata):
+class TinyLlama(ModelFamilyMetadata):
     """Metadata for the TinyLlama model family.
 
     Args:
@@ -985,27 +959,10 @@ class TinyLlama(ModelMetadata):
         self,
         model_name_or_path: str,
         tokenizer: PreTrainedTokenizerBase | None = None,
-        rope_scaling_factor: float | None = None,
+        rope_scaling_factor: float | int | None = None,
         **kwargs,
     ) -> None:
-        config, tokenizer = ModelMetadata._load_config_and_tokenizer(model_name_or_path, tokenizer)
-
-        super().__init__(
-            autoconfig=config,
-            instruction=DEFAULT_INSTRUCTION,
-            prompt_config=LLMPromptConfig.from_tokenizer(
-                template=PROMPT_TEMPLATE,
-                add_bos_token_to_prompt=True,
-                add_eos_token_to_prompt=True,
-                tokenizer=tokenizer,
-                name=model_name_or_path,
-            ),
-            model_name_or_path=model_name_or_path,
-            rope_scaling=rope_scaling_factor,  # ty: ignore[invalid-argument-type] -- third-party stub
-            rope_parameters_location="autoconfig",
-            tokenizer=tokenizer,
-            **kwargs,
-        )
+        super().__init__(model_name_or_path, tokenizer=tokenizer, rope_scaling_factor=rope_scaling_factor, **kwargs)
 
 
 # Pydantic 2.12 + transformers v5 + `from __future__ import annotations` interact

--- a/src/nemo_safe_synthesizer/llm/metadata.py
+++ b/src/nemo_safe_synthesizer/llm/metadata.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import importlib
 from pathlib import Path
-from typing import Any, ClassVar, Literal
+from typing import Any, ClassVar, Literal, cast
 
 from pydantic import (
     BaseModel,
@@ -681,7 +681,7 @@ class Granite(ModelMetadata):
     def __init__(
         self,
         model_name_or_path: str,
-        tokenizer=None,
+        tokenizer: PreTrainedTokenizerBase | None = None,
         rope_scaling_factor: float | None = None,
         **kwargs,
     ) -> None:
@@ -708,8 +708,8 @@ class Granite(ModelMetadata):
 class Llama32(ModelMetadata):
     """Metadata for Meta Llama 3.2 model family.
 
-    Uses ``<|im_start|>`` (id 151644) as the BOS token and disables
-    automatic BOS/EOS injection in prompts.
+    Uses ``<|im_start|>`` as the BOS token and disables automatic
+    BOS/EOS injection in prompts.
 
     Args:
         model_name_or_path: HuggingFace model identifier or local path.
@@ -721,12 +721,13 @@ class Llama32(ModelMetadata):
     def __init__(
         self,
         model_name_or_path: str,
-        tokenizer=None,
+        tokenizer: PreTrainedTokenizerBase | None = None,
         rope_scaling_factor: float | None = None,
         **kwargs,
     ) -> None:
         config, tokenizer = ModelMetadata._load_config_and_tokenizer(model_name_or_path, tokenizer)
 
+        im_start_id = tokenizer.convert_tokens_to_ids("<|im_start|>")
         super().__init__(
             autoconfig=config,
             instruction=DEFAULT_INSTRUCTION,
@@ -735,7 +736,7 @@ class Llama32(ModelMetadata):
                 tokenizer=tokenizer,
                 template="user\n {instruction} {schema} \n assistant\n{prefill}",
                 bos_token="<|im_start|>",
-                bos_token_id=151644,
+                bos_token_id=im_start_id,
                 add_bos_token_to_prompt=False,
                 add_eos_token_to_prompt=False,
             ),
@@ -807,7 +808,7 @@ class Nemotron(ModelMetadata):
     def __init__(
         self,
         model_name_or_path: str,
-        tokenizer=None,
+        tokenizer: PreTrainedTokenizerBase | None = None,
         rope_scaling_factor: float | None = None,
         **kwargs,
     ) -> None:
@@ -844,7 +845,7 @@ class Qwen(ModelMetadata):
     def __init__(
         self,
         model_name_or_path: str,
-        tokenizer=None,
+        tokenizer: PreTrainedTokenizerBase | None = None,
         rope_scaling_factor: float | None = None,
         **kwargs,
     ) -> None:
@@ -885,7 +886,7 @@ class SmolLM2(ModelMetadata):
     def __init__(
         self,
         model_name_or_path: str,
-        tokenizer=None,
+        tokenizer: PreTrainedTokenizerBase | None = None,
         rope_scaling_factor: float | None = None,
         **kwargs,
     ) -> None:
@@ -919,9 +920,9 @@ class SmolLM2(ModelMetadata):
 class SmolLM3(ModelMetadata):
     """Metadata for HuggingFace SmolLM3 model family.
 
-    Uses ``<|im_start|>`` (id 128011) as the BOS token.  RoPE scaling
-    is not supported. Any supplied ``rope_scaling_factor`` will be
-    ignored with a warning.
+    Uses ``<|im_start|>`` as the BOS token.  RoPE scaling is not
+    supported. Any supplied ``rope_scaling_factor`` will be ignored
+    with a warning.
 
     Args:
         model_name_or_path: HuggingFace model identifier or local path.
@@ -933,7 +934,7 @@ class SmolLM3(ModelMetadata):
     def __init__(
         self,
         model_name_or_path: str,
-        tokenizer=None,
+        tokenizer: PreTrainedTokenizerBase | None = None,
         rope_scaling_factor: float | None = None,
         **kwargs,
     ) -> None:
@@ -942,7 +943,7 @@ class SmolLM3(ModelMetadata):
         # we use the bos token here explicitly for support during group-by SFT.
         # the groupby assumes there is a bos token at the start of the prompt.
         bos_token = "<|im_start|>"
-        bos_token_id = 128011
+        bos_token_id = tokenizer.convert_tokens_to_ids(bos_token)
 
         # SmolLM3 uses high theta values (1.5M-5M) so it's important to read from config
         if rope_scaling_factor:
@@ -983,7 +984,7 @@ class TinyLlama(ModelMetadata):
     def __init__(
         self,
         model_name_or_path: str,
-        tokenizer=None,
+        tokenizer: PreTrainedTokenizerBase | None = None,
         rope_scaling_factor: float | None = None,
         **kwargs,
     ) -> None:

--- a/tests/llm/test_metadata.py
+++ b/tests/llm/test_metadata.py
@@ -32,6 +32,7 @@ from nemo_safe_synthesizer.llm.metadata import (
     DEFAULT_MAX_SEQ_LENGTH,
     GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER,
     GLOBAL_MAX_SEQ_LENGTH,
+    Granite,
     Llama32,
     LLMPromptConfig,
     Mistral,
@@ -95,6 +96,7 @@ MODEL_DETECTION_SCENARIOS = [
     ModelDetectionScenario("smollm3", "HuggingFaceTB/SmolLM3-3B", SmolLM3),
     ModelDetectionScenario("mistral", "mistralai/Mistral-7B-Instruct-v0.3", Mistral),
     ModelDetectionScenario("nemotron", "nvidia/Nemotron-4-340B", Nemotron),
+    ModelDetectionScenario("granite", "ibm-granite/granite-3.0-2b-instruct", Granite),
 ]
 
 # Model initialization scenarios - tests each model's specific configuration
@@ -150,6 +152,16 @@ MODEL_INIT_SCENARIOS = [
         expected_bos_token="<|im_start|>",
         expected_bos_token_id=1,
         use_global_max_seq=True,
+    ),
+    ModelInitScenario(
+        id="granite",
+        model_class=Granite,
+        model_path="ibm-granite/granite-3.0-2b-instruct",
+        expected_template="user\n {instruction} {schema} \n assistant\n{prefill}",
+        expected_add_bos=False,
+        expected_add_eos=True,
+        expected_bos_token=None,
+        expected_bos_token_id=None,
     ),
     ModelInitScenario(
         id="mistral",
@@ -297,7 +309,7 @@ def mock_tokenizer():
     """Create a mock tokenizer for testing."""
     tokenizer = MagicMock(spec=PreTrainedTokenizerBase)
     tokenizer.bos_token = "<s>"
-    tokenizer.bos_token_id = 1
+    tokenizer.bos_token_id = 10
     tokenizer.eos_token = "</s>"
     tokenizer.eos_token_id = 2
     _token_ids = {"<|im_start|>": 1, "<|im_end|>": 2}
@@ -1021,6 +1033,21 @@ class TestModelMetadataKwargsPassthrough:
         assert metadata.rope_scaling.factor == 4
         assert metadata.rope_scaling_factor == 4
         assert metadata.max_seq_length == 4 * DEFAULT_MAX_SEQ_LENGTH
+
+    @patch("nemo_safe_synthesizer.llm.metadata.AutoConfig")
+    @patch("nemo_safe_synthesizer.llm.metadata.load_fast_tokenizer")
+    @pytest.mark.parametrize("model_class", [Mistral, SmolLM2, SmolLM3])
+    def test_unsupported_families_ignore_raw_rope_scaling(
+        self, mock_auto_tokenizer, mock_auto_config, mock_tokenizer, mock_autoconfig_obj, model_class
+    ):
+        """Raw rope_scaling kwargs should not bypass unsupported-family defaults."""
+        mock_auto_tokenizer.return_value = mock_tokenizer
+        mock_auto_config.from_pretrained.return_value = mock_autoconfig_obj
+
+        metadata = model_class(model_name_or_path=f"test-{model_class.__name__}", rope_scaling=2)
+
+        assert metadata.rope_scaling is None
+        assert metadata.rope_scaling_factor == 1.0
 
 
 class TestTinyLlamaWithTokenizer:

--- a/tests/llm/test_metadata.py
+++ b/tests/llm/test_metadata.py
@@ -127,7 +127,7 @@ MODEL_INIT_SCENARIOS = [
         expected_add_bos=False,
         expected_add_eos=False,
         expected_bos_token="<|im_start|>",
-        expected_bos_token_id=1,
+        expected_bos_token_id=1,  #  this is the token_id that the mock_tockenizer injects, not what a real model would use
     ),
     ModelInitScenario(
         id="smollm2",

--- a/tests/llm/test_metadata.py
+++ b/tests/llm/test_metadata.py
@@ -1038,6 +1038,24 @@ class TestModelMetadataKwargsPassthrough:
 
     @patch("nemo_safe_synthesizer.llm.metadata.AutoConfig")
     @patch("nemo_safe_synthesizer.llm.metadata.load_fast_tokenizer")
+    def test_autoconfig_passthrough_when_prompt_config_is_derived(
+        self, mock_auto_tokenizer, mock_auto_config, mock_tokenizer, mock_autoconfig_obj
+    ):
+        """Preserve a caller-provided autoconfig while deriving the prompt config."""
+        loaded_autoconfig = PretrainedConfig()
+        loaded_autoconfig.max_position_embeddings = 4096
+        mock_auto_tokenizer.return_value = mock_tokenizer
+        mock_auto_config.from_pretrained.return_value = loaded_autoconfig
+
+        metadata = TinyLlama(
+            model_name_or_path="TinyLlama/TinyLlama-1.1B-Chat-v1.0",
+            autoconfig=mock_autoconfig_obj,
+        )
+
+        assert metadata.autoconfig is mock_autoconfig_obj
+
+    @patch("nemo_safe_synthesizer.llm.metadata.AutoConfig")
+    @patch("nemo_safe_synthesizer.llm.metadata.load_fast_tokenizer")
     def test_rope_scaling_factor_passthrough(
         self, mock_auto_tokenizer, mock_auto_config, mock_tokenizer, mock_autoconfig_obj
     ):

--- a/tests/llm/test_metadata.py
+++ b/tests/llm/test_metadata.py
@@ -127,7 +127,7 @@ MODEL_INIT_SCENARIOS = [
         expected_add_bos=False,
         expected_add_eos=False,
         expected_bos_token="<|im_start|>",
-        expected_bos_token_id=151644,
+        expected_bos_token_id=1,
     ),
     ModelInitScenario(
         id="smollm2",
@@ -148,7 +148,7 @@ MODEL_INIT_SCENARIOS = [
         expected_add_bos=True,
         expected_add_eos=False,
         expected_bos_token="<|im_start|>",
-        expected_bos_token_id=128011,
+        expected_bos_token_id=1,
         use_global_max_seq=True,
     ),
     ModelInitScenario(

--- a/tests/llm/test_metadata.py
+++ b/tests/llm/test_metadata.py
@@ -91,7 +91,7 @@ class RopeScalingScenario:
 MODEL_DETECTION_SCENARIOS = [
     ModelDetectionScenario("tinyllama", "TinyLlama/TinyLlama-1.1B-Chat-v1.0", TinyLlama),
     ModelDetectionScenario("qwen", "Qwen/Qwen2-0.5B", Qwen),
-    ModelDetectionScenario("llama32", "meta-llama/Llama32-1B", Llama32),
+    ModelDetectionScenario("llama32", "meta-llama/Llama-3.2-1B-Instruct", Llama32),
     ModelDetectionScenario("smollm2", "HuggingFaceTB/SmolLM2-135M", SmolLM2),
     ModelDetectionScenario("smollm3", "HuggingFaceTB/SmolLM3-3B", SmolLM3),
     ModelDetectionScenario("mistral", "mistralai/Mistral-7B-Instruct-v0.3", Mistral),
@@ -124,12 +124,12 @@ MODEL_INIT_SCENARIOS = [
     ModelInitScenario(
         id="llama32",
         model_class=Llama32,
-        model_path="meta-llama/Llama32-1B",
+        model_path="meta-llama/Llama-3.2-1B-Instruct",
         expected_template="user\n {instruction} {schema} \n assistant\n{prefill}",
         expected_add_bos=False,
         expected_add_eos=False,
-        expected_bos_token="<|im_start|>",
-        expected_bos_token_id=1,  #  this is the token_id that the mock_tockenizer injects, not what a real model would use
+        expected_bos_token="<s>",
+        expected_bos_token_id=10,
     ),
     ModelInitScenario(
         id="smollm2",
@@ -801,6 +801,25 @@ class TestResolveModelClass:
         assert ModelMetadata._resolve_model_class("HuggingFaceTB/SmolLM3-3B") is SmolLM3
         assert ModelMetadata._resolve_model_class("mistralai/Mistral-7B-v0.3") is Mistral
         assert ModelMetadata._resolve_model_class("TinyLlama/TinyLlama-1.1B-Chat-v1.0") is TinyLlama
+
+    def test_resolve_model_class_accepts_canonical_llama32_id(self):
+        """Canonical Hugging Face Llama 3.2 IDs resolve despite punctuation in the family name."""
+        assert ModelMetadata._resolve_model_class("meta-llama/Llama-3.2-1B-Instruct") is Llama32
+
+
+class TestRequiredBosToken:
+    """Tests for model families that require a specific BOS token."""
+
+    @patch("nemo_safe_synthesizer.llm.metadata.AutoConfig")
+    def test_unknown_required_bos_token_is_rejected(self, mock_auto_config, mock_tokenizer, mock_autoconfig_obj):
+        """Do not silently use the tokenizer's unknown-token ID as a required BOS token."""
+        mock_auto_config.from_pretrained.return_value = mock_autoconfig_obj
+        mock_tokenizer.unk_token = "<unk>"
+        mock_tokenizer.unk_token_id = 0
+        mock_tokenizer.convert_tokens_to_ids = lambda _token: 0
+
+        with pytest.raises(ValueError, match="did not resolve required BOS token"):
+            SmolLM3(model_name_or_path="HuggingFaceTB/SmolLM3-3B", tokenizer=mock_tokenizer)
 
 
 class TestModelDetection:

--- a/tests/llm/test_metadata.py
+++ b/tests/llm/test_metadata.py
@@ -129,7 +129,7 @@ MODEL_INIT_SCENARIOS = [
         expected_add_bos=False,
         expected_add_eos=False,
         expected_bos_token="<s>",
-        expected_bos_token_id=10,
+        expected_bos_token_id=10,  # From mock_tokenizer, not the model's real token ID.
     ),
     ModelInitScenario(
         id="smollm2",
@@ -1074,14 +1074,27 @@ class TestModelMetadataKwargsPassthrough:
     @patch("nemo_safe_synthesizer.llm.metadata.AutoConfig")
     @patch("nemo_safe_synthesizer.llm.metadata.load_fast_tokenizer")
     @pytest.mark.parametrize("model_class", [Mistral, SmolLM2, SmolLM3])
-    def test_unsupported_families_ignore_raw_rope_scaling(
-        self, mock_auto_tokenizer, mock_auto_config, mock_tokenizer, mock_autoconfig_obj, model_class
+    @pytest.mark.parametrize(
+        "scaling_kwargs",
+        [
+            pytest.param({"rope_scaling": 2}, id="raw-rope-scaling"),
+            pytest.param({"rope_scaling_factor": 2}, id="configured-rope-scaling-factor"),
+        ],
+    )
+    def test_unsupported_families_ignore_rope_scaling(
+        self,
+        mock_auto_tokenizer,
+        mock_auto_config,
+        mock_tokenizer,
+        mock_autoconfig_obj,
+        model_class,
+        scaling_kwargs,
     ):
-        """Raw rope_scaling kwargs should not bypass unsupported-family defaults."""
+        """RoPE scaling inputs should not bypass unsupported-family defaults."""
         mock_auto_tokenizer.return_value = mock_tokenizer
         mock_auto_config.from_pretrained.return_value = mock_autoconfig_obj
 
-        metadata = model_class(model_name_or_path=f"test-{model_class.__name__}", rope_scaling=2)
+        metadata = model_class(model_name_or_path=f"test-{model_class.__name__}", **scaling_kwargs)
 
         assert metadata.rope_scaling is None
         assert metadata.rope_scaling_factor == 1.0


### PR DESCRIPTION
## Summary

- centralize model-family prompt and RoPE metadata while standardizing tokenizer types
- derive special-token IDs from tokenizers and reject required BOS tokens that resolve to the unknown-token ID
- recognize canonical `meta-llama/Llama-3.2-*` model IDs and use Llama's native BOS token
- keep unsupported RoPE overrides from bypassing model-family policy

## Test plan

- [x] `uv run --frozen pytest tests/llm/test_metadata.py -n 0 -q` — 74 passed
- [x] formatting, lint, type checking, and copyright checks
- [x] full unit suite — 1,487 passed; one unrelated parallel vLLM teardown race passed when rerun alone

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized model metadata initialization across supported model families, including smarter default config/tokenizer handling and prompt setup.
  * Added family-level controls for prompt template and BOS/EOS prompt injection, with improved automatic model detection using family naming markers.
  * Introduced `rope_scaling_factor` as a convenient input for RoPE configuration.
* **Bug Fixes**
  * Unsupported RoPE scaling inputs are now ignored safely.
  * Updated Llama 3.2 BOS handling and added stronger validation when required BOS tokens can’t be resolved.
* **Tests**
  * Expanded coverage for Granite, Llama 3.2, autoconfig pass-through, RoPE behavior, and BOS resolution failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
