### PR TITLE
ci: publish dev wheels to Test PyPI on push to main

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -16,6 +16,7 @@ All workflows that use `.github/actions/setup-python-env` now default to the ver
 | [conventional-commit.yml](conventional-commit.yml) | PRs                                      | Validates PR titles follow conventional commit format |
 | [copyright-check.yml](copyright-check.yml)         | Push to `main`/`pull-request/*`          | Validates NVIDIA copyright headers on Python files    |
 | [docs.yml](docs.yml)                               | Push to `main` (docs paths)              | Builds and deploys documentation to GitHub Pages      |
+| [dev-wheel.yml](dev-wheel.yml)                     | Push to `main`, manual                   | Builds and publishes dev wheel to Test PyPI           |
 | [internal-release.yml](internal-release.yml)       | Tag push (`v[0-9]*`), manual dispatch    | Builds and publishes wheel to Artifactory or PyPI     |
 | [release.yml](release.yml)                         | Manual dispatch                          | Builds and publishes package to PyPI (production)     |
 | [secrets-detector.yml](secrets-detector.yml)       | PRs                                      | Scans for accidentally committed secrets              |
@@ -87,15 +88,22 @@ flowchart LR
         slackNotify[Slack Notification]
     end
 
+    subgraph devWheel [Dev Wheel]
+        buildWheelDev[Build Wheel]
+        publishTestPyPI[Publish to Test PyPI]
+        publishArtifactoryDev["Publish to Artifactory (best-effort)"]
+        buildWheelDev --> publishTestPyPI & publishArtifactoryDev
+    end
+
     subgraph internalRelease [Internal Release]
         buildWheelInt[Build Wheel]
         publishArtifactory[Publish to Artifactory/PyPI]
     end
 
-    push --> ci & gpu
+    push --> ci & gpu & devWheel
     cpb --> gpu & copyright
     pr --> ci & conventional & secrets
-    manual --> release
+    manual --> release & devWheel
     tag[Tag push v[0-9]*] --> internalRelease
 
     buildWheel --> publishPyPI --> ghRelease --> slackNotify
