### PR TITLE
fix: raise group by column not found error

### DIFF
--- a/src/nemo_safe_synthesizer/data_processing/assembler.py
+++ b/src/nemo_safe_synthesizer/data_processing/assembler.py
@@ -31,6 +31,7 @@ from ..data_processing.stats import (
     RunningStatistics,
     Statistics,
 )
+from ..data_processing.validation import MISSING_GROUP_BY_COLUMN_ERROR, MISSING_ORDER_BY_COLUMN_ERROR
 from ..defaults import (
     DEFAULT_CACHE_PREFIX,
     PSEUDO_GROUP_COLUMN,
@@ -866,13 +867,13 @@ class SequentialExampleAssembler(TabularDataExampleAssembler):
             ParameterError: If group or order column is not found in dataset.
         """
         if self.group_by_column not in dataset.column_names:
-            msg = f"Group by column {self.group_by_column!r} not found in dataset."
+            msg = MISSING_GROUP_BY_COLUMN_ERROR.format(group_by=self.group_by_column)
             if "," in self.group_by_column:
                 msg += " The column name contains a comma -- multi-column grouping is not supported. Use a single column name."
             raise ParameterError(msg)
 
         if self.order_by_column not in dataset.column_names:
-            raise ParameterError(f"Order by column '{self.order_by_column}' not found in dataset.")
+            raise ParameterError(MISSING_ORDER_BY_COLUMN_ERROR.format(order_by=self.order_by_column))
 
     def _reorder_columns(self, dataset: Dataset) -> Dataset:
         """Reorder columns: group_by first, order_by second, then the rest.

--- a/src/nemo_safe_synthesizer/data_processing/assembler.py
+++ b/src/nemo_safe_synthesizer/data_processing/assembler.py
@@ -31,7 +31,7 @@ from ..data_processing.stats import (
     RunningStatistics,
     Statistics,
 )
-from ..data_processing.validation import MISSING_GROUP_BY_COLUMN_ERROR, MISSING_ORDER_BY_COLUMN_ERROR
+from ..data_processing.validation import validate_groupby_column, validate_orderby_column
 from ..defaults import (
     DEFAULT_CACHE_PREFIX,
     PSEUDO_GROUP_COLUMN,
@@ -866,14 +866,8 @@ class SequentialExampleAssembler(TabularDataExampleAssembler):
         Raises:
             ParameterError: If group or order column is not found in dataset.
         """
-        if self.group_by_column not in dataset.column_names:
-            msg = MISSING_GROUP_BY_COLUMN_ERROR.format(group_by=self.group_by_column)
-            if "," in self.group_by_column:
-                msg += " The column name contains a comma -- multi-column grouping is not supported. Use a single column name."
-            raise ParameterError(msg)
-
-        if self.order_by_column not in dataset.column_names:
-            raise ParameterError(MISSING_ORDER_BY_COLUMN_ERROR.format(order_by=self.order_by_column))
+        validate_groupby_column(dataset.column_names, self.group_by_column)
+        validate_orderby_column(dataset.column_names, self.order_by_column)
 
     def _reorder_columns(self, dataset: Dataset) -> Dataset:
         """Reorder columns: group_by first, order_by second, then the rest.

--- a/src/nemo_safe_synthesizer/data_processing/validation.py
+++ b/src/nemo_safe_synthesizer/data_processing/validation.py
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Data validation helpers shared across pipeline stages."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from ..errors import DataError, ParameterError
+
+MISSING_GROUP_BY_COLUMN_ERROR = (
+    "Group by column '{group_by}' not found in input dataset columns. "
+    "Please set `data.group_training_examples_by` to an existing column or to `null`/`None` to disable grouping."
+)
+MISSING_GROUP_BY_VALUES_ERROR = "Group by column '{group_by}' has missing values. Please remove/replace them."
+MISSING_ORDER_BY_COLUMN_ERROR = "Order by column '{order_by}' not found in the input data."
+
+
+def validate_groupby_column(df: pd.DataFrame, group_by: str | None) -> None:
+    """Validate that the configured group-by column exists and has no missing values.
+
+    Args:
+        df: Dataframe to validate.
+        group_by: Name of the configured grouping column.
+
+    Raises:
+        ParameterError: If ``group_by`` is configured but not present in ``df``.
+        DataError: If ``group_by`` contains missing values.
+    """
+    if group_by is None:
+        return
+
+    if group_by not in df.columns:
+        message = MISSING_GROUP_BY_COLUMN_ERROR.format(group_by=group_by)
+        if "," in group_by:
+            message += " The column name contains a comma -- multi-column grouping is not supported. Use a single column name."
+        raise ParameterError(message)
+
+    if df[group_by].isna().any():
+        raise DataError(MISSING_GROUP_BY_VALUES_ERROR.format(group_by=group_by))
+
+
+def validate_orderby_column(df: pd.DataFrame, order_by: str | None) -> None:
+    """Validate that the configured order-by column exists.
+
+    Args:
+        df: Dataframe to validate.
+        order_by: Name of the configured ordering column.
+
+    Raises:
+        ParameterError: If ``order_by`` is configured but not present in ``df``.
+    """
+    if order_by is None:
+        return
+
+    if order_by not in df.columns:
+        raise ParameterError(MISSING_ORDER_BY_COLUMN_ERROR.format(order_by=order_by))

--- a/src/nemo_safe_synthesizer/data_processing/validation.py
+++ b/src/nemo_safe_synthesizer/data_processing/validation.py
@@ -5,54 +5,69 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
+
 import pandas as pd
 
 from ..errors import DataError, ParameterError
 
-MISSING_GROUP_BY_COLUMN_ERROR = (
-    "Group by column '{group_by}' not found in input dataset columns. "
-    "Please set `data.group_training_examples_by` to an existing column or to `null`/`None` to disable grouping."
-)
+MISSING_GROUP_BY_COLUMN_ERROR = "Group by column '{group_by}' not found in input dataset columns. "
 MISSING_GROUP_BY_VALUES_ERROR = "Group by column '{group_by}' has missing values. Please remove/replace them."
 MISSING_ORDER_BY_COLUMN_ERROR = "Order by column '{order_by}' not found in the input data."
 
 
-def validate_groupby_column(df: pd.DataFrame, group_by: str | None) -> None:
+def _get_column_names(data: pd.DataFrame |Collection[str]) -> Collection[str]:
+    if isinstance(data, pd.DataFrame):
+        return data.columns
+    return data
+
+
+def validate_groupby_column(data: pd.DataFrame |Collection[str], group_by: str | None) -> None:
     """Validate that the configured group-by column exists and has no missing values.
 
     Args:
-        df: Dataframe to validate.
+        data: A DataFrame or collection of column names to validate against.
         group_by: Name of the configured grouping column.
 
     Raises:
-        ParameterError: If ``group_by`` is configured but not present in ``df``.
-        DataError: If ``group_by`` contains missing values.
+        ParameterError: If ``group_by`` is configured but not present in ``data``.
+        DataError: If ``data`` is a DataFrame and ``group_by`` contains missing values.
     """
     if group_by is None:
         return
 
-    if group_by not in df.columns:
+    columns = _get_column_names(data)
+
+    if group_by not in columns:
         message = MISSING_GROUP_BY_COLUMN_ERROR.format(group_by=group_by)
         if "," in group_by:
-            message += " The column name contains a comma -- multi-column grouping is not supported. Use a single column name."
+            message += (
+                " The column name contains a comma -- multi-column grouping is not supported. Use a single column name."
+            )
+        else:
+            message += (
+                " Please set `data.group_training_examples_by` to an existing column or to `null`/`None` to disable grouping."
+            )
         raise ParameterError(message)
 
-    if df[group_by].isna().any():
+    if isinstance(data, pd.DataFrame) and data[group_by].isna().any():
         raise DataError(MISSING_GROUP_BY_VALUES_ERROR.format(group_by=group_by))
 
 
-def validate_orderby_column(df: pd.DataFrame, order_by: str | None) -> None:
+def validate_orderby_column(data: pd.DataFrame |Collection[str], order_by: str | None) -> None:
     """Validate that the configured order-by column exists.
 
     Args:
-        df: Dataframe to validate.
+        data: A DataFrame or collection of column names to validate against.
         order_by: Name of the configured ordering column.
 
     Raises:
-        ParameterError: If ``order_by`` is configured but not present in ``df``.
+        ParameterError: If ``order_by`` is configured but not present in ``data``.
     """
     if order_by is None:
         return
 
-    if order_by not in df.columns:
+    columns = _get_column_names(data)
+
+    if order_by not in columns:
         raise ParameterError(MISSING_ORDER_BY_COLUMN_ERROR.format(order_by=order_by))

--- a/src/nemo_safe_synthesizer/data_processing/validation.py
+++ b/src/nemo_safe_synthesizer/data_processing/validation.py
@@ -16,13 +16,13 @@ MISSING_GROUP_BY_VALUES_ERROR = "Group by column '{group_by}' has missing values
 MISSING_ORDER_BY_COLUMN_ERROR = "Order by column '{order_by}' not found in the input data."
 
 
-def _get_column_names(data: pd.DataFrame |Collection[str]) -> Collection[str]:
+def _get_column_names(data: pd.DataFrame | Collection[str]) -> Collection[str]:
     if isinstance(data, pd.DataFrame):
         return data.columns
     return data
 
 
-def validate_groupby_column(data: pd.DataFrame |Collection[str], group_by: str | None) -> None:
+def validate_groupby_column(data: pd.DataFrame | Collection[str], group_by: str | None) -> None:
     """Validate that the configured group-by column exists and has no missing values.
 
     Args:
@@ -45,16 +45,14 @@ def validate_groupby_column(data: pd.DataFrame |Collection[str], group_by: str |
                 " The column name contains a comma -- multi-column grouping is not supported. Use a single column name."
             )
         else:
-            message += (
-                " Please set `data.group_training_examples_by` to an existing column or to `null`/`None` to disable grouping."
-            )
+            message += " Please set `data.group_training_examples_by` to an existing column or to `null`/`None` to disable grouping."
         raise ParameterError(message)
 
     if isinstance(data, pd.DataFrame) and data[group_by].isna().any():
         raise DataError(MISSING_GROUP_BY_VALUES_ERROR.format(group_by=group_by))
 
 
-def validate_orderby_column(data: pd.DataFrame |Collection[str], order_by: str | None) -> None:
+def validate_orderby_column(data: pd.DataFrame | Collection[str], order_by: str | None) -> None:
     """Validate that the configured order-by column exists.
 
     Args:

--- a/src/nemo_safe_synthesizer/holdout/holdout.py
+++ b/src/nemo_safe_synthesizer/holdout/holdout.py
@@ -15,6 +15,7 @@ from sklearn.model_selection import GroupShuffleSplit, train_test_split
 
 from ..config.data import DEFAULT_HOLDOUT, MIN_HOLDOUT
 from ..config.parameters import SafeSynthesizerParameters
+from ..data_processing.validation import validate_groupby_column
 from ..observability import get_logger
 
 MIN_RECORDS_FOR_TEXT_AND_PRIVACY_METRICS = 200
@@ -79,11 +80,10 @@ def grouped_train_test_split(
         grouped split could be produced.
 
     Raises:
-        ValueError: If the ``group_by`` column contains missing values.
+        ParameterError: If the ``group_by`` column is not present in ``df``.
+        DataError: If the ``group_by`` column contains missing values.
     """
-    if input_df[group_by].isna().any():
-        msg = f"Group by column '{group_by}' has missing values. Please remove/replace them."
-        raise ValueError(msg)
+    validate_groupby_column(input_df, group_by)
 
     if test_size > input_df.groupby(group_by).ngroups or test_size == 1 or test_size == 0:
         logger.info(
@@ -150,9 +150,11 @@ class Holdout:
 
         Raises:
             ValueError: If the input dataframe has fewer than
-                ``MIN_RECORDS_FOR_TEXT_AND_PRIVACY_METRICS`` rows, if the
-                computed holdout is smaller than ``MIN_HOLDOUT``, or if
-                the ``group_by`` column contains missing values.
+                ``MIN_RECORDS_FOR_TEXT_AND_PRIVACY_METRICS`` rows or if the
+                computed holdout is smaller than ``MIN_HOLDOUT``.
+            ParameterError: If the configured ``group_by`` column is missing.
+            DataError: If the configured ``group_by`` column contains missing
+                values.
         """
         if not self.holdout or not self.max_holdout:
             return input_df, None
@@ -187,14 +189,7 @@ class Holdout:
                 HOLDOUT_TOO_SMALL_ERROR,
             )
 
-        if self.group_by is not None and self.group_by not in input_df.columns:
-            msg = f"Group by column {self.group_by!r} not found in input dataset columns. Doing a normal split."
-            if "," in self.group_by:
-                msg += " The column name contains a comma -- multi-column grouping is not supported. Use a single column name."
-            logger.warning(msg)
-            self.group_by = None
-        if self.group_by is not None and input_df[self.group_by].isna().any():
-            raise ValueError(f"Group by column '{self.group_by}' has missing values. Please remove/replace them.")
+        validate_groupby_column(input_df, self.group_by)
 
         if self.group_by:
             training_df, test_df = grouped_train_test_split(

--- a/src/nemo_safe_synthesizer/sdk/library_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/library_builder.py
@@ -23,6 +23,7 @@ from ..config import (
     SafeSynthesizerParameters,
 )
 from ..config.autoconfig import AutoConfigResolver
+from ..data_processing.validation import validate_groupby_column, validate_orderby_column
 from ..evaluation.evaluator import Evaluator
 from ..generation.timeseries_backend import TimeseriesBackend
 from ..generation.vllm_backend import VllmBackend
@@ -247,9 +248,11 @@ class SafeSynthesizer(ConfigBuilder):
     def process_data(self) -> SafeSynthesizer:
         """Perform train/test split, auto-config resolution, and optional PII replacement.
 
-        Splits the data via ``Holdout``, runs ``AutoConfigResolver`` to
-        resolve ``"auto"`` parameters, applies PII replacement to the
-        training set when enabled, and persists the splits to the workdir.
+        Validates configured grouping/ordering columns against the input
+        dataset, splits the data via ``Holdout``, runs
+        ``AutoConfigResolver`` to resolve ``"auto"`` parameters, applies
+        PII replacement to the training set when enabled, and persists the
+        splits to the workdir.
 
         Returns:
             Self for method chaining.
@@ -270,6 +273,9 @@ class SafeSynthesizer(ConfigBuilder):
         if TYPE_CHECKING:
             assert self._nss_config is not None
             assert isinstance(self._data_source, pd.DataFrame)
+
+        validate_groupby_column(self._data_source, self._nss_config.data.group_training_examples_by)
+        validate_orderby_column(self._data_source, self._nss_config.data.order_training_examples_by)
 
         holdout = Holdout(self._nss_config)
         original_training_df, self._test_df = holdout.train_test_split(self._data_source)

--- a/src/nemo_safe_synthesizer/training/backend.py
+++ b/src/nemo_safe_synthesizer/training/backend.py
@@ -220,11 +220,11 @@ class TrainingBackend(metaclass=abc.ABCMeta):
     def prepare_training_data(self) -> None:
         """Load, validate, and tokenize the training dataset.
 
-        Runs auto-config resolution, validates groupby/orderby columns,
-        applies time-series processing and ``action_executor`` preprocessing,
-        then assembles tokenized training examples. Populates
-        ``training_examples``, ``dataset_schema``, ``training_df``, and
-        ``data_fraction``.
+        Validates grouping/ordering columns (where applicable), resolves
+        auto-config values, applies time-series processing and
+        ``action_executor`` preprocessing, then assembles tokenized training
+        examples. Populates ``training_examples``, ``dataset_schema``,
+        ``training_df``, and ``data_fraction``.
         """
         ...
 

--- a/src/nemo_safe_synthesizer/training/huggingface_backend.py
+++ b/src/nemo_safe_synthesizer/training/huggingface_backend.py
@@ -42,6 +42,7 @@ from ..cli.artifact_structure import BoundDir
 from ..config.autoconfig import AutoConfigResolver
 from ..data_processing.assembler import TrainingExampleAssembler
 from ..data_processing.dataset import make_json_schema
+from ..data_processing.validation import validate_groupby_column, validate_orderby_column
 from ..defaults import (
     DEFAULT_VALID_RECORD_EVAL_BATCH_SIZE,
     EVAL_STEPS,
@@ -538,32 +539,6 @@ class HuggingFaceBackend(TrainingBackend):
         self.trainer = self._create_trainer(self.train_args, data_collator)
         self._configure_trainer_callbacks(self.trainer, training_args)
 
-    def _validate_groupby_column(self, df: pd.DataFrame) -> None:
-        """Validate the groupby column exists and has no missing values.
-
-        Args:
-            df: The DataFrame to validate.
-
-        Raises:
-            ParameterError: If the groupby column doesn't exist.
-            DataError: If the groupby column has missing values.
-        """
-        col = self.params.data.group_training_examples_by
-        if col is None:
-            return
-
-        if col not in df.columns:
-            msg = f"Group by column {col!r} not found in the input data."
-            if "," in col:
-                msg += " The column name contains a comma -- multi-column grouping is not supported. Use a single column name."
-            logger.error(msg)
-            raise ParameterError(msg)
-
-        if df[col].isnull().any():
-            msg = f"Group by column '{col}' has missing values. Please remove/replace them."
-            logger.error(msg)
-            raise DataError(msg)
-
     def _validate_orderby_column(self, df: pd.DataFrame) -> None:
         """Validate the orderby column exists in the dataset.
 
@@ -580,10 +555,7 @@ class HuggingFaceBackend(TrainingBackend):
         if self.params.time_series.is_timeseries and self.params.time_series.timestamp_column is None:
             return
 
-        if orderby_col and orderby_col not in df.columns:
-            msg = f"Order by column '{orderby_col}' not found in the input data."
-            logger.error(msg)
-            raise ParameterError(msg)
+        validate_orderby_column(df, orderby_col)
 
     def _apply_preprocessing(self, df: pd.DataFrame) -> pd.DataFrame:
         """Apply action_executor preprocessing if available.
@@ -664,8 +636,8 @@ class HuggingFaceBackend(TrainingBackend):
     def prepare_training_data(self) -> None:
         """Validate, preprocess, and tokenize the training dataset.
 
-        Runs auto-config resolution, time-series processing, groupby /
-        orderby validation, and assembles tokenized training examples.
+        Validates groupby/orderby columns, resolves auto-config values,
+        runs time-series preprocessing, and assembles tokenized training examples.
         Populates ``training_examples``, ``dataset_schema``,
         ``training_df``, and ``data_fraction``.
 
@@ -681,11 +653,10 @@ class HuggingFaceBackend(TrainingBackend):
         if not isinstance(training_df, pd.DataFrame):
             raise DataError("Expected DataFrame from to_pandas(), got an iterator")
 
-        self.params = AutoConfigResolver(training_df, self.params).resolve()
-
         # Validate groupby/orderby parameters as a preprocessing step.
-        self._validate_groupby_column(training_df)
+        validate_groupby_column(training_df, self.params.data.group_training_examples_by)
         self._validate_orderby_column(training_df)
+        self.params = AutoConfigResolver(training_df, self.params).resolve()
 
         # Process time series data (sort by timestamp, infer intervals, etc.)
         training_df = self._process_timeseries(training_df)

--- a/tests/data_processing/test_assembler.py
+++ b/tests/data_processing/test_assembler.py
@@ -661,7 +661,7 @@ def test_sequential_assembler_raises_for_missing_group_column(
     fixture_sequential_metadata: ModelMetadata,
 ):
     """Test that SequentialExampleAssembler raises for missing group column."""
-    with pytest.raises(ParameterError, match="Group by column.*not found in dataset"):
+    with pytest.raises(ParameterError, match="Group by column.*not found"):
         SequentialExampleAssembler(
             dataset=fixture_iris_dataset,
             tokenizer=fixture_tokenizer,
@@ -680,7 +680,7 @@ def test_sequential_assembler_raises_for_missing_order_column(
     fixture_sequential_metadata: ModelMetadata,
 ):
     """Test that SequentialExampleAssembler raises for missing order column."""
-    with pytest.raises(ParameterError, match="Order by column.*not found in dataset"):
+    with pytest.raises(ParameterError, match="Order by column.*not found"):
         SequentialExampleAssembler(
             dataset=fixture_iris_dataset,
             tokenizer=fixture_tokenizer,

--- a/tests/data_processing/test_assembler.py
+++ b/tests/data_processing/test_assembler.py
@@ -661,7 +661,7 @@ def test_sequential_assembler_raises_for_missing_group_column(
     fixture_sequential_metadata: ModelMetadata,
 ):
     """Test that SequentialExampleAssembler raises for missing group column."""
-    with pytest.raises(ParameterError, match="Group by column.*not found"):
+    with pytest.raises(ParameterError, match="Group by column.*not found in dataset"):
         SequentialExampleAssembler(
             dataset=fixture_iris_dataset,
             tokenizer=fixture_tokenizer,
@@ -680,7 +680,7 @@ def test_sequential_assembler_raises_for_missing_order_column(
     fixture_sequential_metadata: ModelMetadata,
 ):
     """Test that SequentialExampleAssembler raises for missing order column."""
-    with pytest.raises(ParameterError, match="Order by column.*not found"):
+    with pytest.raises(ParameterError, match="Order by column.*not found in dataset"):
         SequentialExampleAssembler(
             dataset=fixture_iris_dataset,
             tokenizer=fixture_tokenizer,

--- a/tests/data_processing/test_validation.py
+++ b/tests/data_processing/test_validation.py
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pandas as pd
+import pytest
+
+from nemo_safe_synthesizer.data_processing.validation import (
+    MISSING_GROUP_BY_COLUMN_ERROR,
+    MISSING_GROUP_BY_VALUES_ERROR,
+    MISSING_ORDER_BY_COLUMN_ERROR,
+    validate_groupby_column,
+    validate_orderby_column,
+)
+from nemo_safe_synthesizer.errors import DataError, ParameterError
+
+
+def test_validate_groupby_column_noop_when_groupby_is_none() -> None:
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    validate_groupby_column(df, None)
+
+
+def test_validate_groupby_column_raises_for_missing_column() -> None:
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    with pytest.raises(ParameterError) as excinfo:
+        validate_groupby_column(df, "missing_group")
+    assert str(excinfo.value) == MISSING_GROUP_BY_COLUMN_ERROR.format(group_by="missing_group")
+
+
+def test_validate_groupby_column_raises_for_missing_values() -> None:
+    df = pd.DataFrame({"group": ["x", None], "value": [1, 2]})
+    with pytest.raises(DataError) as excinfo:
+        validate_groupby_column(df, "group")
+    assert str(excinfo.value) == MISSING_GROUP_BY_VALUES_ERROR.format(group_by="group")
+
+
+def test_validate_orderby_column_noop_when_orderby_is_none() -> None:
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    validate_orderby_column(df, None)
+
+
+def test_validate_orderby_column_raises_for_missing_column() -> None:
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    with pytest.raises(ParameterError) as excinfo:
+        validate_orderby_column(df, "missing_order")
+    assert str(excinfo.value) == MISSING_ORDER_BY_COLUMN_ERROR.format(order_by="missing_order")

--- a/tests/data_processing/test_validation.py
+++ b/tests/data_processing/test_validation.py
@@ -5,9 +5,6 @@ import pandas as pd
 import pytest
 
 from nemo_safe_synthesizer.data_processing.validation import (
-    MISSING_GROUP_BY_COLUMN_ERROR,
-    MISSING_GROUP_BY_VALUES_ERROR,
-    MISSING_ORDER_BY_COLUMN_ERROR,
     validate_groupby_column,
     validate_orderby_column,
 )
@@ -21,16 +18,20 @@ def test_validate_groupby_column_noop_when_groupby_is_none() -> None:
 
 def test_validate_groupby_column_raises_for_missing_column() -> None:
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
-    with pytest.raises(ParameterError) as excinfo:
+    with pytest.raises(ParameterError, match="disable grouping"):
         validate_groupby_column(df, "missing_group")
-    assert str(excinfo.value) == MISSING_GROUP_BY_COLUMN_ERROR.format(group_by="missing_group")
+
+
+def test_validate_groupby_column_raises_for_comma_in_name() -> None:
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    with pytest.raises(ParameterError, match="multi-column grouping is not supported"):
+        validate_groupby_column(df, "col1,col2")
 
 
 def test_validate_groupby_column_raises_for_missing_values() -> None:
     df = pd.DataFrame({"group": ["x", None], "value": [1, 2]})
-    with pytest.raises(DataError) as excinfo:
+    with pytest.raises(DataError, match="missing values"):
         validate_groupby_column(df, "group")
-    assert str(excinfo.value) == MISSING_GROUP_BY_VALUES_ERROR.format(group_by="group")
 
 
 def test_validate_orderby_column_noop_when_orderby_is_none() -> None:
@@ -40,6 +41,5 @@ def test_validate_orderby_column_noop_when_orderby_is_none() -> None:
 
 def test_validate_orderby_column_raises_for_missing_column() -> None:
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
-    with pytest.raises(ParameterError) as excinfo:
+    with pytest.raises(ParameterError, match="not found in the input data"):
         validate_orderby_column(df, "missing_order")
-    assert str(excinfo.value) == MISSING_ORDER_BY_COLUMN_ERROR.format(order_by="missing_order")

--- a/tests/data_processing/test_validation.py
+++ b/tests/data_processing/test_validation.py
@@ -16,9 +16,23 @@ def test_validate_groupby_column_noop_when_groupby_is_none() -> None:
     validate_groupby_column(df, None)
 
 
+def test_validate_groupby_column_passes_when_column_exists() -> None:
+    df = pd.DataFrame(
+        {
+            "col1": [1, 2, 3, 4, 5],
+            "col2": ["a", "b", "c", "d", "e"],
+            "group_col": ["g1", "g1", "g2", "g2", "g3"],
+        }
+    )
+    validate_groupby_column(df, "group_col")
+
+
 def test_validate_groupby_column_raises_for_missing_column() -> None:
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
-    with pytest.raises(ParameterError, match="disable grouping"):
+    with pytest.raises(
+        ParameterError,
+        match=r"Group by column 'missing_group' not found in input dataset columns.*disable grouping",
+    ):
         validate_groupby_column(df, "missing_group")
 
 

--- a/tests/holdout/test_holdout.py
+++ b/tests/holdout/test_holdout.py
@@ -6,6 +6,7 @@ import pandas as pd
 import pytest
 
 from nemo_safe_synthesizer.config.parameters import SafeSynthesizerParameters
+from nemo_safe_synthesizer.errors import DataError, ParameterError
 from nemo_safe_synthesizer.holdout.holdout import (
     HOLDOUT_TOO_SMALL_ERROR,
     INPUT_DATA_TOO_SMALL_ERROR,
@@ -103,12 +104,18 @@ def test_does_group_by_holdout(df):
     assert len(test) == 100
 
 
-def test_skips_group_by_holdout_with_bad_column(df):
+def test_raises_on_group_by_holdout_with_bad_column(df):
     holdout = Holdout(SafeSynthesizerParameters.from_params(group_training_examples_by="dne"))
-    train, test = holdout.train_test_split(df)
-    assert len(train) == 190
-    assert test is not None
-    assert len(test) == 10
+    with pytest.raises(ParameterError, match="Group by column 'dne' not found"):
+        holdout.train_test_split(df)
+
+
+def test_raises_on_group_by_holdout_with_missing_values(df):
+    df_with_missing_group = df.copy()
+    df_with_missing_group.loc[0, "big_cat"] = None
+    holdout = Holdout(SafeSynthesizerParameters.from_params(group_training_examples_by="big_cat"))
+    with pytest.raises(DataError, match="Group by column 'big_cat' has missing values"):
+        holdout.train_test_split(df_with_missing_group)
 
 
 def test_complains_when_training_dataset_is_too_small():

--- a/tests/sdk/test_process_data.py
+++ b/tests/sdk/test_process_data.py
@@ -21,6 +21,7 @@ from pydantic import ValidationError
 
 from nemo_safe_synthesizer.cli.artifact_structure import Workdir
 from nemo_safe_synthesizer.config import SafeSynthesizerParameters
+from nemo_safe_synthesizer.errors import ParameterError
 from nemo_safe_synthesizer.sdk.library_builder import SafeSynthesizer
 
 # ---------------------------------------------------------------------------
@@ -591,7 +592,9 @@ class TestProcessDataConfigValidation:
     methods after construction are not visible to the Pydantic validator
     until ``_resolve_nss_config()`` is called.  ``process_data`` must
     call it at the top of the method so invalid configs are caught
-    immediately -- before holdout split, PII replacement, or any disk I/O.
+    immediately. It also validates configured group/order columns against
+    the input dataset before holdout split, autoconfig resolution, PII
+    replacement, or any disk I/O.
     """
 
     def test_dp_and_explicit_unsloth_raises_at_process_data(self, fixture_workdir: Workdir) -> None:
@@ -606,3 +609,52 @@ class TestProcessDataConfigValidation:
         )
         with pytest.raises(ValidationError, match="not compatible with DP"):
             ss.process_data()
+
+    @patch("nemo_safe_synthesizer.sdk.library_builder.Holdout")
+    def test_invalid_groupby_raises_before_holdout(
+        self,
+        mock_holdout_cls,
+        fixture_workdir: Workdir,
+        fixture_sample_patient_dataframe: pd.DataFrame,
+    ) -> None:
+        """Missing group-by column raises immediately during ``process_data``.
+
+        This catches invalid ``group_training_examples_by`` before holdout split
+        or autoconfig runs, ensuring a clear ``ParameterError`` instead of a
+        downstream ``KeyError``.
+        """
+        ss = SafeSynthesizer(
+            config=SafeSynthesizerParameters.from_params(group_training_examples_by="non_existent_group"),
+            workdir=fixture_workdir,
+        ).with_data_source(fixture_sample_patient_dataframe)
+
+        with pytest.raises(ParameterError, match="Group by column 'non_existent_group' not found"):
+            ss.process_data()
+
+        mock_holdout_cls.assert_not_called()
+
+    @patch("nemo_safe_synthesizer.sdk.library_builder.Holdout")
+    def test_invalid_orderby_raises_before_holdout(
+        self,
+        mock_holdout_cls,
+        fixture_workdir: Workdir,
+        fixture_sample_patient_dataframe: pd.DataFrame,
+    ) -> None:
+        """Missing order-by column raises immediately during ``process_data``.
+
+        This catches invalid ``order_training_examples_by`` before holdout split
+        or autoconfig runs, ensuring a clear ``ParameterError`` instead of a
+        downstream pandas error.
+        """
+        ss = SafeSynthesizer(
+            config=SafeSynthesizerParameters.from_params(
+                group_training_examples_by="patient_name",
+                order_training_examples_by="non_existent_order",
+            ),
+            workdir=fixture_workdir,
+        ).with_data_source(fixture_sample_patient_dataframe)
+
+        with pytest.raises(ParameterError, match="Order by column 'non_existent_order' not found"):
+            ss.process_data()
+
+        mock_holdout_cls.assert_not_called()

--- a/tests/training/test_huggingface_backend.py
+++ b/tests/training/test_huggingface_backend.py
@@ -18,6 +18,7 @@ from nemo_safe_synthesizer.config import (
     SafeSynthesizerParameters,
     TrainingHyperparams,
 )
+from nemo_safe_synthesizer.data_processing.validation import validate_groupby_column
 from nemo_safe_synthesizer.errors import DataError, ParameterError
 from nemo_safe_synthesizer.training.huggingface_backend import (
     HuggingFaceBackend,
@@ -561,34 +562,28 @@ class TestConfigureStandardTraining:
 
 
 class TestValidateGroupbyColumn:
-    def test_does_nothing_when_no_groupby(self, backend, sample_dataframe):
+    def test_does_nothing_when_no_groupby(self, sample_dataframe):
         """Test that nothing happens when groupby is None."""
-        backend._validate_groupby_column(sample_dataframe)  # Should not raise
+        validate_groupby_column(sample_dataframe, None)  # Should not raise
 
-    def test_passes_when_column_exists(self, backend, sample_dataframe):
+    def test_passes_when_column_exists(self, sample_dataframe):
         """Test that validation passes when column exists."""
-        backend.params.data.group_training_examples_by = "group_col"
-        backend._validate_groupby_column(sample_dataframe)  # Should not raise
+        validate_groupby_column(sample_dataframe, "group_col")  # Should not raise
 
-    def test_raises_when_column_missing(self, backend, sample_dataframe):
+    def test_raises_when_column_missing(self, sample_dataframe):
         """Test that ParameterError is raised when column is missing."""
-        backend.params.data.group_training_examples_by = "nonexistent_col"
+        with pytest.raises(ParameterError, match="Group by column 'nonexistent_col' not found"):
+            validate_groupby_column(sample_dataframe, "nonexistent_col")
 
-        with pytest.raises(ParameterError, match="not found in the input data"):
-            backend._validate_groupby_column(sample_dataframe)
-
-    def test_raises_with_comma_hint_when_column_has_comma(self, backend, sample_dataframe):
-        backend.params.data.group_training_examples_by = "patient_id,event_id"
-
+    def test_raises_with_comma_hint_when_column_has_comma(self, sample_dataframe):
+        """Test that ParameterError is raised when column name has a comma."""
         with pytest.raises(ParameterError, match="multi-column grouping is not supported"):
-            backend._validate_groupby_column(sample_dataframe)
+            validate_groupby_column(sample_dataframe, "patient_id,event_id")
 
-    def test_raises_when_column_has_nulls(self, backend, dataframe_with_null_group):
+    def test_raises_when_column_has_nulls(self, dataframe_with_null_group):
         """Test that DataError is raised when column has null values."""
-        backend.params.data.group_training_examples_by = "group_col"
-
         with pytest.raises(DataError, match="has missing values"):
-            backend._validate_groupby_column(dataframe_with_null_group)
+            validate_groupby_column(dataframe_with_null_group, "group_col")
 
 
 class TestValidateOrderbyColumn:

--- a/tests/training/test_huggingface_backend.py
+++ b/tests/training/test_huggingface_backend.py
@@ -18,8 +18,7 @@ from nemo_safe_synthesizer.config import (
     SafeSynthesizerParameters,
     TrainingHyperparams,
 )
-from nemo_safe_synthesizer.data_processing.validation import validate_groupby_column
-from nemo_safe_synthesizer.errors import DataError, ParameterError
+from nemo_safe_synthesizer.errors import ParameterError
 from nemo_safe_synthesizer.training.huggingface_backend import (
     HuggingFaceBackend,
     compute_metrics,
@@ -205,17 +204,6 @@ def sample_dataframe():
             "col2": ["a", "b", "c", "d", "e"],
             "group_col": ["g1", "g1", "g2", "g2", "g3"],
             "order_col": [1, 2, 3, 4, 5],
-        }
-    )
-
-
-@pytest.fixture
-def dataframe_with_null_group():
-    """Create a DataFrame with null values in the group column."""
-    return pd.DataFrame(
-        {
-            "col1": [1, 2, 3],
-            "group_col": ["g1", None, "g2"],
         }
     )
 
@@ -559,31 +547,6 @@ class TestConfigureStandardTraining:
 
         assert data_collator == custom_collator
         assert "data_collator" not in training_args
-
-
-class TestValidateGroupbyColumn:
-    def test_does_nothing_when_no_groupby(self, sample_dataframe):
-        """Test that nothing happens when groupby is None."""
-        validate_groupby_column(sample_dataframe, None)  # Should not raise
-
-    def test_passes_when_column_exists(self, sample_dataframe):
-        """Test that validation passes when column exists."""
-        validate_groupby_column(sample_dataframe, "group_col")  # Should not raise
-
-    def test_raises_when_column_missing(self, sample_dataframe):
-        """Test that ParameterError is raised when column is missing."""
-        with pytest.raises(ParameterError, match="Group by column 'nonexistent_col' not found"):
-            validate_groupby_column(sample_dataframe, "nonexistent_col")
-
-    def test_raises_with_comma_hint_when_column_has_comma(self, sample_dataframe):
-        """Test that ParameterError is raised when column name has a comma."""
-        with pytest.raises(ParameterError, match="multi-column grouping is not supported"):
-            validate_groupby_column(sample_dataframe, "patient_id,event_id")
-
-    def test_raises_when_column_has_nulls(self, dataframe_with_null_group):
-        """Test that DataError is raised when column has null values."""
-        with pytest.raises(DataError, match="has missing values"):
-            validate_groupby_column(dataframe_with_null_group, "group_col")
 
 
 class TestValidateOrderbyColumn:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

Previously if the `group_training_examples_by` column is missing in the data set, we file a warning at the holdout step and revert to the naive train test split. This is pointless because later on we'd error out at either the rope scaling auto resolution step or the training step, with less informative error messages. In this PR, we
- Instead raise an error early at the holdout step
- Added an early validation for `order_training_examples_by` in the library builder to fail early as well
- Centralize the group by and order by validation checks so we do the same check regardless of the entry point and consistently provide an informative error message. 

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [x] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->

- Closes #176 

### Current Behavior
- entry point 1
```
safe-synthesizer run --config /root/configs/quick-tinyllama-unsloth.yaml --data-source /root/datasets/clinc_oos.csv --data__group_training_examples_by non_existent
```
First, a warning
```
2026-04-07T14:56:01.168 | Nemo Safe Synthesizer |  runtime |  warning |  holdout.py: Holdout.train_test_split: 177 
Group By column non_existent not found in input Dataset columns! Doing a normal split.
```
Then, raises key error at… `config/autoconfig.py::get_max_token_count`

- entry point 2
```
safe-synthesizer run --config /root/configs/quick-tinyllama-unsloth.yaml --data-source /root/datasets/clinc_oos.csv --data__group_training_examples_by non_existent --training__rope_scaling_factor 1
```
Same warning, then raises error at the training step, 
```
File "/root/Safe-Synthesizer/src/nemo_safe_synthesizer/training/huggingface_backend.py", line 548, in _validate_groupby_column
    raise ParameterError(msg)
nemo_safe_synthesizer.errors.ParameterError: Group by column 'non_existent' not found in the input data.
```

- order by missing
```
safe-synthesizer run --config /root/configs/quick-tinyllama-unsloth.yaml --data-source /root/datasets/clinc_oos.csv --data__group_training_examples_by label --data__order_training_examples_by non_existent
```
Raises an error in the training step:
```
 File "/root/Safe-Synthesizer/src/nemo_safe_synthesizer/training/huggingface_backend.py", line 551, in _validate_orderby_column
    raise ParameterError(msg)
nemo_safe_synthesizer.errors.ParameterError: Order by column 'non_existent' not found in the input data.
```

### New Behavior
- group by error
Raises the same error always, and early:
```
  File "/root/Safe-Synthesizer/src/nemo_safe_synthesizer/data_processing/validation.py", line 34, in validate_groupby_column
    raise ParameterError(MISSING_GROUP_BY_COLUMN_ERROR.format(group_by=group_by))
nemo_safe_synthesizer.errors.ParameterError: Group by column 'non_existent' not found in input dataset columns. Please set `data.group_training_examples_by` to an existing column or disable grouping.
```
- order by error
```
  File "/root/Safe-Synthesizer/src/nemo_safe_synthesizer/sdk/library_builder.py", line 278, in process_data
    validate_orderby_column(self._data_source, self._nss_config.data.order_training_examples_by)
  File "/root/Safe-Synthesizer/src/nemo_safe_synthesizer/data_processing/validation.py", line 55, in validate_orderby_column
    raise ParameterError(MISSING_ORDER_BY_COLUMN_ERROR.format(order_by=order_by))
nemo_safe_synthesizer.errors.ParameterError: Order by column 'non_existent' not found in the input data.
```
