### PR TITLE
chore: Add test for DependsOnValidator getsource fallback

### DIFF
--- a/tests/configurator/test_validators.py
+++ b/tests/configurator/test_validators.py
@@ -14,12 +14,12 @@ from pydantic import BaseModel, ValidationError
 from nemo_safe_synthesizer.configurator.validators import DependsOnValidator
 
 
-class MyModel(BaseModel):
-    group_by: str | None = None
-    order_by: Annotated[
+class MinimalDataModel(BaseModel):
+    group_training_examples_by: str | None = None
+    order_training_examples_by: Annotated[
         str | None,
         DependsOnValidator(
-            depends_on="group_by",
+            depends_on="group_training_examples_by",
             depends_on_func=lambda v: v is not None,
             value_func=lambda v: v is not None,
         ),
@@ -30,12 +30,16 @@ class TestDependsOnValidatorGetsourceFallback:
     """The error message must not crash when inspect.getsource() is unavailable."""
 
     def test_validation_error_when_source_available(self):
-        with pytest.raises(ValidationError, match="order_by is only allowed when group_by passes"):
-            MyModel(order_by="time")
+        with pytest.raises(
+            ValidationError,
+            match="order_training_examples_by is only allowed when group_training_examples_by passes",
+        ):
+            MinimalDataModel(order_training_examples_by="time")
 
     def test_validation_error_when_source_unavailable(self):
         with patch("nemo_safe_synthesizer.configurator.validators.inspect.getsource", side_effect=OSError):
             with pytest.raises(
-                ValidationError, match="order_by is only allowed when group_by passes its dependency condition"
+                ValidationError,
+                match="order_training_examples_by is only allowed when group_training_examples_by passes its dependency condition",
             ):
-                MyModel(order_by="time")
+                MinimalDataModel(order_training_examples_by="time")


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
- Passing order_training_examples_by without group_training_examples_by in with_data() is correctly invalid, but the validation error path crashes with OSError: could not get source code instead of surfacing a clear message.
- Root cause: inspect.getsource() in DependsOnValidator.validate() fails when running from installed wheel/.pyc files where source isn't bundled.
- Fix: wrap inspect.getsource() in a try/except OSError and fall back to the function's __name__ or repr() so the validation error is always raised cleanly.

now here's what will show:
```
safe-synthesizer-config.yaml is invalid:
2 validation errors for SafeSynthesizerParameters
data.order_training_examples_by
  Value error, order_training_examples_by is only allowed when group_training_examples_by pass condition `<lambda>` [type=value_error, input_value='event_id', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
privacy
  Value error, Data parameters must be provided when DP is enabled. [type=value_error, input_value=DifferentialPrivacyHyperp...ample_max_grad_norm=1.0), input_type=DifferentialPrivacyHyperparams]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
```

EDIT: (April 7th)
The main fix was addressed by PR #141 but the unit tests are still helpful. Changed the title and scope for this PR.

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [x] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #356 make 