@@ -202,6 +210,60 @@ Scans PRs for accidentally committed secrets. False positives can be added to `.
 
 Validates that Python files have proper NVIDIA copyright headers.
 
+## Dev Wheel Workflow
+
+The `dev-wheel.yml` workflow builds a dev wheel on every push to `main` and publishes it to [Test PyPI](https://test.pypi.org/). Artifactory is a best-effort secondary target. It can also be triggered manually via `workflow_dispatch`.
+
+### Version Format
+
+Dev versions are produced by `uv-dynamic-versioning` from git tags. With `metadata = false` and `bump = true` in `pyproject.toml`, the format is:
+
+- On a tagged commit (e.g. `v0.1.0`): `0.1.0`
+- N commits past a tag: `0.1.1.devN` (patch bumped, no local segment)
+
+The `metadata = false` setting strips the `+commit` local segment that PyPI and Test PyPI reject. The `bump = true` setting increments the patch for dev versions, producing cleaner version strings.
+
+### Prerequisites
+
+Before the first publish, create a proper version tag on `main`:
+
+```bash
+git tag v0.1.0
+git push --tags
+```
+
+Without a version tag, dev versions will be based on the fallback `0.0.0`.
+
+### Installing Dev Wheels
+
+```bash
+pip install --index-url https://test.pypi.org/simple/ \
+    --extra-index-url https://pypi.org/simple/ \
+    nemo-safe-synthesizer
+```
+
+The `--extra-index-url` is needed because Test PyPI doesn't host the project's dependencies -- they're fetched from production PyPI.
+
+### Publishing Locally
+
+To Test PyPI:
+
+```bash
+export TWINE_USERNAME=__token__
+export TWINE_PASSWORD=<your-test-pypi-token>
+make publish-test-pypi
+```
+
+To production PyPI (manual, uses separate credentials from CI):
+
+```bash
+export PYPI_USERNAME=__token__
+export PYPI_PASSWORD=<your-pypi-token>
+make publish-pypi-manual
+```
+
+This target uses `PYPI_USERNAME` / `PYPI_PASSWORD` instead of `TWINE_USERNAME` / `TWINE_PASSWORD` so local credentials don't collide with the CI secrets used by `release.yml`.
+
 ## Internal Release Workflow
 
 The `internal-release.yml` workflow builds a wheel and publishes it to NVIDIA Artifactory or PyPI.
@@ -302,19 +364,21 @@ The release workflow automatically bumps the PATCH version (or PRE_RELEASE for r
 
 The following secrets must be configured in GitHub repository settings:
 
-| Secret                      | Purpose                      |
-| --------------------------- | ---------------------------- |
-| `TWINE_USERNAME`            | PyPI username                |
-| `TWINE_PASSWORD`            | PyPI API token               |
-| `SLACK_WEBHOOK_ADMIN`       | Slack admin notifications    |
-| `SLACK_RELEASE_ENDPOINT`    | Slack release notifications  |
-| `PAT`                       | GitHub Personal Access Token |
-| `SSH_KEY`                   | GPG signing key              |
-| `SSH_PWD`                   | GPG key passphrase           |
-| `BOT_KEY`                   | GitHub App private key       |
-| `ARTIFACTORY_USERNAME`      | NVIDIA Artifactory username  |
-| `ARTIFACTORY_TOKEN`         | NVIDIA Artifactory API key   |
-| `ARTIFACTORY_INTERNAL_URL`  | NVIDIA Artifactory repo URL  |
+| Secret                      | Purpose                          |
+| --------------------------- | -------------------------------- |
+| `TWINE_USERNAME`            | PyPI username                    |
+| `TWINE_PASSWORD`            | PyPI API token                   |
+| `TEST_PYPI_USERNAME`        | Test PyPI username (`__token__`) |
+| `TEST_PYPI_PASSWORD`        | Test PyPI API token              |
+| `SLACK_WEBHOOK_ADMIN`       | Slack admin notifications        |
+| `SLACK_RELEASE_ENDPOINT`    | Slack release notifications      |
+| `PAT`                       | GitHub Personal Access Token     |
+| `SSH_KEY`                   | GPG signing key                  |
+| `SSH_PWD`                   | GPG key passphrase               |
+| `BOT_KEY`                   | GitHub App private key           |
+| `ARTIFACTORY_USERNAME`      | NVIDIA Artifactory username      |
+| `ARTIFACTORY_TOKEN`         | NVIDIA Artifactory API key       |
+| `ARTIFACTORY_INTERNAL_URL`  | NVIDIA Artifactory repo URL      |
 
 | Variable | Purpose       |
 | -------- | ------------- |

--- a/.github/workflows/dev-wheel.yml
+++ b/.github/workflows/dev-wheel.yml
@@ -13,19 +13,22 @@
 # limitations under the License.
 
 # ---------------------------------------------------------------------------
-# Dev wheel: build and publish to NVIDIA Artifactory on every merge to main.
-# Version is determined from git tags via uv-dynamic-versioning (PEP 440 dev
-# releases, e.g. 0.2.1.dev3+gabcdef for 3 commits past v0.2.0).
+# Dev wheel: build and publish to Test PyPI on every merge to main.
+# Also publishes to NVIDIA Artifactory when credentials are available.
+# Version is determined from git tags via uv-dynamic-versioning (PEP 440 dev releases).
 # Skips docs/config-only merges using the detect-changes action.
+#
+# Install dev wheels with:
+#   pip install --index-url https://test.pypi.org/simple/ \
+#       --extra-index-url https://pypi.org/simple/ nemo-safe-synthesizer
 # ---------------------------------------------------------------------------
 
 name: "Dev Wheel"
 
 on:
-  # Disabled due to connectivity issues
-  # push:
-  #   branches:
-  #    - main
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 defaults:
@@ -69,12 +72,8 @@ jobs:
           fetch-depth: 0
           bootstrap-tools: "false"
 
-      - name: Build and publish
-        run: make publish-internal
-        env:
-          TWINE_REPOSITORY_URL: ${{ secrets.ARTIFACTORY_INTERNAL_URL }}
-          TWINE_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          TWINE_PASSWORD: ${{ secrets.ARTIFACTORY_TOKEN }}
+      - name: Build wheel
+        run: make build-wheel
 
       - name: Show built version
         id: version
@@ -83,6 +82,31 @@ jobs:
           VERSION=$(echo "$WHEEL" | sed -n 's/.*-\([0-9][^-]*\)-.*/\1/p')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Built: $WHEEL (version $VERSION)"
+
+      - name: Publish to Test PyPI
+        run: |
+          uvx twine upload \
+            --repository-url https://test.pypi.org/legacy/ \
+            --non-interactive \
+            --verbose \
+            dist/*.whl
+        env:
+          TWINE_USERNAME: ${{ secrets.TEST_PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_PASSWORD }}
+
+      - name: Publish to Artifactory
+        if: ${{ secrets.ARTIFACTORY_INTERNAL_URL != '' }}
+        continue-on-error: true
+        run: |
+          uvx twine upload \
+            --repository-url "$TWINE_REPOSITORY_URL" \
+            --non-interactive \
+            --verbose \
+            dist/*.whl
+        env:
+          TWINE_REPOSITORY_URL: ${{ secrets.ARTIFACTORY_INTERNAL_URL }}
+          TWINE_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.ARTIFACTORY_TOKEN }}
 
       - name: Upload wheel as artifact
         uses: actions/upload-artifact@v7

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 - [Testing](#testing)
 - [Code Style](#code-style)
 - [Documentation](#documentation)
+- [Releases and Publishing](#releases-and-publishing)
 
 ## Getting Started
 
@@ -563,6 +564,93 @@ API reference pages are auto-generated from Python docstrings. The `mkdocstrings
 ### Deployment
 
 Documentation is deployed to GitHub Pages automatically when changes to `docs/`, `mkdocs.yml`, or `src/` are pushed to `main`. The workflow is defined in `.github/workflows/docs.yml`.
