### PR TITLE
fix: Remove dead `typical_p` / `TypicalLogitsWarperWrapper` code

### DIFF
--- a/src/nemo_safe_synthesizer/generation/AGENTS.md
+++ b/src/nemo_safe_synthesizer/generation/AGENTS.md
@@ -57,7 +57,6 @@ In `GenerationBatches.add_batch()`:
 - `_resolve_temperature()` — forces `temperature=0.0` when `do_sample=False`; raises if `do_sample=False` and `temperature > 0`.
 - `need_special_token_outputs` — `True` when processor is not `TabularDataProcessor` (VllmBackend) or not `TimeSeriesDataProcessor` (TimeseriesBackend). When True: `skip_special_tokens=False`, `include_stop_str_in_output=True`. `ignore_eos` is always `False` (native EOS stopping). Needed for GroupedDataProcessor BOS/EOS.
 - Timeseries single valid response — `_retain_single_valid_response()` keeps only the response with the most valid records per batch; others trimmed for sliding-window continuity.
-- `typical_p` — wrapped as `TypicalLogitsWarperWrapper` (logits processor) because vLLM lacks native typical sampling.
 - `num_beams` — mapped to `beam_width` only when `x > 1`; otherwise `(None, None)` (excluded from SamplingParams).
 
 ## Extension Points

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -10,7 +10,6 @@ from functools import partial
 from typing import TYPE_CHECKING, Any
 
 import torch
-from transformers import TypicalLogitsWarper
 from vllm import LLM as vLLM
 from vllm import RequestOutput
 from vllm.config import StructuredOutputsConfig
@@ -291,10 +290,6 @@ class VllmBackend(GeneratorBackend):
             "eos_token_id": lambda x: (
                 "stop_token_ids",
                 x if isinstance(x, list) else [x],
-            ),
-            "typical_p": lambda x: (
-                "logits_processors",
-                [TypicalLogitsWarperWrapper(x)],
             ),
             "temperature": lambda x: ("temperature", resolved_temperature),
             "num_beams": lambda x: ("beam_width", x) if x > 1 else (None, None),
@@ -585,21 +580,3 @@ class VllmBackend(GeneratorBackend):
         )
 
         return self.gen_results
-
-
-class TypicalLogitsWarperWrapper:
-    """Adapter enabling locally typical sampling in vLLM.
-
-    Wraps the HuggingFace ``TypicalLogitsWarper`` to match the vLLM
-    logits-processor signature.  See
-    `vllm#1444 <https://github.com/vllm-project/vllm/issues/1444>`_.
-
-    Args:
-        mass: Probability mass for typical sampling.
-    """
-
-    def __init__(self, mass: float):
-        self.warper = TypicalLogitsWarper(mass=mass)
-
-    def __call__(self, token_ids: list[int], logits: torch.FloatTensor) -> torch.FloatTensor:
-        return self.warper(input_ids=None, scores=logits.reshape((1, -1)))

--- a/tests/generation/test_vllm_backend.py
+++ b/tests/generation/test_vllm_backend.py
@@ -280,7 +280,6 @@ class TestGetApiParamMapping:
         expected_keys = {
             "max_new_tokens",
             "eos_token_id",
-            "typical_p",
             "temperature",
             "num_beams",
             "early_stopping",
@@ -362,22 +361,6 @@ class TestGetApiParamMapping:
 
         assert key is None
         assert value is None
-
-    def test_typical_p_creates_logits_processor(self, base_params, mock_model_metadata, mock_schema, mock_workdir):
-        """Test that typical_p creates a TypicalLogitsWarperWrapper."""
-        backend = create_backend(base_params, mock_model_metadata, mock_schema, mock_workdir)
-
-        mapping = backend._get_api_param_mapping(resolved_temperature=0.5)
-        key, value = mapping["typical_p"](0.95)
-
-        assert key == "logits_processors"
-        assert len(value) == 1
-        # Verify it's a TypicalLogitsWarperWrapper
-        from nemo_safe_synthesizer.generation.vllm_backend import (
-            TypicalLogitsWarperWrapper,
-        )
-
-        assert isinstance(value[0], TypicalLogitsWarperWrapper)
 
 
 class TestTransformKwargsToSamplingParams:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
- Remove typical_p support from the vLLM backend, which was unreachable dead code -- a holdover from when this code unified vLLM and HuggingFace inference paths.
- typical_p was never exposed as a user-facing config parameter, never included in DEFAULT_SAMPLING_PARAMETERS, and never passed to prepare_params from any call site. The mapping entry in _get_api_param_mapping and the TypicalLogitsWarperWrapper adapter class could never be triggered in the normal pipeline.

Changes:
- vllm_backend.py: Removed TypicalLogitsWarperWrapper class, its "typical_p" entry in _get_api_param_mapping, and the from transformers import TypicalLogitsWarper import.
- test_vllm_backend.py: Removed "typical_p" from the expected_keys assertion and deleted the test_typical_p_creates_logits_processor test.
- generation/AGENTS.md: Removed the typical_p documentation bullet.

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [x] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New or updated tests for any fix or new behavior
- [x] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #345 
