### PR TITLE
chore: move SPDX header in notebook to first code cell

### DIFF
--- a/docs/tutorials/safe-synthesizer-101.ipynb
+++ b/docs/tutorials/safe-synthesizer-101.ipynb
@@ -38,10 +38,10 @@
       "metadata": {},
       "outputs": [],
       "source": [
+        "%%capture\n",
         "# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n",
         "# SPDX-License-Identifier: Apache-2.0\n",
         "\n",
-        "%%capture\n",
         "#TODO: Replace the internal NVIDIA Artifactory endpoint with the public PyPI release when available.\n",
         "!uv pip install nemo-safe-synthesizer[engine,cu128] --extra-index-url \"https://urm.nvidia.com/artifactory/api/pypi/nv-shared-pypi-local/simple\"\n",
         "!uv pip install datasets\n"


### PR DESCRIPTION
## Summary
- Move SPDX copyright/license header from a raw cell at the top of the 101 tutorial notebook into the first code cell as Python comments
- Raw cells render poorly in some notebook viewers; placing the header in the code cell ensures visibility and passes the copyright check

## Test plan
- [x] Notebook renders correctly in JupyterLab / VS Code / GitHub
- [x] Copyright check CI passes

Made with [Cursor](https://cursor.com)