### PR TITLE
docs: add upperbound for python versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Several source modules also have their own `AGENTS.md` with internal patterns an
 
 See [STYLE_GUIDE.md](STYLE_GUIDE.md) for detailed code style conventions (Python, markdown, Dockerfiles, shell scripts, testing, config files, docstrings).
 
-Use `uv` for everything -- never `pip` or raw `python`. Python 3.11+ with modern syntax (`X | Y`, `list[str]`, `Self`).
+Use `uv` for everything -- never `pip` or raw `python`. Python 3.11–3.13 with modern syntax (`X | Y`, `list[str]`, `Self`). Python 3.14+ is not supported (ray has no cp314 wheels).
 
 Common commands: `make test` (unit tests), `make format` (auto-fix formatting + lint + copyright), `make check` (all read-only CI checks), `make typecheck` (ty only). Always use Make targets or the wrapper scripts in `tools/` instead of running `ruff` or `ty` directly. Use `uv run` for Python execution. When in doubt, read the source (`make help`, `pytest --markers`).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 
 ### Prerequisites
 
-- Python 3.11+ (project supports Python ≥3.11; `.python-version` currently pins 3.11 for bootstrapping at the repo root)
+- Python 3.11–3.13 (project supports Python 3.11, 3.12, and 3.13; `.python-version` currently pins 3.11 for bootstrapping at the repo root. Python 3.14+ is not supported — see [Troubleshooting](docs/user-guide/troubleshooting.md#python-314-is-not-supported))
 - Git 2.34+ (minimum required for SSH commit signing)
 
 > Note: Other tools like [uv](https://docs.astral.sh/uv/), [ruff](https://docs.astral.sh/ruff/), [ty](https://github.com/astral-sh/ty), and [gh](https://cli.github.com/) are installed automatically by `make bootstrap-tools`.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Read detailed usage below, or jump to the documentation with [Getting Started](h
 
 ### Prerequisites
 
-- Python 3.11+ (we pin a specific 3.11.x in `.python-version` for local/dev bootstrap; any supported 3.11+ interpreter is fine)
+- Python 3.11–3.13 (we pin a specific 3.11.x in `.python-version` for local/dev bootstrap; any 3.11, 3.12, or 3.13 interpreter works. Python 3.14+ is **not** supported because ray, a transitive dependency of vLLM, does not yet publish `cp314` wheels)
 - [uv](https://docs.astral.sh/uv/) - Python package manager (>=0.9.14, <0.11.0)
 - NVIDIA GPU (A100 or larger) for training and generation
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -115,7 +115,7 @@ How to write clear, testable Python -- independent of which library primitives y
 
 ### Type hints
 
-The codebase targets Python 3.11+ and uses native typing syntax throughout. Expect this minimum for the foreseeable future.
+The codebase targets Python 3.11–3.13 and uses native typing syntax throughout. Expect 3.11 as the minimum for the foreseeable future; the upper bound tracks dependency availability (currently ray/vLLM lack `cp314` wheels).
 
 ```python
 from typing import Self, Sequence

--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -14,7 +14,7 @@ does at each stage.
 
 ### Prerequisites
 
-- Python 3.11+ (dev tooling currently pins 3.11 via `.python-version` in the repo root)
+- Python 3.11–3.13 (dev tooling currently pins 3.11 via `.python-version` in the repo root; Python 3.14+ is **not** supported — see [Troubleshooting](troubleshooting.md#python-314-is-not-supported))
 - CUDA runtime 12.8
 - NVIDIA GPU (A100 or larger) for training and generation
 

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -14,6 +14,7 @@ configuration, and NER parallelism, see [Environment Variables](environment.md).
 
 | Symptom | Likely Cause | Fix |
 |---------|-------------|-----|
+| Install fails on Python 3.14 | ray has no `cp314` wheels | [Use Python 3.11–3.13](#python-314-is-not-supported) |
 | "kernels package not installed" | No network for Kernels Hub | Set `training.attn_implementation: sdpa` |
 | `ConnectionError` during startup | No internet / model not cached | [Pre-cache models](environment.md#pre-caching-models) |
 | OOM in training | VRAM exhausted | [Reduce batch size, quantize](#out-of-memory-during-training) |
@@ -61,6 +62,29 @@ export NSS_LOG_LEVEL=DEBUG
 
 See [Running -- Logging](running.md#logging) for the full logging
 configuration reference.
+
+---
+
+## Installation
+
+### Python 3.14 Is Not Supported
+
+Safe Synthesizer requires **Python 3.11, 3.12, or 3.13**. Python 3.14+ is not
+supported because [ray](https://github.com/ray-project/ray) (a transitive
+dependency of vLLM) does not publish `cp314` wheels. Attempting to install on
+Python 3.14 fails with an unresolvable dependency error during `pip install` or
+`uv pip install`.
+
+To fix, create a virtual environment with a supported interpreter:
+
+```bash
+uv venv --python 3.13
+source .venv/bin/activate
+```
+
+The project's `pyproject.toml` enforces `requires-python = ">=3.11, <3.14"`, so
+package managers will reject the install on unsupported versions. This upper
+bound will be raised once all transitive dependencies ship `cp314` wheels.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ classifiers = [
   "Topic :: Software Development",
   "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
 ]
 
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
Added upperbound for python versions according to the findings [here](https://nvidia.slack.com/archives/C08M4GD7FCY/p1775013092549049?thread_ts=1774976341.976169&cid=C08M4GD7FCY)

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #329 
