### PR TITLE
fix: misleading data parameter when groupby is null and orderby has value

### DIFF
--- a/src/nemo_safe_synthesizer/config/parameters.py
+++ b/src/nemo_safe_synthesizer/config/parameters.py
@@ -82,24 +82,30 @@ class SafeSynthesizerParameters(Parameters):
         ``max_sequences_per_example`` is ``"auto"``, defaults it to
         ``10``.
 
+        The ``dp_enabled`` check runs before inspecting ``data`` so that
+        an upstream data-section validation failure does not produce a
+        misleading "Data parameters must be provided when DP is enabled"
+        error when DP is actually disabled.
+
         Raises:
-            ParameterError: If ``data`` or ``training`` parameters are
-                missing, ``max_sequences_per_example`` is not ``1``, or
-                Unsloth is enabled alongside DP.
+            ParameterError: If DP is enabled and ``data`` or ``training``
+                parameters are missing, ``max_sequences_per_example`` is
+                not ``1``, or Unsloth is enabled alongside DP.
         """
         if dp_params is None:
             return dp_params
         logger.debug("Checking DP compatibility for privacy parameters. ")
-        # logger.debug(f"Privacy parameters: {dp_params}")
-        data: DataParameters | None = info.data.get("data")
-        if not data:
-            raise ParameterError("Data parameters must be provided when DP is enabled.")
 
         if not dp_params.dp_enabled:
-            if data.max_sequences_per_example is not None and data.max_sequences_per_example == AUTO_STR:
+            data: DataParameters | None = info.data.get("data")
+            if data and data.max_sequences_per_example is not None and data.max_sequences_per_example == AUTO_STR:
                 logger.debug("setting max_sequences_per_example to the default of 10 because DP is disabled")
                 data.max_sequences_per_example = 10
             return dp_params
+
+        data = info.data.get("data")
+        if not data:
+            raise ParameterError("Data parameters must be provided when DP is enabled.")
 
         match data.max_sequences_per_example:
             # this should be a valid none or parameter[int|str|none]

--- a/tests/config/test_nss_config.py
+++ b/tests/config/test_nss_config.py
@@ -177,6 +177,16 @@ class TestSafeSynthesizerParameters:
         params = TimeSeriesParameters(is_timeseries=True, timestamp_column="event_time")
         assert params.timestamp_column == "event_time"
 
+    def test_data_validation_error_without_phantom_dp_error(self):
+        """A bad data section should not produce a phantom 'DP is enabled' error when DP is disabled."""
+        with pytest.raises(ValidationError) as exc_info:
+            SafeSynthesizerParameters.from_yaml_str(
+                "data:\n  order_training_examples_by: event_id\n  group_training_examples_by: null\n"
+            )
+        error_messages = [e["msg"] for e in exc_info.value.errors()]
+        assert any("order_training_examples_by" in msg for msg in error_messages)
+        assert not any("DP is enabled" in msg for msg in error_messages)
+
     def test_read_from_yaml(self, yaml_config_str):
         p = SafeSynthesizerParameters.from_yaml_str(yaml_config_str)
         assert p.get("gradient_accumulation_steps") == 8


### PR DESCRIPTION
…a value

<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
- Fix misleading "Data parameters must be provided when DP is enabled" validation error that appeared when DP was disabled but the data section had its own validation failure (e.g., order_training_examples_by set without group_training_examples_by).
- Root cause: `check_dp_compatibility` inspected `info.data["data"]` before checking `dp_enabled`. When `Pydantic` v2 excludes a field that failed validation, the lookup returned `None` and the validator raised as if DP were active. The fix reorders the checks so `dp_enabled=False` returns early without requiring a valid data section.

Tested with the following config and command `safe-synthesizer run --data-source data/patient_events.csv --config safe-synthesizer-config.yaml`

```
data:
  holdout: 0    
  max_holdout: 0
  group_training_examples_by: null
  order_training_examples_by: event_id

generation:
  num_records: 1000   

training:
  pretrained_model: "HuggingFaceTB/SmolLM3-3B"
  num_input_records_to_sample: 25000 
```

Outputs:
```
(Safe-Synthesizer) root@gpu-dev-pod:~/Safe-Synthesizer# safe-synthesizer run --data-source data/patient_events.csv --config safe-synthesizer-config.yaml
/root/Safe-Synthesizer/src/nemo_safe_synthesizer/observability.py:152: UserWarning: stdout is a tty, setting nss_log_color to True
  warnings.warn("stdout is a tty, setting nss_log_color to True", UserWarning)
2026-04-09T17:37:15.005 | Nemo Safe Synthesizer |  system  |  info  |  utils.py: _initialize_logging_for_cli_from_settings: 345 
Project directory: /root/Safe-Synthesizer/safe-synthesizer-artifacts/safe-synthesizer-config---patient_events
2026-04-09T17:37:15.005 | Nemo Safe Synthesizer |  system  |  info  |  utils.py: _initialize_logging_for_cli_from_settings: 346 
Run directory: /root/Safe-Synthesizer/safe-synthesizer-artifacts/safe-synthesizer-config---patient_events/2026-04-09T17:37:15
2026-04-09T17:37:15.006 | Nemo Safe Synthesizer |  system  |  info  |  utils.py: _initialize_logging_for_cli_from_settings: 347 
Phase directory: /root/Safe-Synthesizer/safe-synthesizer-artifacts/safe-synthesizer-config---patient_events/2026-04-09T17:37:15/end_to_end
2026-04-09T17:37:15.006 | Nemo Safe Synthesizer |  system  |  info  |  utils.py: _initialize_logging_for_cli_from_settings: 348 
Log file: /root/Safe-Synthesizer/safe-synthesizer-artifacts/safe-synthesizer-config---patient_events/2026-04-09T17:37:15/logs/end_to_end.jsonl
2026-04-09T17:37:15.006 | Nemo Safe Synthesizer |  runtime |  info  |  observability.py: 644 
Reading dataset from data/patient_events.csv
safe-synthesizer-config.yaml is invalid:
1 validation error for SafeSynthesizerParameters
data.order_training_examples_by
  Value error, order_training_examples_by is only allowed when group_training_examples_by passes its dependency condition [type=value_error, input_value='event_id', input_type=str]
    For further information visit https://errors.pydantic.dev/2.12/v/value_error
```

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [x] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #386 