+
+## Releases and Publishing
+
+This project publishes wheels to three destinations depending on the release stage. All versioning is derived from git tags via `uv-dynamic-versioning` -- there is no manual version file to edit.
+
+### Version Format
+
+Versions follow PEP 440 and are computed automatically at build time:
+
+- Tagged commit (e.g. `v0.1.0`): `0.1.0`
+- N commits past a tag: `0.1.1.devN` (patch bumped, no local segment)
+
+The `[tool.uv-dynamic-versioning]` section in `pyproject.toml` controls this. The `metadata = false` setting strips the `+commit` local segment that PyPI rejects, and `bump = true` increments the patch for dev versions.
+
+### Dev Wheels (Test PyPI)
+
+Dev wheels are published to [Test PyPI](https://test.pypi.org/) automatically on every push to `main` that changes source files. The workflow is [`dev-wheel.yml`](.github/workflows/dev-wheel.yml).
+
+Install a dev wheel:
+
+```bash
+pip install --index-url https://test.pypi.org/simple/ \
+    --extra-index-url https://pypi.org/simple/ \
+    nemo-safe-synthesizer
+```
+
+The `--extra-index-url` is needed because Test PyPI doesn't host the project's dependencies.
+
+To publish manually:
+
+```bash
+export TWINE_USERNAME=__token__
+export TWINE_PASSWORD=<your-test-pypi-token>
+make publish-test-pypi
+```
+
+### Internal Releases (Artifactory)
+
+Pushing a version tag to `main` triggers [`internal-release.yml`](.github/workflows/internal-release.yml), which builds a wheel and publishes it to NVIDIA Artifactory:
+
+```bash
+git tag v0.2.0
+git push --tags
+```
+
+The same workflow can be triggered manually via Actions > Internal Release with a choice of `artifactory` or `pypi` as the publish target.
+
+To publish to Artifactory locally:
+
+```bash
+export TWINE_REPOSITORY_URL=<artifactory-repo-url>
+export TWINE_USERNAME=<your-username>
+export TWINE_PASSWORD=<your-api-key>
+make publish-internal
+```
+
+### Production Releases (PyPI)
+
+Full production releases use [`release.yml`](.github/workflows/release.yml), which delegates to the [FW-CI-templates `_release_library.yml`](https://github.com/NVIDIA-NeMo/FW-CI-templates) reusable workflow. This is a manual-dispatch-only workflow that:
+
+1. Validates the wheel can be built (dry-run)
+2. Creates a version-bump PR
+3. Builds and publishes the wheel to PyPI (or Test PyPI for dry runs)
+4. Creates a GitHub release with changelog
+5. Sends a Slack notification
+
+To trigger: Actions > Release NeMo Safe Synthesizer, then fill in the commit SHA or tag, set `dry-run` to `false` for a real release, and specify the version-bump branch.
+
+To publish to production PyPI locally with personal credentials (separate from CI):
+
+```bash
+export PYPI_USERNAME=__token__
+export PYPI_PASSWORD=<your-pypi-token>
+make publish-pypi-manual
+```
+
+### Publishing Summary
+
+| Destination | Trigger | Workflow | Makefile target |
+| --- | --- | --- | --- |
+| Test PyPI | Push to `main`, manual | `dev-wheel.yml` | `make publish-test-pypi` |
+| Artifactory | Tag push `v[0-9]*`, manual | `internal-release.yml` | `make publish-internal` |
+| PyPI (production) | Manual dispatch | `release.yml` | `make publish-pypi` (CI) / `make publish-pypi-manual` (local) |
+
+### Required Secrets
+
+See [`.github/workflows/README.md`](.github/workflows/README.md#required-secrets) for the full list of secrets that must be configured in GitHub repository settings.
 
 ## AI Agents
 

--- a/Makefile
+++ b/Makefile
@@ -408,6 +408,43 @@ endif
 		dist/*.whl
 	@echo "published: $$(ls dist/*.whl)"
 
+TEST_PYPI_URL := https://test.pypi.org/legacy/
+
+.PHONY: publish-test-pypi
+publish-test-pypi: build-wheel ## Build and publish wheel to Test PyPI. Uses TWINE_USERNAME and TWINE_PASSWORD env vars.
+ifndef TWINE_USERNAME
+	$(error TWINE_USERNAME is not set. For token auth, set TWINE_USERNAME=__token__.)
+endif
+ifndef TWINE_PASSWORD
+	$(error TWINE_PASSWORD is not set. For token auth, set TWINE_PASSWORD=<your-test-pypi-token>.)
+endif
+	@echo "~~~~~~"
+	@echo "uploading to Test PyPI: $(TEST_PYPI_URL)"
+	uvx twine upload \
+		--repository-url $(TEST_PYPI_URL) \
+		--non-interactive \
+		--verbose \
+		dist/*.whl
+	@echo "published to Test PyPI: $$(ls dist/*.whl)"
+	@echo "install with: pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ nemo-safe-synthesizer"
+
+.PHONY: publish-pypi-manual
+publish-pypi-manual: build-wheel ## Build and publish wheel to PyPI with personal credentials. Uses PYPI_USERNAME and PYPI_PASSWORD env vars.
+ifndef PYPI_USERNAME
+	$(error PYPI_USERNAME is not set. For token auth, set PYPI_USERNAME=__token__.)
+endif
+ifndef PYPI_PASSWORD
+	$(error PYPI_PASSWORD is not set. For token auth, set PYPI_PASSWORD=<your-pypi-token>.)
+endif
+	@echo "~~~~~~"
+	@echo "uploading to PyPI (manual)"
+	TWINE_USERNAME=$(PYPI_USERNAME) TWINE_PASSWORD=$(PYPI_PASSWORD) \
+	uvx twine upload \
+		--non-interactive \
+		--verbose \
+		dist/*.whl
+	@echo "published: $$(ls dist/*.whl)"
+
 
 ### NMP SYNCHRONIZATION ###
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -310,6 +310,10 @@ source = "uv-dynamic-versioning"
 fallback-version = "0.0.0"
 vcs = "git"
 style = "pep440"
+# metadata=false strips the +commit local segment that PyPI/Test PyPI reject.
+# bump=true increments the patch for dev versions (e.g. 0.1.1.dev3 instead of 0.1.0.post3.dev0).
+metadata = false
+bump = true
 
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
## Summary

- Fix dev version format for PyPI compatibility (`metadata = false`, `bump = true` in `uv-dynamic-versioning`) -- strips the `+commit` local segment that PyPI rejects
- Re-enable push-to-main trigger in `dev-wheel.yml`, publishing to Test PyPI as the primary target and Artifactory as best-effort
- Add `make publish-test-pypi` (Test PyPI) and `make publish-pypi-manual` (production PyPI with separate `PYPI_USERNAME`/`PYPI_PASSWORD` credentials) for local use
- Document version format, prerequisites, install instructions, and new secrets in the workflows README

## Test plan

- [ ] Add `TEST_PYPI_USERNAME` and `TEST_PYPI_PASSWORD` secrets to the repo
- [ ] Create a `v0.1.0` tag on main for clean dev version numbering
- [ ] Trigger `dev-wheel.yml` via workflow_dispatch and verify the wheel lands on Test PyPI
- [ ] `pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ nemo-safe-synthesizer`

Made with [Cursor](https://cursor.com)