### PR TITLE
fix(generation): set reasonable prompt amount

### DIFF
--- a/src/nemo_safe_synthesizer/generation/results.py
+++ b/src/nemo_safe_synthesizer/generation/results.py
@@ -281,11 +281,18 @@ class GenerationBatches:
         if self.target_num_records is None:
             return num_prompts
 
-        if self.num_valid_records > 0:
-            num_records_remaining = self.target_num_records - self.num_valid_records
-            valid_records_per_prompt = 0 if self.num_prompts == 0 else self.num_valid_records / self.num_prompts
+        num_records_remaining = self.target_num_records - self.num_valid_records
+
+        if self.num_valid_records > 0 and self.num_prompts > 0:
+            valid_records_per_prompt = self.num_valid_records / self.num_prompts
             num_prompts_needed = round(num_records_remaining / (valid_records_per_prompt + EPS))
             num_prompts = min(num_prompts, num_prompts_needed + NUM_PROMPT_BUFFER)
+        else:
+            # First batch: no records-per-prompt history yet.  Assume at
+            # least 1 record per prompt (the actual ratio is typically much
+            # higher) to avoid sending max_num_prompts_per_batch prompts
+            # when the target is small.
+            num_prompts = min(num_prompts, num_records_remaining + NUM_PROMPT_BUFFER)
 
         return num_prompts
 

--- a/tests/generation/test_generation.py
+++ b/tests/generation/test_generation.py
@@ -15,7 +15,7 @@ from nemo_safe_synthesizer.data_processing.actions.data_actions import (
 from nemo_safe_synthesizer.errors import GenerationError
 from nemo_safe_synthesizer.generation.batch import Batch
 from nemo_safe_synthesizer.generation.processors import ParsedResponse
-from nemo_safe_synthesizer.generation.results import GenerationBatches, GenerationStatus
+from nemo_safe_synthesizer.generation.results import NUM_PROMPT_BUFFER, GenerationBatches, GenerationStatus
 
 
 # Purpose: Builds reusable good/bad Batch sets for generation tests.
@@ -160,6 +160,22 @@ def test_get_next_num_prompts(fixture_stub_batches):
     # so far the average is 3 records per prompt so we only need around 6 more but
     # we are expecting a higher number of prompts because of the NUM_PROMPT_BUFFER minimum
     assert generation_with_target.get_next_num_prompts() == 16
+
+
+# Purpose: First batch (no history) caps prompts to target + buffer instead of max.
+# Data: Empty GenerationBatches with small target_num_records and no prior batches.
+# Asserts: Returns target + NUM_PROMPT_BUFFER when that's less than max; returns max otherwise.
+@pytest.mark.parametrize(
+    "target, expected",
+    [
+        (10, 10 + NUM_PROMPT_BUFFER),
+        (50, 50 + NUM_PROMPT_BUFFER),
+        (200, 100),  # target + buffer exceeds max (100), so capped
+    ],
+)
+def test_get_next_num_prompts_first_batch(target, expected):
+    generation = GenerationBatches(target_num_records=target)
+    assert generation.get_next_num_prompts() == expected
 
 
 # Purpose: Build a DataFrame of valid records across batches, honoring max record cap and validity.


### PR DESCRIPTION
* Found while running an e2e test in the NeMo Platform...

> The bug: get_next_num_prompts() always sends MAX_NUM_PROMPTS_PER_BATCH (100) prompts on the first batch because the adaptive scaling is gated behind if self.num_valid_records > 0, which is false before any batch has run. For small targets like num_records=50, this means 100 prompts x ~100+ records/prompt = massive over-generation (11,336 records for a target of 50) and 21 minutes wasted.