### PR TITLE
refactor(tests): add fixture_ prefix, type annotations, and docstrings

### DIFF
--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -112,11 +112,11 @@ Load helpers in root `conftest.py`:
 
 9 `conftest.py` files: `tests/`, `tests/training/`, `tests/generation/`, `tests/evaluation/`, `tests/cli/`, `tests/data_processing/`, `tests/config/`, `tests/e2e/` (currently empty), `tests/smoke/`.
 
-Dataset/tokenizer fixtures use the `fixture_` prefix; config/CLI use descriptive names (`mock_workdir`, `training_hyperparams`).
+Dataset/tokenizer fixtures use the `fixture_` prefix; CLI helpers use descriptive names (`mock_workdir`).
 
 Key fixtures in root `conftest.py`:
 
-- `yaml_config_str`, `fixture_session_cache_dir`, `fixture_stub_tokenizer_path`
+- `fixture_yaml_config_str`, `fixture_session_cache_dir`, `fixture_stub_tokenizer_path`
 - Dataset loaders: `fixture_iris_dataset`, `fixture_dow_jones_index_dataset` (loads `dow_jones_index_group_size_8.csv`), `fixture_clinc_oos_dataset` (loads `clinc_oos.csv`), `fixture_chickweight_dataset`, etc.
 - `fixture_mock_processor`, `fixture_mock_processor_without_valid_records`
 
@@ -124,8 +124,8 @@ Per-module fixtures:
 
 - Generation/eval/data_processing: shared tokenizer and JSONL fixtures
 - CLI: `mock_workdir(tmp_path)` for tmp_path-based Workdir
-- Config: `basic_parameter`, `training_hyperparams`, `simple_safe_synthesizer_parameters`
-- Smoke: session-scoped `tiny_llama_config`, `stub_tokenizer`, `local_tinyllama_dir`, `iris_df`, `base_smoke_config`, `_patch_attn_eager`; function-scoped `tiny_model`; helpers `train_with_sdk()`, `assert_adapter_saved()`
+- Config: `basic_parameter`, `fixture_training_hyperparams`, `fixture_simple_safe_synthesizer_parameters`
+- Smoke: session-scoped `fixture_tiny_llama_config`, `fixture_stub_tokenizer`, `fixture_local_tinyllama_dir`, `fixture_iris_df`, `fixture_base_smoke_config`, `_patch_attn_eager`; function-scoped `fixture_tiny_model`; helpers `train_with_sdk()`, `assert_adapter_saved()`
 
 ## Fixture Scoping
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -110,7 +110,7 @@ Load helpers in root `conftest.py`:
 
 ## Fixture Discovery
 
-9 `conftest.py` files: `tests/`, `tests/training/`, `tests/generation/`, `tests/evaluation/`, `tests/cli/`, `tests/data_processing/`, `tests/config/`, `tests/e2e/` (currently empty), `tests/smoke/`.
+9 `conftest.py` files: `tests/`, `tests/training/`, `tests/generation/`, `tests/evaluation/`, `tests/cli/`, `tests/data_processing/`, `tests/config/`, `tests/e2e/`, `tests/smoke/`.
 
 Dataset/tokenizer fixtures use the `fixture_` prefix; CLI helpers use descriptive names (`mock_workdir`).
 

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -51,7 +51,7 @@ def test_merge_dicts():
     assert test_data_base == test_data_base_copy
 
 
-def test_config_keep_default_with_nested_replacement(tmp_path_factory, yaml_config_str):
+def test_config_keep_default_with_nested_replacement(tmp_path_factory, fixture_yaml_config_str):
     """
     Note these tests need to be run without extra pytest capturing
     to see the print statements, e.g. pytest -s or pytest --log-cli-level=DEBUG
@@ -59,7 +59,7 @@ def test_config_keep_default_with_nested_replacement(tmp_path_factory, yaml_conf
     tmp_path = tmp_path_factory.mktemp("data", numbered=True)
     config_path = tmp_path / "test_safe_synth.yaml"
     with open(config_path, "w") as f:
-        f.write(yaml_config_str)
+        f.write(fixture_yaml_config_str)
     runner = CliRunner()
     result = runner.invoke(
         cli,
@@ -85,7 +85,7 @@ def test_config_keep_default_with_nested_replacement(tmp_path_factory, yaml_conf
     assert vals["data"]["max_sequences_per_example"] == 2
 
 
-def test_config_accurate_replacement(tmp_path_factory, yaml_config_str):
+def test_config_accurate_replacement(tmp_path_factory, fixture_yaml_config_str):
     """
     Note these tests need to be ran without extra pytest capturing
     to see the print statements, e.g. pytest -s or pytest --log-cli-level=DEBUG
@@ -93,7 +93,7 @@ def test_config_accurate_replacement(tmp_path_factory, yaml_config_str):
     tmp_path = tmp_path_factory.mktemp("data", numbered=True)
     config_path = tmp_path / "test_safe_synth.yaml"
     with open(config_path, "w") as f:
-        f.write(yaml_config_str)
+        f.write(fixture_yaml_config_str)
     runner = CliRunner()
     result = runner.invoke(
         cli,
@@ -120,7 +120,7 @@ def test_config_accurate_replacement(tmp_path_factory, yaml_config_str):
     assert result.exit_code == 0
 
 
-def test_config_accurate_replacement_multiples(tmp_path_factory, yaml_config_str):
+def test_config_accurate_replacement_multiples(tmp_path_factory, fixture_yaml_config_str):
     """
     Note these tests need to be ran without extra pytest capturing
     to see the print statements, e.g. pytest -s or pytest --log-cli-level=DEBUG
@@ -128,7 +128,7 @@ def test_config_accurate_replacement_multiples(tmp_path_factory, yaml_config_str
     tmp_path = tmp_path_factory.mktemp("data", True)
     config_path = tmp_path / "test_safe_synth.yaml"
     with open(config_path, "w") as f:
-        f.write(yaml_config_str)
+        f.write(fixture_yaml_config_str)
     runner = CliRunner()
     result = runner.invoke(
         cli,

--- a/tests/config/conftest.py
+++ b/tests/config/conftest.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""Config test fixtures: parameter objects for config validation tests."""
+
+from __future__ import annotations
+
 import pytest
 
 from nemo_safe_synthesizer.config import (
@@ -13,8 +17,8 @@ from nemo_safe_synthesizer.config import (
 
 
 @pytest.fixture
-def training_hyperparams():
-    """Training hyperparameters for the Safe Synthesizer."""
+def fixture_training_hyperparams() -> TrainingHyperparams:
+    """Minimal TrainingHyperparams with 100 samples, batch 10, 8 grad-accum steps."""
     return TrainingHyperparams(
         num_input_records_to_sample=100,
         batch_size=10,
@@ -24,8 +28,8 @@ def training_hyperparams():
 
 
 @pytest.fixture
-def simple_safe_synthesizer_parameters():
-    """Simple Safe Synthesizer parameters for the Safe Synthesizer."""
+def fixture_simple_safe_synthesizer_parameters() -> SafeSynthesizerParameters:
+    """SafeSynthesizerParameters with group-by, order-by, structured gen, and DP off."""
     return SafeSynthesizerParameters(
         data=DataParameters(
             group_training_examples_by="my_col",

--- a/tests/config/test_nss_config.py
+++ b/tests/config/test_nss_config.py
@@ -98,11 +98,11 @@ class TestValueValidation:
 
 
 class TestParametersClass:
-    def test_parameters_get_method(self, simple_safe_synthesizer_parameters):
-        assert simple_safe_synthesizer_parameters.get("num_input_records_to_sample") == 100
+    def test_parameters_get_method(self, fixture_simple_safe_synthesizer_parameters):
+        assert fixture_simple_safe_synthesizer_parameters.get("num_input_records_to_sample") == 100
 
-    def test_parameters_nesting(self, simple_safe_synthesizer_parameters):
-        assert simple_safe_synthesizer_parameters.get("num_input_records_to_sample") == 100
+    def test_parameters_nesting(self, fixture_simple_safe_synthesizer_parameters):
+        assert fixture_simple_safe_synthesizer_parameters.get("num_input_records_to_sample") == 100
 
     def test_nested_auto_param_round_trip(self, subgroup_fixture, parent_fixture):
         subgroup_py = subgroup_fixture.model_dump()
@@ -146,8 +146,8 @@ class TestSafeSynthesizerParameters:
         )
         assert params.get("max_sequences_per_example") == expected
 
-    def test_parameter_values(self, simple_safe_synthesizer_parameters):
-        params = simple_safe_synthesizer_parameters
+    def test_parameter_values(self, fixture_simple_safe_synthesizer_parameters):
+        params = fixture_simple_safe_synthesizer_parameters
         assert params.get("num_input_records_to_sample") == 100
         assert params.get("batch_size") == 10
         print(params.training)
@@ -187,8 +187,8 @@ class TestSafeSynthesizerParameters:
         assert any("order_training_examples_by" in msg for msg in error_messages)
         assert not any("DP is enabled" in msg for msg in error_messages)
 
-    def test_read_from_yaml(self, yaml_config_str):
-        p = SafeSynthesizerParameters.from_yaml_str(yaml_config_str)
+    def test_read_from_yaml(self, fixture_yaml_config_str):
+        p = SafeSynthesizerParameters.from_yaml_str(fixture_yaml_config_str)
         assert p.get("gradient_accumulation_steps") == 8
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def pytest_collection_modifyitems(config, items):
 
 
 @pytest.fixture()
-def yaml_config_str() -> str:
+def fixture_yaml_config_str() -> str:
     """Return a representative YAML config string covering all SafeSynthesizerParameters sections."""
     return """
 data:

--- a/tests/data_processing/test_assembler.py
+++ b/tests/data_processing/test_assembler.py
@@ -747,8 +747,8 @@ def test_sequential_assembler_sorts_records_by_group_and_order(
     )
 
     assert assembler.training_dataset is not None
-    fixture_training_df = cast(pd.DataFrame, assembler.training_dataset.to_pandas())
-    for chick_id, group_df in fixture_training_df.groupby("Chick"):
+    training_df = cast(pd.DataFrame, assembler.training_dataset.to_pandas())
+    for chick_id, group_df in training_df.groupby("Chick"):
         time_values = group_df["Time"].tolist()
         assert time_values == sorted(time_values), f"Time values not sorted for Chick {chick_id}"
 

--- a/tests/data_processing/test_assembler.py
+++ b/tests/data_processing/test_assembler.py
@@ -747,8 +747,8 @@ def test_sequential_assembler_sorts_records_by_group_and_order(
     )
 
     assert assembler.training_dataset is not None
-    training_df = cast(pd.DataFrame, assembler.training_dataset.to_pandas())
-    for chick_id, group_df in training_df.groupby("Chick"):
+    fixture_training_df = cast(pd.DataFrame, assembler.training_dataset.to_pandas())
+    for chick_id, group_df in fixture_training_df.groupby("Chick"):
         time_values = group_df["Time"].tolist()
         assert time_values == sorted(time_values), f"Time values not sorted for Chick {chick_id}"
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,8 +1,13 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""End-to-end test fixtures: GPU cleanup, temp paths, remote datasets."""
+
+from __future__ import annotations
+
 import gc
 import tempfile
+from collections.abc import Generator
 from pathlib import Path
 
 import pandas as pd
@@ -10,7 +15,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-def cleanup_gpu_memory():
+def cleanup_gpu_memory() -> Generator[None, None, None]:
     """Clean up GPU memory between tests to prevent OOM errors.
 
     This fixture ensures that GPU memory from training models and vLLM
@@ -28,12 +33,14 @@ def cleanup_gpu_memory():
 
 
 @pytest.fixture
-def fixture_save_path():
+def fixture_save_path() -> Path:
+    """Temp directory for e2e test artifacts."""
     return Path(tempfile.mkdtemp(prefix="nemo_safe_synthesizer_tmp"))
 
 
 @pytest.fixture
-def fixture_financial_transactions_dataset():
+def fixture_financial_transactions_dataset() -> pd.DataFrame:
+    """Gretel financial-transactions sample CSV fetched from GitHub."""
     return pd.read_csv(
         "https://raw.githubusercontent.com/gretelai/gretel-blueprints/refs/heads/main/sample_data/financial_transactions.csv"
     )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 import gc
-import tempfile
 from collections.abc import Generator
 from pathlib import Path
 
@@ -33,9 +32,9 @@ def cleanup_gpu_memory() -> Generator[None, None, None]:
 
 
 @pytest.fixture
-def fixture_save_path() -> Path:
-    """Temp directory for e2e test artifacts."""
-    return Path(tempfile.mkdtemp(prefix="nemo_safe_synthesizer_tmp"))
+def fixture_save_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Temp directory for e2e test artifacts; cleanup managed by pytest's tmp_path policy."""
+    return tmp_path_factory.mktemp("nemo_safe_synthesizer_tmp")
 
 
 @pytest.fixture

--- a/tests/evaluation/components/test_attribute_inference_protection.py
+++ b/tests/evaluation/components/test_attribute_inference_protection.py
@@ -19,9 +19,11 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.slow
-def test_attribute_inference_protection(training_df_5k, synthetic_df_5k, test_df):
+def test_attribute_inference_protection(fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df):
     """Test AIA with tabular-only data (sklearn NearestNeighbors path)."""
-    evaluation_datasets = EvaluationDatasets.from_dataframes(training_df_5k, synthetic_df_5k, test_df)
+    evaluation_datasets = EvaluationDatasets.from_dataframes(
+        fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df
+    )
     attribute_inference_protection = AttributeInferenceProtection.from_evaluation_datasets(evaluation_datasets)
     logger.info(attribute_inference_protection.col_accuracy_df)
     assert (
@@ -32,7 +34,9 @@ def test_attribute_inference_protection(training_df_5k, synthetic_df_5k, test_df
 
 @pytest.mark.slow
 @pytest.mark.requires_gpu
-def test_attribute_inference_protection_mixed_text_tabular(training_df_mixed_5k, synthetic_df_mixed_5k, test_df_mixed):
+def test_attribute_inference_protection_mixed_text_tabular(
+    fixture_training_df_mixed_5k, fixture_synthetic_df_mixed_5k, fixture_test_df_mixed
+):
     """Test AIA with mixed text+tabular data (hybrid sklearn + sentence-transformers path).
 
     This test exercises the hybrid nearest neighbor path that combines:
@@ -40,7 +44,9 @@ def test_attribute_inference_protection_mixed_text_tabular(training_df_mixed_5k,
     - sklearn NearestNeighbors for tabular column similarity
     - weighted hybrid distance calculation
     """
-    evaluation_datasets = EvaluationDatasets.from_dataframes(training_df_mixed_5k, synthetic_df_mixed_5k, test_df_mixed)
+    evaluation_datasets = EvaluationDatasets.from_dataframes(
+        fixture_training_df_mixed_5k, fixture_synthetic_df_mixed_5k, fixture_test_df_mixed
+    )
     attribute_inference_protection = AttributeInferenceProtection.from_evaluation_datasets(evaluation_datasets)
 
     logger.info(f"AIA columns evaluated: {attribute_inference_protection.col_accuracy_df}")
@@ -52,14 +58,16 @@ def test_attribute_inference_protection_mixed_text_tabular(training_df_mixed_5k,
 
 
 @pytest.mark.requires_gpu
-def test_attribute_inference_protection_text_only(training_df_text_only, synthetic_df_text_only, test_df_text_only):
+def test_attribute_inference_protection_text_only(
+    fixture_training_df_text_only, fixture_synthetic_df_text_only, fixture_test_df_text_only
+):
     """Test AIA with text-only data (sentence-transformers only, no sklearn).
 
     This test exercises the text-only nearest neighbor path that uses
     only sentence-transformers for semantic similarity search.
     """
     evaluation_datasets = EvaluationDatasets.from_dataframes(
-        training_df_text_only, synthetic_df_text_only, test_df_text_only
+        fixture_training_df_text_only, fixture_synthetic_df_text_only, fixture_test_df_text_only
     )
     attribute_inference_protection = AttributeInferenceProtection.from_evaluation_datasets(evaluation_datasets)
 

--- a/tests/evaluation/components/test_column_distribution.py
+++ b/tests/evaluation/components/test_column_distribution.py
@@ -10,18 +10,18 @@ from nemo_safe_synthesizer.evaluation.data_model.evaluation_datasets import (
 
 
 @pytest.mark.slow
-def test_column_distribution(evaluation_datasets_5k):
+def test_column_distribution(fixture_evaluation_datasets_5k):
     """Statistical analysis on 5k rows - computationally expensive."""
-    column_distribution = ColumnDistribution.from_evaluation_datasets(evaluation_datasets_5k)
+    column_distribution = ColumnDistribution.from_evaluation_datasets(fixture_evaluation_datasets_5k)
     assert column_distribution.name == "Column Distribution Stability"
     assert len(column_distribution.evaluation_fields) == 8
 
 
 @pytest.mark.slow
-def test_column_distribution_text_other(training_df_5k):
+def test_column_distribution_text_other(fixture_training_df_5k):
     """Statistical analysis on 5k rows - computationally expensive."""
     evaluation_datasets = EvaluationDatasets.from_dataframes(
-        training_df_5k[["text", "other"]], training_df_5k[["text", "other"]], None
+        fixture_training_df_5k[["text", "other"]], fixture_training_df_5k[["text", "other"]], None
     )
     column_distribution = ColumnDistribution.from_evaluation_datasets(evaluation_datasets)
     assert column_distribution.score.score is None

--- a/tests/evaluation/components/test_composite_score.py
+++ b/tests/evaluation/components/test_composite_score.py
@@ -38,8 +38,8 @@ def deep_structure_stability():
 
 
 @pytest.fixture
-def column_distribution_stability(evaluation_datasets_5k):
-    return ColumnDistribution.from_evaluation_datasets(evaluation_datasets_5k)
+def column_distribution_stability(fixture_evaluation_datasets_5k):
+    return ColumnDistribution.from_evaluation_datasets(fixture_evaluation_datasets_5k)
 
 
 @pytest.fixture

--- a/tests/evaluation/components/test_correlation.py
+++ b/tests/evaluation/components/test_correlation.py
@@ -15,9 +15,11 @@ from nemo_safe_synthesizer.evaluation.data_model.evaluation_score import Grade
 
 
 @pytest.mark.slow
-def test_correlation(training_df_5k, synthetic_df_5k, test_df):
+def test_correlation(fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df):
     """Correlation matrix computation on 5k rows - computationally expensive."""
-    evaluation_datasets = EvaluationDatasets.from_dataframes(training_df_5k, synthetic_df_5k, test_df)
+    evaluation_datasets = EvaluationDatasets.from_dataframes(
+        fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df
+    )
     correlation = Correlation.from_evaluation_datasets(evaluation_datasets)
 
     assert correlation.name == "Column Correlation Stability"
@@ -39,14 +41,16 @@ def test_correlation(training_df_5k, synthetic_df_5k, test_df):
 
 
 @pytest.mark.slow
-def test_correlation_all_numeric(training_df_5k, synthetic_df_5k, test_df):
+def test_correlation_all_numeric(fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df):
     """Correlation matrix computation on 5k rows - computationally expensive."""
     # We should still do correlation if no nominal columns
     nominal_columns = ["num_cat", "num_cat_Int64", "small_cat", "boolean"]
-    training_df_5k = training_df_5k.drop(nominal_columns, axis=1)
-    synthetic_df_5k = synthetic_df_5k.drop(nominal_columns, axis=1)
+    fixture_training_df_5k = fixture_training_df_5k.drop(nominal_columns, axis=1)
+    fixture_synthetic_df_5k = fixture_synthetic_df_5k.drop(nominal_columns, axis=1)
 
-    evaluation_datasets = EvaluationDatasets.from_dataframes(training_df_5k, synthetic_df_5k, test_df)
+    evaluation_datasets = EvaluationDatasets.from_dataframes(
+        fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df
+    )
     correlation = Correlation.from_evaluation_datasets(evaluation_datasets)
 
     assert correlation.name == "Column Correlation Stability"
@@ -60,15 +64,17 @@ def test_correlation_all_numeric(training_df_5k, synthetic_df_5k, test_df):
 
 
 @pytest.mark.slow
-def test_correlation_not_enough_columns(training_df_5k, synthetic_df_5k, test_df, caplog):
+def test_correlation_not_enough_columns(fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df, caplog):
     """Correlation matrix computation on 5k rows - computationally expensive."""
     caplog.set_level(logging.INFO)
 
     # Two columns, one is text. We will not have enough to do correlations.
-    training_df_5k = training_df_5k[["num_cat", "text"]]
-    synthetic_df_5k = synthetic_df_5k[["num_cat", "text"]]
+    fixture_training_df_5k = fixture_training_df_5k[["num_cat", "text"]]
+    fixture_synthetic_df_5k = fixture_synthetic_df_5k[["num_cat", "text"]]
 
-    evaluation_datasets = EvaluationDatasets.from_dataframes(training_df_5k, synthetic_df_5k, test_df)
+    evaluation_datasets = EvaluationDatasets.from_dataframes(
+        fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df
+    )
     correlation = Correlation.from_evaluation_datasets(evaluation_datasets)
 
     assert correlation.name == "Column Correlation Stability"

--- a/tests/evaluation/components/test_deep_structure.py
+++ b/tests/evaluation/components/test_deep_structure.py
@@ -9,9 +9,9 @@ from nemo_safe_synthesizer.evaluation.data_model.evaluation_score import Grade
 
 
 @pytest.mark.slow
-def test_deep_structure(evaluation_datasets_5k):
+def test_deep_structure(fixture_evaluation_datasets_5k):
     """PCA (Principal Component Analysis) on 5k rows - very computationally expensive."""
-    deep_structure = DeepStructure.from_evaluation_datasets(evaluation_datasets_5k)
+    deep_structure = DeepStructure.from_evaluation_datasets(fixture_evaluation_datasets_5k)
     assert deep_structure.name == "Deep Structure Stability"
     assert deep_structure.score.score is not None and deep_structure.score.score > 0
     assert deep_structure.training_pca is not None
@@ -20,12 +20,12 @@ def test_deep_structure(evaluation_datasets_5k):
     assert deep_structure.synthetic_pca.shape == (5000, 2)
 
 
-def test_too_few_cols(training_df, synthetic_df, test_df):
+def test_too_few_cols(fixture_training_df, fixture_synthetic_df, fixture_test_df):
     """Edge case test - small dataset, should be fast."""
-    training_df = training_df[["num"]]
-    synthetic_df = synthetic_df[["num"]]
-    test_df = test_df[["num"]]
-    evaluation_datasets = EvaluationDatasets.from_dataframes(training_df, synthetic_df, test_df)
+    fixture_training_df = fixture_training_df[["num"]]
+    fixture_synthetic_df = fixture_synthetic_df[["num"]]
+    fixture_test_df = fixture_test_df[["num"]]
+    evaluation_datasets = EvaluationDatasets.from_dataframes(fixture_training_df, fixture_synthetic_df, fixture_test_df)
     deep_structure = DeepStructure.from_evaluation_datasets(evaluation_datasets)
     assert deep_structure.name == "Deep Structure Stability"
     assert deep_structure.training_pca is None

--- a/tests/evaluation/components/test_membership_inference_protection.py
+++ b/tests/evaluation/components/test_membership_inference_protection.py
@@ -18,9 +18,11 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.requires_gpu
-def test_membership_inference_protection(training_df_5k, synthetic_df_5k, test_df):
+def test_membership_inference_protection(fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df):
     """Test MIA with tabular-only data (sklearn NearestNeighbors path)."""
-    evaluation_datasets = EvaluationDatasets.from_dataframes(training_df_5k, synthetic_df_5k, test_df)
+    evaluation_datasets = EvaluationDatasets.from_dataframes(
+        fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df
+    )
     membership_inference_protection = MembershipInferenceProtection.from_evaluation_datasets(evaluation_datasets)
 
     logger.info(membership_inference_protection.attack_sum_df)
@@ -39,7 +41,9 @@ def test_membership_inference_protection(training_df_5k, synthetic_df_5k, test_d
 
 
 @pytest.mark.requires_gpu
-def test_membership_inference_protection_mixed_text_tabular(training_df_mixed_5k, synthetic_df_mixed_5k, test_df_mixed):
+def test_membership_inference_protection_mixed_text_tabular(
+    fixture_training_df_mixed_5k, fixture_synthetic_df_mixed_5k, fixture_test_df_mixed
+):
     """Test MIA with mixed text+tabular data (hybrid sklearn + sentence-transformers path).
 
     This test exercises the hybrid nearest neighbor path that combines:
@@ -47,7 +51,9 @@ def test_membership_inference_protection_mixed_text_tabular(training_df_mixed_5k
     - sklearn NearestNeighbors for tabular column similarity
     - weighted hybrid distance calculation
     """
-    evaluation_datasets = EvaluationDatasets.from_dataframes(training_df_mixed_5k, synthetic_df_mixed_5k, test_df_mixed)
+    evaluation_datasets = EvaluationDatasets.from_dataframes(
+        fixture_training_df_mixed_5k, fixture_synthetic_df_mixed_5k, fixture_test_df_mixed
+    )
     membership_inference_protection = MembershipInferenceProtection.from_evaluation_datasets(evaluation_datasets)
 
     logger.info(f"MIA attack summary: {membership_inference_protection.attack_sum_df}")
@@ -65,14 +71,16 @@ def test_membership_inference_protection_mixed_text_tabular(training_df_mixed_5k
 
 
 @pytest.mark.requires_gpu
-def test_membership_inference_protection_text_only(training_df_text_only, synthetic_df_text_only, test_df_text_only):
+def test_membership_inference_protection_text_only(
+    fixture_training_df_text_only, fixture_synthetic_df_text_only, fixture_test_df_text_only
+):
     """Test MIA with text-only data (sentence-transformers only, no sklearn).
 
     This test exercises the text-only nearest neighbor path that uses
     only sentence-transformers for semantic similarity search.
     """
     evaluation_datasets = EvaluationDatasets.from_dataframes(
-        training_df_text_only, synthetic_df_text_only, test_df_text_only
+        fixture_training_df_text_only, fixture_synthetic_df_text_only, fixture_test_df_text_only
     )
     membership_inference_protection = MembershipInferenceProtection.from_evaluation_datasets(evaluation_datasets)
 

--- a/tests/evaluation/components/test_multi_modal_figures.py
+++ b/tests/evaluation/components/test_multi_modal_figures.py
@@ -246,10 +246,6 @@ class TestGenerateAiaFigure:
         fig = generate_aia_figure(df)
 
         assert isinstance(fig, go.Figure)
-        df = fixture_mia_aia_df
-        fig = generate_aia_figure(df)
-
-        assert isinstance(fig, go.Figure)
 
 
 class TestCorrelationHeatmap:
@@ -323,10 +319,10 @@ class TestStructureStabilityFigure:
     """Tests for structure_stability_figure function."""
 
     def test_structure_stability_figure_basic(self):
-        fixture_training_df = pd.DataFrame({"pc1": np.random.randn(100), "pc2": np.random.randn(100)})
-        fixture_synthetic_df = pd.DataFrame({"pc1": np.random.randn(100), "pc2": np.random.randn(100)})
+        training_df = pd.DataFrame({"pc1": np.random.randn(100), "pc2": np.random.randn(100)})
+        synthetic_df = pd.DataFrame({"pc1": np.random.randn(100), "pc2": np.random.randn(100)})
 
-        fig = structure_stability_figure(fixture_training_df, fixture_synthetic_df)
+        fig = structure_stability_figure(training_df, synthetic_df)
 
         assert isinstance(fig, go.Figure)
         assert fig.layout.height == 420

--- a/tests/evaluation/components/test_multi_modal_figures.py
+++ b/tests/evaluation/components/test_multi_modal_figures.py
@@ -204,16 +204,16 @@ class TestGetAutoBins:
 class TestGenerateMiaFigure:
     """Tests for generate_mia_figure function."""
 
-    def test_generate_mia_figure_basic(self, mia_aia_df):
-        df = mia_aia_df
+    def test_generate_mia_figure_basic(self, fixture_mia_aia_df):
+        df = fixture_mia_aia_df
         fig = generate_mia_figure(df)
 
         assert isinstance(fig, go.Figure)
         assert len(fig.data) == 1
         assert isinstance(fig.data[0], go.Pie)
 
-    def test_generate_mia_figure_with_zero_percentages(self, mia_aia_df):
-        df = mia_aia_df
+    def test_generate_mia_figure_with_zero_percentages(self, fixture_mia_aia_df):
+        df = fixture_mia_aia_df
         df.loc[df["Attack Percentage"] == 0, "Attack Percentage"] = np.nan
         fig = generate_mia_figure(df)
 
@@ -221,8 +221,8 @@ class TestGenerateMiaFigure:
         assert len(fig.data) == 1
         assert isinstance(fig.data[0], go.Pie)
 
-    def test_generate_mia_figure_with_nan_percentages(self, mia_aia_df_with_nan_protection):
-        df = mia_aia_df_with_nan_protection
+    def test_generate_mia_figure_with_nan_percentages(self, fixture_mia_aia_df_with_nan_protection):
+        df = fixture_mia_aia_df_with_nan_protection
         fig = generate_mia_figure(df)
 
         assert isinstance(fig, go.Figure)
@@ -230,9 +230,9 @@ class TestGenerateMiaFigure:
         pie_trace = fig.data[0]
         assert pie_trace is not None
 
-    def test_generate_mia_figure_ordering(self, mia_aia_df):
+    def test_generate_mia_figure_ordering(self, fixture_mia_aia_df):
         # Test that the figure sorts by Protection grade
-        df = mia_aia_df
+        df = fixture_mia_aia_df
         fig = generate_mia_figure(df)
 
         assert isinstance(fig, go.Figure)
@@ -241,12 +241,12 @@ class TestGenerateMiaFigure:
 class TestGenerateAiaFigure:
     """Tests for generate_aia_figure function."""
 
-    def test_generate_aia_figure_basic(self, mia_aia_df):
-        df = mia_aia_df
+    def test_generate_aia_figure_basic(self, fixture_mia_aia_df):
+        df = fixture_mia_aia_df
         fig = generate_aia_figure(df)
 
         assert isinstance(fig, go.Figure)
-        df = mia_aia_df
+        df = fixture_mia_aia_df
         fig = generate_aia_figure(df)
 
         assert isinstance(fig, go.Figure)
@@ -255,16 +255,16 @@ class TestGenerateAiaFigure:
 class TestCorrelationHeatmap:
     """Tests for correlation_heatmap function."""
 
-    def test_correlation_heatmap_basic(self, mia_aia_df):
-        matrix = mia_aia_df
+    def test_correlation_heatmap_basic(self, fixture_mia_aia_df):
+        matrix = fixture_mia_aia_df
         fig = correlation_heatmap(matrix)
 
         assert isinstance(fig, go.Figure)
         assert len(fig.data) == 1
         assert isinstance(fig.data[0], go.Heatmap)
 
-    def test_correlation_heatmap_truncates_long_names(self, mia_aia_df):
-        matrix = mia_aia_df
+    def test_correlation_heatmap_truncates_long_names(self, fixture_mia_aia_df):
+        matrix = fixture_mia_aia_df
         fig = correlation_heatmap(matrix)
 
         assert isinstance(fig, go.Figure)
@@ -291,16 +291,16 @@ class TestGenerateCombinedCorrelationFigure:
 class TestScatterPlot:
     """Tests for scatter_plot function."""
 
-    def test_scatter_plot_basic(self, mia_aia_df):
-        x = mia_aia_df["Risk"]
-        y = mia_aia_df["Attack Percentage"]
+    def test_scatter_plot_basic(self, fixture_mia_aia_df):
+        x = fixture_mia_aia_df["Risk"]
+        y = fixture_mia_aia_df["Attack Percentage"]
         fig = scatter_plot(x, y)
 
         assert isinstance(fig, go.Figure)
 
-    def test_scatter_plot_respects_maximum_points(self, mia_aia_df):
-        x = mia_aia_df["Risk"]
-        y = mia_aia_df["Attack Percentage"]
+    def test_scatter_plot_respects_maximum_points(self, fixture_mia_aia_df):
+        x = fixture_mia_aia_df["Risk"]
+        y = fixture_mia_aia_df["Attack Percentage"]
         fig = scatter_plot(x, y, maximum_points=100)
 
         assert isinstance(fig, go.Figure)
@@ -308,9 +308,9 @@ class TestScatterPlot:
         scatter_trace = fig.data[0]
         assert len(scatter_trace.x) <= 100
 
-    def test_scatter_plot_no_cap_when_zero(self, mia_aia_df):
-        x = mia_aia_df["Risk"]
-        y = mia_aia_df["Attack Percentage"]
+    def test_scatter_plot_no_cap_when_zero(self, fixture_mia_aia_df):
+        x = fixture_mia_aia_df["Risk"]
+        y = fixture_mia_aia_df["Attack Percentage"]
         fig = scatter_plot(x, y, maximum_points=0)
 
         assert isinstance(fig, go.Figure)
@@ -323,10 +323,10 @@ class TestStructureStabilityFigure:
     """Tests for structure_stability_figure function."""
 
     def test_structure_stability_figure_basic(self):
-        training_df = pd.DataFrame({"pc1": np.random.randn(100), "pc2": np.random.randn(100)})
-        synthetic_df = pd.DataFrame({"pc1": np.random.randn(100), "pc2": np.random.randn(100)})
+        fixture_training_df = pd.DataFrame({"pc1": np.random.randn(100), "pc2": np.random.randn(100)})
+        fixture_synthetic_df = pd.DataFrame({"pc1": np.random.randn(100), "pc2": np.random.randn(100)})
 
-        fig = structure_stability_figure(training_df, synthetic_df)
+        fig = structure_stability_figure(fixture_training_df, fixture_synthetic_df)
 
         assert isinstance(fig, go.Figure)
         assert fig.layout.height == 420

--- a/tests/evaluation/components/test_pii_replay.py
+++ b/tests/evaluation/components/test_pii_replay.py
@@ -12,10 +12,10 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.slow
-def test_pii_replay(training_df_5k, synthetic_df_5k, test_df, column_statistics):
+def test_pii_replay(fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df, fixture_column_statistics):
     """PII analysis on 5k rows - computationally expensive."""
     evaluation_datasets = EvaluationDatasets.from_dataframes(
-        training_df_5k, synthetic_df_5k, test_df, column_statistics
+        fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df, fixture_column_statistics
     )
     pii_replay = PIIReplay.from_evaluation_datasets(evaluation_datasets)
 

--- a/tests/evaluation/components/test_privacy_metric_utils.py
+++ b/tests/evaluation/components/test_privacy_metric_utils.py
@@ -28,15 +28,15 @@ def mock_embedder():
     return embedder
 
 
-def test_divide_tabular_text(training_df):
+def test_divide_tabular_text(fixture_training_df):
     text_fields = ["text", "other"]
-    tabular, text = divide_tabular_text(training_df, text_fields)
+    tabular, text = divide_tabular_text(fixture_training_df, text_fields)
 
     assert "text" not in tabular.columns
     assert "other" not in tabular.columns
     assert set(text.columns) == {"other", "text"}
-    assert len(tabular) == len(training_df)
-    assert len(text) == len(training_df)
+    assert len(tabular) == len(fixture_training_df)
+    assert len(text) == len(fixture_training_df)
 
 
 def test_embed_text(mock_embedder):

--- a/tests/evaluation/conftest.py
+++ b/tests/evaluation/conftest.py
@@ -134,6 +134,7 @@ def fixture_dp_not_enabled_config() -> SafeSynthesizerParameters:
 
 @pytest.fixture
 def fixture_column_statistics(fixture_training_df_5k) -> dict[str, ColumnStatistics]:
+    """ColumnStatistics for `small_cat` and `other` columns derived from the 5k training DataFrame."""
     small_cat_values = {"foo", "bar"}
     small_cat_count = len(fixture_training_df_5k["small_cat"].to_frame().query("`small_cat` in @small_cat_values"))
     other_cat_values = {"barf"}

--- a/tests/evaluation/conftest.py
+++ b/tests/evaluation/conftest.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""Evaluation test fixtures: synthetic/training/test DataFrames and evaluation configs."""
+
+from __future__ import annotations
+
 import random
 
 import faker
@@ -58,52 +62,64 @@ def make_df(seed: int, n: int = 100):
 
 
 @pytest.fixture
-def training_df():
+def fixture_training_df() -> pd.DataFrame:
+    """100-row training DataFrame seeded at 370."""
     return make_df(370)
 
 
 @pytest.fixture
-def training_df_5k():
+def fixture_training_df_5k() -> pd.DataFrame:
+    """5 000-row training DataFrame seeded at 370."""
     return make_df(370, 5000)
 
 
 @pytest.fixture
-def training_df_10k():
+def fixture_training_df_10k() -> pd.DataFrame:
+    """10 000-row training DataFrame seeded at 370."""
     return make_df(370, 10000)
 
 
 @pytest.fixture
-def synthetic_df():
+def fixture_synthetic_df() -> pd.DataFrame:
+    """100-row synthetic DataFrame seeded at 753."""
     return make_df(753)
 
 
 @pytest.fixture
-def synthetic_df_5k():
+def fixture_synthetic_df_5k() -> pd.DataFrame:
+    """5 000-row synthetic DataFrame seeded at 753."""
     return make_df(753, 5000)
 
 
 @pytest.fixture
-def synthetic_df_10k():
+def fixture_synthetic_df_10k() -> pd.DataFrame:
+    """10 000-row synthetic DataFrame seeded at 753."""
     return make_df(753, 10000)
 
 
 @pytest.fixture
-def test_df():
+def fixture_test_df() -> pd.DataFrame:
+    """100-row holdout test DataFrame seeded at 476."""
     return make_df(476)
 
 
 @pytest.fixture
-def evaluation_datasets_5k(training_df_5k, synthetic_df_5k, test_df):
-    return EvaluationDatasets.from_dataframes(training_df_5k, synthetic_df_5k, test_df)
+def fixture_evaluation_datasets_5k(
+    fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df
+) -> EvaluationDatasets:
+    """EvaluationDatasets built from 5k training/synthetic and 100-row test."""
+    return EvaluationDatasets.from_dataframes(fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df)
 
 
 @pytest.fixture
-def skip_privacy_metrics_config():
+def fixture_skip_privacy_metrics_config() -> SafeSynthesizerParameters:
+    """Config with MIA and AIA disabled."""
     return SafeSynthesizerParameters(evaluation=EvaluationParameters(mia_enabled=False, aia_enabled=False))
 
 
 @pytest.fixture
-def dp_enabled_config():
+def fixture_dp_enabled_config() -> SafeSynthesizerParameters:
+    """Config with DP enabled (epsilon=0.2, delta=0.1) and AIA on."""
     return SafeSynthesizerParameters(
         privacy=DifferentialPrivacyHyperparams(dp_enabled=True, delta=0.1, epsilon=0.2),
         evaluation=EvaluationParameters(mia_enabled=False, aia_enabled=True),
@@ -111,16 +127,17 @@ def dp_enabled_config():
 
 
 @pytest.fixture
-def dp_not_enabled_config():
+def fixture_dp_not_enabled_config() -> SafeSynthesizerParameters:
+    """Config with DP disabled but AIA enabled."""
     return SafeSynthesizerParameters(evaluation=EvaluationParameters(mia_enabled=False, aia_enabled=True))
 
 
 @pytest.fixture
-def column_statistics(training_df_5k):
+def fixture_column_statistics(fixture_training_df_5k) -> dict[str, ColumnStatistics]:
     small_cat_values = {"foo", "bar"}
-    small_cat_count = len(training_df_5k["small_cat"].to_frame().query("`small_cat` in @small_cat_values"))
+    small_cat_count = len(fixture_training_df_5k["small_cat"].to_frame().query("`small_cat` in @small_cat_values"))
     other_cat_values = {"barf"}
-    other_cat_count = len(training_df_5k["small_cat"].to_frame().query("`small_cat` in @other_cat_values"))
+    other_cat_count = len(fixture_training_df_5k["small_cat"].to_frame().query("`small_cat` in @other_cat_values"))
     small_cat_col_stats = ColumnStatistics(
         assigned_type="text",
         assigned_entity="some_cats",
@@ -130,7 +147,7 @@ def column_statistics(training_df_5k):
         transform_functions={"fake", "munge"},
     )
 
-    other_values = set(training_df_5k["other"].head(250))
+    other_values = set(fixture_training_df_5k["other"].head(250))
     other_count = len(other_values)
     other_col_stats = ColumnStatistics(
         assigned_type="text",
@@ -152,7 +169,7 @@ def column_statistics(training_df_5k):
 
 
 @pytest.fixture
-def mia_aia_df():
+def fixture_mia_aia_df() -> pd.DataFrame:
     fake = faker.Faker("en_US")
     fake.seed_instance(546)
     random.seed(302)
@@ -250,43 +267,43 @@ def make_text_only_df(seed: int, n: int = 100):
 
 
 @pytest.fixture
-def training_df_text_only():
+def fixture_training_df_text_only() -> pd.DataFrame:
     """Training DataFrame with only text columns (500 rows)."""
     return make_text_only_df(seed=444, n=500)
 
 
 @pytest.fixture
-def synthetic_df_text_only():
+def fixture_synthetic_df_text_only() -> pd.DataFrame:
     """Synthetic DataFrame with only text columns (500 rows)."""
     return make_text_only_df(seed=555, n=500)
 
 
 @pytest.fixture
-def test_df_text_only():
+def fixture_test_df_text_only() -> pd.DataFrame:
     """Test DataFrame with only text columns (100 rows)."""
     return make_text_only_df(seed=666, n=100)
 
 
 @pytest.fixture
-def training_df_mixed_5k():
+def fixture_training_df_mixed_5k() -> pd.DataFrame:
     """Training DataFrame with mixed text+tabular columns (5000 rows)."""
     return make_mixed_text_tabular_df(seed=111, n=5000)
 
 
 @pytest.fixture
-def synthetic_df_mixed_5k():
+def fixture_synthetic_df_mixed_5k() -> pd.DataFrame:
     """Synthetic DataFrame with mixed text+tabular columns (5000 rows)."""
     return make_mixed_text_tabular_df(seed=222, n=5000)
 
 
 @pytest.fixture
-def test_df_mixed():
+def fixture_test_df_mixed() -> pd.DataFrame:
     """Test DataFrame with mixed text+tabular columns (100 rows)."""
     return make_mixed_text_tabular_df(seed=333, n=100)
 
 
 @pytest.fixture
-def mia_aia_df_with_nan_protection():
+def fixture_mia_aia_df_with_nan_protection() -> pd.DataFrame:
     """I'm not sure how often we get nans like this
     but we've seen errors like this in the wild:
     """

--- a/tests/evaluation/conftest.py
+++ b/tests/evaluation/conftest.py
@@ -305,9 +305,7 @@ def fixture_test_df_mixed() -> pd.DataFrame:
 
 @pytest.fixture
 def fixture_mia_aia_df_with_nan_protection() -> pd.DataFrame:
-    """I'm not sure how often we get nans like this
-    but we've seen errors like this in the wild:
-    """
+    """MIA/AIA DataFrame with NaN values in the Protection and Attack Percentage columns (regression data)."""
     fake = faker.Faker("en_US")
     fake.seed_instance(546)
     random.seed(302)

--- a/tests/evaluation/datamodel/test_evaluation_datasets.py
+++ b/tests/evaluation/datamodel/test_evaluation_datasets.py
@@ -13,8 +13,8 @@ from nemo_safe_synthesizer.evaluation.data_model.evaluation_datasets import (
 )
 
 
-def test_from_dataframes_happy_path(training_df, synthetic_df, test_df):
-    evaluation_datasets = EvaluationDatasets.from_dataframes(training_df, synthetic_df, test_df)
+def test_from_dataframes_happy_path(fixture_training_df, fixture_synthetic_df, fixture_test_df):
+    evaluation_datasets = EvaluationDatasets.from_dataframes(fixture_training_df, fixture_synthetic_df, fixture_test_df)
 
     assert evaluation_datasets is not None
     assert len(evaluation_datasets.training) == 100
@@ -61,8 +61,10 @@ def test_from_dataframes_happy_path(training_df, synthetic_df, test_df):
             assert f.distribution_distance is None
 
 
-def test_from_dataframes_with_sampling(training_df_5k, synthetic_df_5k, test_df):
-    evaluation_datasets = EvaluationDatasets.from_dataframes(training_df_5k, synthetic_df_5k, test_df, rows=1000)
+def test_from_dataframes_with_sampling(fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df):
+    evaluation_datasets = EvaluationDatasets.from_dataframes(
+        fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df, rows=1000
+    )
 
     assert evaluation_datasets is not None
     assert len(evaluation_datasets.training) == 1000
@@ -73,39 +75,39 @@ def test_from_dataframes_with_sampling(training_df_5k, synthetic_df_5k, test_df)
     assert len(evaluation_datasets.evaluation_fields) == 8
 
 
-def test_degenerate_input(synthetic_df_5k, test_df):
+def test_degenerate_input(fixture_synthetic_df_5k, fixture_test_df):
     with pytest.raises(ValueError):
-        EvaluationDatasets.from_dataframes(None, synthetic_df_5k, test_df)  # ty: ignore[invalid-argument-type]
+        EvaluationDatasets.from_dataframes(None, fixture_synthetic_df_5k, fixture_test_df)  # ty: ignore[invalid-argument-type]
     with pytest.raises(ValueError):
-        EvaluationDatasets.from_dataframes(pd.DataFrame(), synthetic_df_5k, test_df)
+        EvaluationDatasets.from_dataframes(pd.DataFrame(), fixture_synthetic_df_5k, fixture_test_df)
 
 
-def test_column_intersection(training_df, synthetic_df, test_df):
-    training_df = training_df[["num", "num_cat"]]
-    synthetic_df = synthetic_df[["num", "other"]]
-    test_df = test_df[["num", "text"]]
-    evaluation_datasets = EvaluationDatasets.from_dataframes(training_df, synthetic_df, test_df)
+def test_column_intersection(fixture_training_df, fixture_synthetic_df, fixture_test_df):
+    fixture_training_df = fixture_training_df[["num", "num_cat"]]
+    fixture_synthetic_df = fixture_synthetic_df[["num", "other"]]
+    fixture_test_df = fixture_test_df[["num", "text"]]
+    evaluation_datasets = EvaluationDatasets.from_dataframes(fixture_training_df, fixture_synthetic_df, fixture_test_df)
     assert len(evaluation_datasets.evaluation_fields) == 1
     assert evaluation_datasets.evaluation_fields[0].name == "num"
 
 
-def test_empty_column_intersection(training_df, synthetic_df):
-    training_df = training_df[["num", "num_cat"]]
-    synthetic_df = synthetic_df[["other", "text"]]
+def test_empty_column_intersection(fixture_training_df, fixture_synthetic_df):
+    fixture_training_df = fixture_training_df[["num", "num_cat"]]
+    fixture_synthetic_df = fixture_synthetic_df[["other", "text"]]
     with pytest.raises(ValueError):
-        EvaluationDatasets.from_dataframes(training_df, synthetic_df)
+        EvaluationDatasets.from_dataframes(fixture_training_df, fixture_synthetic_df)
 
 
-def test_empty_testdf_intersection(training_df, synthetic_df, test_df):
-    training_df = training_df[["num", "num_cat"]]
-    synthetic_df = synthetic_df[["num", "num_cat"]]
-    test_df = test_df[["other", "text"]]
+def test_empty_testdf_intersection(fixture_training_df, fixture_synthetic_df, fixture_test_df):
+    fixture_training_df = fixture_training_df[["num", "num_cat"]]
+    fixture_synthetic_df = fixture_synthetic_df[["num", "num_cat"]]
+    fixture_test_df = fixture_test_df[["other", "text"]]
     with pytest.raises(ValueError):
-        EvaluationDatasets.from_dataframes(training_df, synthetic_df, test_df)
+        EvaluationDatasets.from_dataframes(fixture_training_df, fixture_synthetic_df, fixture_test_df)
 
 
-def test_get_columns_of_type(training_df):
-    dataset = EvaluationDatasets.from_dataframes(training_df, training_df, training_df)
+def test_get_columns_of_type(fixture_training_df):
+    dataset = EvaluationDatasets.from_dataframes(fixture_training_df, fixture_training_df, fixture_training_df)
     assert set(dataset.get_tabular_columns()) == set(
         ["num", "num_Int64", "num_cat", "num_cat_Int64", "small_cat", "boolean"]
     )

--- a/tests/evaluation/reports/test_multimodal_report.py
+++ b/tests/evaluation/reports/test_multimodal_report.py
@@ -16,9 +16,9 @@ from nemo_safe_synthesizer.evaluation.reports.multimodal.multimodal_report impor
 
 
 def _minimal_multimodal_report() -> MultimodalReport:
-    training_df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
-    synthetic_df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
-    datasets = EvaluationDatasets(training=training_df, synthetic=synthetic_df)
+    fixture_training_df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+    fixture_synthetic_df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+    datasets = EvaluationDatasets(training=fixture_training_df, synthetic=fixture_synthetic_df)
     return MultimodalReport(evaluation_datasets=datasets, components=[])
 
 
@@ -37,9 +37,14 @@ def test_jinja_context_job_id_set_when_nemo_job_id_present(monkeypatch: pytest.M
 
 
 @pytest.mark.skip(reason="Times out")
-def test_multimodal_report(training_df_5k, synthetic_df_5k, test_df, skip_privacy_metrics_config):
+def test_multimodal_report(
+    fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df, fixture_skip_privacy_metrics_config
+):
     report = MultimodalReport.from_dataframes(
-        training=training_df_5k, synthetic=synthetic_df_5k, test=test_df, config=skip_privacy_metrics_config
+        training=fixture_training_df_5k,
+        synthetic=fixture_synthetic_df_5k,
+        test=fixture_test_df,
+        config=fixture_skip_privacy_metrics_config,
     )
 
     assert len(report.components) == 11

--- a/tests/evaluation/reports/test_multimodal_report.py
+++ b/tests/evaluation/reports/test_multimodal_report.py
@@ -16,9 +16,9 @@ from nemo_safe_synthesizer.evaluation.reports.multimodal.multimodal_report impor
 
 
 def _minimal_multimodal_report() -> MultimodalReport:
-    fixture_training_df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
-    fixture_synthetic_df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
-    datasets = EvaluationDatasets(training=fixture_training_df, synthetic=fixture_synthetic_df)
+    training_df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+    synthetic_df = pd.DataFrame({"x": [1, 2], "y": [3, 4]})
+    datasets = EvaluationDatasets(training=training_df, synthetic=synthetic_df)
     return MultimodalReport(evaluation_datasets=datasets, components=[])
 
 

--- a/tests/evaluation/test_render.py
+++ b/tests/evaluation/test_render.py
@@ -14,13 +14,19 @@ from nemo_safe_synthesizer.evaluation.reports.multimodal.multimodal_report impor
 
 
 @pytest.mark.slow
-def test_render(training_df_10k, synthetic_df_10k, test_df, skip_privacy_metrics_config, column_statistics):
+def test_render(
+    fixture_training_df_10k,
+    fixture_synthetic_df_10k,
+    fixture_test_df,
+    fixture_skip_privacy_metrics_config,
+    fixture_column_statistics,
+):
     report = MultimodalReport.from_dataframes(
-        training=training_df_10k,
-        synthetic=synthetic_df_10k,
-        test=test_df,
-        config=skip_privacy_metrics_config,
-        column_statistics=column_statistics,
+        training=fixture_training_df_10k,
+        synthetic=fixture_synthetic_df_10k,
+        test=fixture_test_df,
+        config=fixture_skip_privacy_metrics_config,
+        column_statistics=fixture_column_statistics,
     )
     output = render_report(report, "multi_modal_report.j2")
     assert output is not None
@@ -39,13 +45,19 @@ def test_render(training_df_10k, synthetic_df_10k, test_df, skip_privacy_metrics
 
 
 @pytest.mark.slow
-def test_render_dp_enabled(training_df_5k, synthetic_df_5k, test_df, dp_enabled_config, column_statistics):
+def test_render_dp_enabled(
+    fixture_training_df_5k,
+    fixture_synthetic_df_5k,
+    fixture_test_df,
+    fixture_dp_enabled_config,
+    fixture_column_statistics,
+):
     report = MultimodalReport.from_dataframes(
-        training=training_df_5k,
-        synthetic=synthetic_df_5k,
-        test=test_df,
-        config=dp_enabled_config,
-        column_statistics=column_statistics,
+        training=fixture_training_df_5k,
+        synthetic=fixture_synthetic_df_5k,
+        test=fixture_test_df,
+        config=fixture_dp_enabled_config,
+        column_statistics=fixture_column_statistics,
     )
     output = render_report(report, "multi_modal_report.j2")
     # output = render_report(report, "multi_modal_report.j2", "/tmp/test_mm_report_dp_enabled.html")
@@ -59,13 +71,19 @@ def test_render_dp_enabled(training_df_5k, synthetic_df_5k, test_df, dp_enabled_
 
 
 @pytest.mark.slow
-def test_render_dp_not_enabled(training_df_5k, synthetic_df_5k, test_df, dp_not_enabled_config, column_statistics):
+def test_render_dp_not_enabled(
+    fixture_training_df_5k,
+    fixture_synthetic_df_5k,
+    fixture_test_df,
+    fixture_dp_not_enabled_config,
+    fixture_column_statistics,
+):
     report = MultimodalReport.from_dataframes(
-        training=training_df_5k,
-        synthetic=synthetic_df_5k,
-        test=test_df,
-        config=dp_not_enabled_config,
-        column_statistics=column_statistics,
+        training=fixture_training_df_5k,
+        synthetic=fixture_synthetic_df_5k,
+        test=fixture_test_df,
+        config=fixture_dp_not_enabled_config,
+        column_statistics=fixture_column_statistics,
     )
     output = render_report(report, "multi_modal_report.j2")
     # output = render_report(report, "multi_modal_report.j2", "/tmp/test_mm_report_dp_not_enabled.html")

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -55,14 +55,14 @@ The shared fixtures cover both CPU and GPU smoke tests. Session-scoped fixtures 
 
 Session-scoped (immutable / read-only):
 
-- `base_smoke_config` -- default `SafeSynthesizerParameters` pointing at the local tiny model (Pydantic frozen model)
+- `fixture_base_smoke_config` -- default `SafeSynthesizerParameters` pointing at the local tiny model (Pydantic frozen model)
 - `_patch_attn_eager` -- the attention implementation workaround mentioned above
-- `stub_tokenizer`, `tiny_llama_config`, `local_tinyllama_dir` -- tokenizer and tiny model on disk
-- `iris_df`, `timeseries_df` -- small DataFrames for training input
+- `fixture_stub_tokenizer`, `fixture_tiny_llama_config`, `fixture_local_tinyllama_dir` -- tokenizer and tiny model on disk
+- `fixture_iris_df`, `fixture_timeseries_df` -- small DataFrames for training input
 
 Function-scoped (fresh per test):
 
-- `tiny_model` -- randomly initialized `LlamaForCausalLM` (mutated by training)
+- `fixture_tiny_model` -- randomly initialized `LlamaForCausalLM` (mutated by training)
 
 Helpers (plain functions, not fixtures):
 

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -1,12 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+"""Smoke-test fixtures: tiny models, stub tokenizers, minimal datasets."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
 from pathlib import Path
 
 import pandas as pd
 import pytest
 from datasets import Dataset
-from transformers import AutoTokenizer, LlamaConfig, LlamaForCausalLM
+from transformers import AutoTokenizer, LlamaConfig, LlamaForCausalLM, PreTrainedTokenizerBase
 
 from nemo_safe_synthesizer.cli.artifact_structure import Workdir
 from nemo_safe_synthesizer.config.parameters import SafeSynthesizerParameters
@@ -20,10 +25,10 @@ def fixture_stub_tokenizer_path(stub_tokenizer_dir) -> str:
 
 
 @pytest.fixture(scope="session")
-def tiny_llama_config(stub_tokenizer):
+def fixture_tiny_llama_config(fixture_stub_tokenizer) -> LlamaConfig:
     """LlamaConfig with minimal dimensions for fast smoke testing."""
     return LlamaConfig(
-        vocab_size=stub_tokenizer.vocab_size,  # 32000 -- must match stub tokenizer
+        vocab_size=fixture_stub_tokenizer.vocab_size,  # 32000 -- must match stub tokenizer
         hidden_size=64,
         intermediate_size=128,
         num_hidden_layers=2,
@@ -34,19 +39,19 @@ def tiny_llama_config(stub_tokenizer):
 
 
 @pytest.fixture
-def tiny_model(tiny_llama_config):
+def fixture_tiny_model(fixture_tiny_llama_config) -> LlamaForCausalLM:
     """Randomly initialized LlamaForCausalLM. Tiny (~few KB), no download."""
-    return LlamaForCausalLM(tiny_llama_config)
+    return LlamaForCausalLM(fixture_tiny_llama_config)
 
 
 @pytest.fixture(scope="session")
-def stub_tokenizer(fixture_stub_tokenizer_path):
+def fixture_stub_tokenizer(fixture_stub_tokenizer_path) -> PreTrainedTokenizerBase:
     """Load the Llama stub tokenizer from tests/stub_tokenizer/."""
     return AutoTokenizer.from_pretrained(fixture_stub_tokenizer_path)
 
 
 @pytest.fixture(scope="session")
-def tiny_training_dataset(stub_tokenizer):
+def fixture_tiny_training_dataset(fixture_stub_tokenizer) -> Dataset:
     """~8 tokenized training examples as a datasets.Dataset."""
     texts = [
         '{"col1":"a","col2":"1"}',
@@ -58,7 +63,7 @@ def tiny_training_dataset(stub_tokenizer):
         '{"col1":"g","col2":"7"}',
         '{"col1":"h","col2":"8"}',
     ]
-    tokenized = stub_tokenizer(texts, padding="max_length", truncation=True, max_length=64, return_tensors="np")
+    tokenized = fixture_stub_tokenizer(texts, padding="max_length", truncation=True, max_length=64, return_tensors="np")
     return Dataset.from_dict(
         {
             "input_ids": tokenized["input_ids"].tolist(),
@@ -69,31 +74,31 @@ def tiny_training_dataset(stub_tokenizer):
 
 
 @pytest.fixture(scope="session")
-def tiny_training_dataset_with_position_ids(tiny_training_dataset):
+def fixture_tiny_training_dataset_with_position_ids(fixture_tiny_training_dataset) -> Dataset:
     """Training dataset with position_ids column, required by DataCollatorForPrivateTokenClassification."""
-    seq_len = len(tiny_training_dataset[0]["input_ids"])
-    position_ids = [list(range(seq_len))] * len(tiny_training_dataset)
-    return tiny_training_dataset.add_column("position_ids", position_ids)
+    seq_len = len(fixture_tiny_training_dataset[0]["input_ids"])
+    position_ids = [list(range(seq_len))] * len(fixture_tiny_training_dataset)
+    return fixture_tiny_training_dataset.add_column("position_ids", position_ids)
 
 
 @pytest.fixture(scope="session")
-def local_tinyllama_dir(tmp_path_factory, tiny_llama_config, stub_tokenizer):
+def fixture_local_tinyllama_dir(tmp_path_factory, fixture_tiny_llama_config, fixture_stub_tokenizer) -> Path:
     """Save tiny model + tokenizer to a local dir named with 'tinyllama' for NSS compatibility."""
     local_dir = tmp_path_factory.mktemp("smoke-tinyllama-model")
-    model = LlamaForCausalLM(tiny_llama_config)
+    model = LlamaForCausalLM(fixture_tiny_llama_config)
     model.save_pretrained(local_dir)
-    stub_tokenizer.save_pretrained(local_dir)
+    fixture_stub_tokenizer.save_pretrained(local_dir)
     return local_dir
 
 
 @pytest.fixture(scope="session")
-def iris_df(stub_datasets_dir):
+def fixture_iris_df() -> pd.DataFrame:
     """Load iris.csv from stub_datasets."""
     return pd.read_csv(stub_datasets_dir / "iris.csv")
 
 
 @pytest.fixture(scope="session")
-def timeseries_df():
+def fixture_timeseries_df() -> pd.DataFrame:
     """Minimal timeseries stub: 2 groups, 5 rows each, 60s intervals."""
     return pd.DataFrame(
         {
@@ -116,13 +121,13 @@ def timeseries_df():
 
 
 @pytest.fixture(scope="session")
-def smoke_save_path(tmp_path_factory):
+def fixture_smoke_save_path(tmp_path_factory) -> Path:
     """Shared temp directory for Tier B (SmolLM2) train -> generate flow."""
     return tmp_path_factory.mktemp("smoke-tier-b")
 
 
 @pytest.fixture(scope="session")
-def base_smoke_config(local_tinyllama_dir):
+def fixture_base_smoke_config(fixture_local_tinyllama_dir) -> SafeSynthesizerParameters:
     """Base SafeSynthesizerParameters shared by all GPU smoke tests with local tiny model.
 
     Session-scoped because the config is immutable (Pydantic frozen model).
@@ -130,7 +135,7 @@ def base_smoke_config(local_tinyllama_dir):
     """
     return SafeSynthesizerParameters.from_params(
         replace_pii=None,
-        pretrained_model=str(local_tinyllama_dir),
+        pretrained_model=str(fixture_local_tinyllama_dir),
         num_input_records_to_sample=10,
         num_records=5,
         lora_r=8,
@@ -157,7 +162,7 @@ def train_with_sdk(config: SafeSynthesizerParameters, data_df: pd.DataFrame, sav
 
 
 @pytest.fixture(scope="session")
-def _patch_attn_eager():
+def _patch_attn_eager() -> Generator[None, None, None]:
     """Override attn_implementation from 'flashinfer' (not a valid HF option) to 'sdpa'.
 
     Session-scoped so class-scoped and function-scoped fixtures can depend on it.

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -92,7 +92,7 @@ def fixture_local_tinyllama_dir(tmp_path_factory, fixture_tiny_llama_config, fix
 
 
 @pytest.fixture(scope="session")
-def fixture_iris_df() -> pd.DataFrame:
+def fixture_iris_df(stub_datasets_dir) -> pd.DataFrame:
     """Load iris.csv from stub_datasets."""
     return pd.read_csv(stub_datasets_dir / "iris.csv")
 

--- a/tests/smoke/test_evaluation_cpu.py
+++ b/tests/smoke/test_evaluation_cpu.py
@@ -24,12 +24,12 @@ def test_multimodal_report_from_dataframes(fixture_iris_df):
     config = SafeSynthesizerParameters(
         evaluation=EvaluationParameters(mia_enabled=False, aia_enabled=False),
     )
-    fixture_training_df = fixture_iris_df.copy()
-    fixture_synthetic_df = fixture_iris_df.sample(frac=0.8, random_state=42).reset_index(drop=True)
+    training_df = fixture_iris_df.copy()
+    synthetic_df = fixture_iris_df.sample(frac=0.8, random_state=42).reset_index(drop=True)
 
     report = MultimodalReport.from_dataframes(
-        training=fixture_training_df,
-        synthetic=fixture_synthetic_df,
+        training=training_df,
+        synthetic=synthetic_df,
         config=config,
     )
     assert report is not None

--- a/tests/smoke/test_evaluation_cpu.py
+++ b/tests/smoke/test_evaluation_cpu.py
@@ -19,17 +19,17 @@ from nemo_safe_synthesizer.config.parameters import EvaluationParameters, SafeSy
 from nemo_safe_synthesizer.evaluation.reports.multimodal.multimodal_report import MultimodalReport
 
 
-def test_multimodal_report_from_dataframes(iris_df):
-    """Build a MultimodalReport from iris_df on CPU with privacy metrics off."""
+def test_multimodal_report_from_dataframes(fixture_iris_df):
+    """Build a MultimodalReport from fixture_iris_df on CPU with privacy metrics off."""
     config = SafeSynthesizerParameters(
         evaluation=EvaluationParameters(mia_enabled=False, aia_enabled=False),
     )
-    training_df = iris_df.copy()
-    synthetic_df = iris_df.sample(frac=0.8, random_state=42).reset_index(drop=True)
+    fixture_training_df = fixture_iris_df.copy()
+    fixture_synthetic_df = fixture_iris_df.sample(frac=0.8, random_state=42).reset_index(drop=True)
 
     report = MultimodalReport.from_dataframes(
-        training=training_df,
-        synthetic=synthetic_df,
+        training=fixture_training_df,
+        synthetic=fixture_synthetic_df,
         config=config,
     )
     assert report is not None

--- a/tests/smoke/test_full_pipeline_gpu.py
+++ b/tests/smoke/test_full_pipeline_gpu.py
@@ -25,7 +25,7 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_full_pipeline_smollm2(iris_df, smoke_save_path):
+def test_full_pipeline_smollm2(fixture_iris_df, fixture_smoke_save_path):
     """Train SmolLM2-135M then generate with vLLM in a single end-to-end pass.
 
     SmolLM2-135M with only 50 sampled rows packs into ~1 training example,
@@ -41,8 +41,8 @@ def test_full_pipeline_smollm2(iris_df, smoke_save_path):
         holdout=0,
         max_holdout=0,
     )
-    nss = SafeSynthesizer(config=config, save_path=smoke_save_path)
-    nss.with_data_source(iris_df).process_data().train()
+    nss = SafeSynthesizer(config=config, save_path=fixture_smoke_save_path)
+    nss.with_data_source(fixture_iris_df).process_data().train()
 
     try:
         nss.generate()

--- a/tests/smoke/test_generation_cpu.py
+++ b/tests/smoke/test_generation_cpu.py
@@ -15,25 +15,25 @@ from nemo_safe_synthesizer.generation.processors import create_processor
 from nemo_safe_synthesizer.utils import create_schema_prompt
 
 
-def test_generate_with_schema_prompt(tiny_model, stub_tokenizer):
+def test_generate_with_schema_prompt(fixture_tiny_model, fixture_stub_tokenizer):
     """Exercises: create_schema_prompt() + model.generate()."""
     prompt = create_schema_prompt(
         columns=["col1", "col2", "col3"],
         instruction=DEFAULT_INSTRUCTION,
         prompt_template=PROMPT_TEMPLATE,
     )
-    input_ids = stub_tokenizer(prompt, return_tensors="pt")["input_ids"]
-    output = tiny_model.generate(input_ids, max_new_tokens=20, do_sample=False)
-    decoded = stub_tokenizer.decode(output[0], skip_special_tokens=True)
+    input_ids = fixture_stub_tokenizer(prompt, return_tensors="pt")["input_ids"]
+    output = fixture_tiny_model.generate(input_ids, max_new_tokens=20, do_sample=False)
+    decoded = fixture_stub_tokenizer.decode(output[0], skip_special_tokens=True)
     assert len(decoded) > len(prompt)  # model produced something
 
 
-def test_processor_parses_generated_text(tiny_model, stub_tokenizer):
+def test_processor_parses_generated_text(fixture_tiny_model, fixture_stub_tokenizer):
     """Exercises: create_processor() does not crash on garbage text from random model."""
     # Generate some text (will be garbage from random model)
-    input_ids = stub_tokenizer("test", return_tensors="pt")["input_ids"]
-    output = tiny_model.generate(input_ids, max_new_tokens=50, do_sample=False)
-    generated_text = stub_tokenizer.decode(output[0], skip_special_tokens=True)
+    input_ids = fixture_stub_tokenizer("test", return_tensors="pt")["input_ids"]
+    output = fixture_tiny_model.generate(input_ids, max_new_tokens=50, do_sample=False)
+    generated_text = fixture_stub_tokenizer.decode(output[0], skip_special_tokens=True)
     assert len(generated_text) > 0
 
     # Create a schema and processor

--- a/tests/smoke/test_nss_adapter_persistence_gpu.py
+++ b/tests/smoke/test_nss_adapter_persistence_gpu.py
@@ -21,7 +21,7 @@ pytestmark = [
 
 
 @pytest.fixture(scope="class")
-def adapter_train_artifacts(
+def fixture_adapter_train_artifacts(
     _patch_attn_eager, fixture_base_smoke_config, fixture_iris_df, tmp_path_factory, fixture_local_tinyllama_dir
 ):
     """Train once per class, return (workdir, local_model_dir) for all adapter tests."""
@@ -33,17 +33,17 @@ def adapter_train_artifacts(
 class TestAdapterPersistence:
     """Train once, verify adapter artifacts in 3 ways."""
 
-    def test_adapter_files_exist_after_train(self, adapter_train_artifacts):
+    def test_adapter_files_exist_after_train(self, fixture_adapter_train_artifacts):
         """Verify all expected adapter files are written to disk."""
-        workdir, _ = adapter_train_artifacts
+        workdir, _ = fixture_adapter_train_artifacts
         assert_adapter_saved(workdir)
         assert workdir.train.adapter.metadata.exists()  # metadata_v2.json
         assert workdir.train.adapter.schema.exists()  # dataset_schema.json
         assert workdir.train.config.exists()  # train/safe-synthesizer-config.json
 
-    def test_adapter_loadable_by_peft(self, adapter_train_artifacts):
+    def test_adapter_loadable_by_peft(self, fixture_adapter_train_artifacts):
         """Verify the adapter can be loaded by PEFT and produces valid output."""
-        workdir, local_dir = adapter_train_artifacts
+        workdir, local_dir = fixture_adapter_train_artifacts
         base = AutoModelForCausalLM.from_pretrained(
             str(local_dir),
             device_map="cpu",
@@ -57,9 +57,9 @@ class TestAdapterPersistence:
         assert output.logits is not None
         assert output.logits.shape[0] == 1
 
-    def test_adapter_config_valid(self, adapter_train_artifacts):
+    def test_adapter_config_valid(self, fixture_adapter_train_artifacts):
         """Verify adapter_config.json has correct LoRA parameters."""
-        workdir, _ = adapter_train_artifacts
+        workdir, _ = fixture_adapter_train_artifacts
         config_path = workdir.train.adapter.path / "adapter_config.json"
         with open(config_path) as f:
             adapter_cfg = json.load(f)

--- a/tests/smoke/test_nss_adapter_persistence_gpu.py
+++ b/tests/smoke/test_nss_adapter_persistence_gpu.py
@@ -21,11 +21,13 @@ pytestmark = [
 
 
 @pytest.fixture(scope="class")
-def adapter_train_artifacts(_patch_attn_eager, base_smoke_config, iris_df, tmp_path_factory, local_tinyllama_dir):
+def adapter_train_artifacts(
+    _patch_attn_eager, fixture_base_smoke_config, fixture_iris_df, tmp_path_factory, fixture_local_tinyllama_dir
+):
     """Train once per class, return (workdir, local_model_dir) for all adapter tests."""
     save_path = tmp_path_factory.mktemp("adapter-smoke")
-    nss = train_with_sdk(base_smoke_config, iris_df, save_path)
-    return nss._workdir, local_tinyllama_dir
+    nss = train_with_sdk(fixture_base_smoke_config, fixture_iris_df, save_path)
+    return nss._workdir, fixture_local_tinyllama_dir
 
 
 class TestAdapterPersistence:

--- a/tests/smoke/test_nss_generation_gpu.py
+++ b/tests/smoke/test_nss_generation_gpu.py
@@ -20,7 +20,7 @@ pytestmark = [
 
 
 @pytest.fixture(scope="class")
-def trained_nss(_patch_attn_eager, fixture_base_smoke_config, fixture_iris_df, tmp_path_factory):
+def fixture_trained_nss(_patch_attn_eager, fixture_base_smoke_config, fixture_iris_df, tmp_path_factory):
     """Train once per class; both SDK chain and manual VllmBackend tests consume this."""
     save_path = tmp_path_factory.mktemp("gen-smoke")
     nss = SafeSynthesizer(config=fixture_base_smoke_config, save_path=save_path)
@@ -29,26 +29,26 @@ def trained_nss(_patch_attn_eager, fixture_base_smoke_config, fixture_iris_df, t
 
 
 class TestNSSGenerationGPU:
-    """GPU generation tests sharing a single training run via the trained_nss fixture."""
+    """GPU generation tests sharing a single training run via the fixture_trained_nss fixture."""
 
-    def test_nss_full_chain_train_and_generate(self, trained_nss):
+    def test_nss_full_chain_train_and_generate(self, fixture_trained_nss):
         """Train and generate through the full SDK chain.
 
         The tiny random model produces garbage output, so GenerationError
         (no valid records) is acceptable -- we just exercise the code path.
         """
         try:
-            trained_nss.generate()
+            fixture_trained_nss.generate()
         except GenerationError as exc:
             assert "generation stopped prematurely" in str(exc).lower(), f"Unexpected GenerationError: {exc}"
 
-    def test_manual_vllm_backend_with_local_model(self, trained_nss, fixture_local_tinyllama_dir):
+    def test_manual_vllm_backend_with_local_model(self, fixture_trained_nss, fixture_local_tinyllama_dir):
         """Manually construct VllmBackend and generate with the saved adapter."""
         from nemo_safe_synthesizer.generation.vllm_backend import VllmBackend
         from nemo_safe_synthesizer.llm.metadata import ModelMetadata
 
-        workdir = trained_nss._workdir
-        config = trained_nss._nss_config
+        workdir = fixture_trained_nss._workdir
+        config = fixture_trained_nss._nss_config
         metadata = ModelMetadata.from_metadata_json(workdir.metadata_file, workdir=workdir)
         backend = VllmBackend(config=config, model_metadata=metadata, workdir=workdir)
         backend.initialize()

--- a/tests/smoke/test_nss_generation_gpu.py
+++ b/tests/smoke/test_nss_generation_gpu.py
@@ -20,11 +20,11 @@ pytestmark = [
 
 
 @pytest.fixture(scope="class")
-def trained_nss(_patch_attn_eager, base_smoke_config, iris_df, tmp_path_factory):
+def trained_nss(_patch_attn_eager, fixture_base_smoke_config, fixture_iris_df, tmp_path_factory):
     """Train once per class; both SDK chain and manual VllmBackend tests consume this."""
     save_path = tmp_path_factory.mktemp("gen-smoke")
-    nss = SafeSynthesizer(config=base_smoke_config, save_path=save_path)
-    nss.with_data_source(iris_df).process_data().train()
+    nss = SafeSynthesizer(config=fixture_base_smoke_config, save_path=save_path)
+    nss.with_data_source(fixture_iris_df).process_data().train()
     return nss
 
 
@@ -42,7 +42,7 @@ class TestNSSGenerationGPU:
         except GenerationError as exc:
             assert "generation stopped prematurely" in str(exc).lower(), f"Unexpected GenerationError: {exc}"
 
-    def test_manual_vllm_backend_with_local_model(self, trained_nss, local_tinyllama_dir):
+    def test_manual_vllm_backend_with_local_model(self, trained_nss, fixture_local_tinyllama_dir):
         """Manually construct VllmBackend and generate with the saved adapter."""
         from nemo_safe_synthesizer.generation.vllm_backend import VllmBackend
         from nemo_safe_synthesizer.llm.metadata import ModelMetadata

--- a/tests/smoke/test_nss_resume_gpu.py
+++ b/tests/smoke/test_nss_resume_gpu.py
@@ -24,19 +24,19 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_resume_generate_after_train(local_tinyllama_dir, iris_df, tmp_path):
+def test_nss_resume_generate_after_train(fixture_local_tinyllama_dir, fixture_iris_df, tmp_path):
     """Train, then create a new SafeSynthesizer instance and generate from saved state.
 
-    Uses doubled iris_df (302 rows) with holdout=0.05 so load_from_save_path()
+    Uses doubled fixture_iris_df (302 rows) with holdout=0.05 so load_from_save_path()
     has a non-empty test.csv to read. The base holdout=0 config produces an empty
     test split which causes EmptyDataError on resume.
     """
     # Double the dataset to exceed the 200-row holdout minimum
-    large_df = pd.concat([iris_df, iris_df], ignore_index=True)
+    large_df = pd.concat([fixture_iris_df, fixture_iris_df], ignore_index=True)
 
     config = SafeSynthesizerParameters.from_params(
         replace_pii=None,
-        pretrained_model=str(local_tinyllama_dir),
+        pretrained_model=str(fixture_local_tinyllama_dir),
         num_input_records_to_sample=10,
         num_records=5,
         lora_r=8,

--- a/tests/smoke/test_nss_structured_gen_gpu.py
+++ b/tests/smoke/test_nss_structured_gen_gpu.py
@@ -21,7 +21,7 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_structured_generation(local_tinyllama_dir, iris_df, tmp_path):
+def test_nss_structured_generation(fixture_local_tinyllama_dir, fixture_iris_df, tmp_path):
     """Train and generate with outlines structured generation backend.
 
     The tiny random model produces garbage, so GenerationError (no valid records)
@@ -29,7 +29,7 @@ def test_nss_structured_generation(local_tinyllama_dir, iris_df, tmp_path):
     """
     config = SafeSynthesizerParameters.from_params(
         replace_pii=None,
-        pretrained_model=str(local_tinyllama_dir),
+        pretrained_model=str(fixture_local_tinyllama_dir),
         num_input_records_to_sample=10,
         num_records=5,
         lora_r=8,
@@ -40,7 +40,7 @@ def test_nss_structured_generation(local_tinyllama_dir, iris_df, tmp_path):
         structured_generation_schema_method="json_schema",
     )
     nss = SafeSynthesizer(config=config, save_path=tmp_path)
-    nss.with_data_source(iris_df).process_data().train()
+    nss.with_data_source(fixture_iris_df).process_data().train()
     try:
         nss.generate()
     except GenerationError as exc:

--- a/tests/smoke/test_nss_timeseries_gpu.py
+++ b/tests/smoke/test_nss_timeseries_gpu.py
@@ -21,11 +21,11 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_timeseries_train_and_generate(local_tinyllama_dir, timeseries_df, tmp_path):
+def test_nss_timeseries_train_and_generate(fixture_local_tinyllama_dir, fixture_timeseries_df, tmp_path):
     """Train and generate through the TimeseriesBackend with inline stub data."""
     config = SafeSynthesizerParameters.from_params(
         replace_pii=None,
-        pretrained_model=str(local_tinyllama_dir),
+        pretrained_model=str(fixture_local_tinyllama_dir),
         num_input_records_to_sample=10,
         num_records=5,
         lora_r=8,
@@ -38,7 +38,7 @@ def test_nss_timeseries_train_and_generate(local_tinyllama_dir, timeseries_df, t
         order_training_examples_by="timestamp",
     )
     nss = SafeSynthesizer(config=config, save_path=tmp_path)
-    nss.with_data_source(timeseries_df).process_data().train()
+    nss.with_data_source(fixture_timeseries_df).process_data().train()
     try:
         nss.generate()
     except GenerationError as exc:

--- a/tests/smoke/test_nss_training_gpu.py
+++ b/tests/smoke/test_nss_training_gpu.py
@@ -20,15 +20,15 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_train_one_batch(base_smoke_config, iris_df, tmp_path):
+def test_nss_train_one_batch(fixture_base_smoke_config, fixture_iris_df, tmp_path):
     """Train one batch through the SafeSynthesizer SDK with local tiny model."""
-    nss = train_with_sdk(base_smoke_config, iris_df, tmp_path)
+    nss = train_with_sdk(fixture_base_smoke_config, fixture_iris_df, tmp_path)
     assert nss._workdir is not None
     assert_adapter_saved(nss._workdir)
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_train_dp_one_batch(local_tinyllama_dir, iris_df, tmp_path):
+def test_nss_train_dp_one_batch(fixture_local_tinyllama_dir, fixture_iris_df, tmp_path):
     """Train one batch with DP enabled through the SafeSynthesizer SDK.
 
     Uses num_input_records_to_sample=100 (vs 10 for non-DP) to keep the epoch
@@ -36,7 +36,7 @@ def test_nss_train_dp_one_batch(local_tinyllama_dir, iris_df, tmp_path):
     """
     config = SafeSynthesizerParameters.from_params(
         replace_pii=None,
-        pretrained_model=str(local_tinyllama_dir),
+        pretrained_model=str(fixture_local_tinyllama_dir),
         num_input_records_to_sample=100,
         num_records=5,
         lora_r=8,
@@ -45,6 +45,6 @@ def test_nss_train_dp_one_batch(local_tinyllama_dir, iris_df, tmp_path):
         dp_enabled=True,
         epsilon=100.0,
     )
-    nss = train_with_sdk(config, iris_df, tmp_path)
+    nss = train_with_sdk(config, fixture_iris_df, tmp_path)
     assert nss._workdir is not None
     assert_adapter_saved(nss._workdir)

--- a/tests/smoke/test_training_cpu.py
+++ b/tests/smoke/test_training_cpu.py
@@ -66,13 +66,13 @@ class _StubModelMetadata:
     prompt_config: _StubPromptConfig = field(default_factory=_StubPromptConfig)
 
 
-def test_hf_trainer_one_step(tiny_model, stub_tokenizer, tiny_training_dataset, tmp_path):
+def test_hf_trainer_one_step(fixture_tiny_model, fixture_stub_tokenizer, fixture_tiny_training_dataset, tmp_path):
     """Exercises: transformers.Trainer forward + backward pass."""
     trainer = Trainer(
-        model=tiny_model,
+        model=fixture_tiny_model,
         args=_cpu_training_args(tmp_path),
-        train_dataset=tiny_training_dataset,
-        data_collator=DataCollatorForTokenClassification(tokenizer=stub_tokenizer),
+        train_dataset=fixture_tiny_training_dataset,
+        data_collator=DataCollatorForTokenClassification(tokenizer=fixture_stub_tokenizer),
     )
     trainer.train()
     assert len(trainer.state.log_history) > 0
@@ -80,7 +80,7 @@ def test_hf_trainer_one_step(tiny_model, stub_tokenizer, tiny_training_dataset, 
     assert "loss" in last_log or "train_loss" in last_log
 
 
-def test_lora_training_one_step(tiny_model, stub_tokenizer, tiny_training_dataset, tmp_path):
+def test_lora_training_one_step(fixture_tiny_model, fixture_stub_tokenizer, fixture_tiny_training_dataset, tmp_path):
     """Exercises: peft.get_peft_model + LoraConfig + Trainer."""
     lora_config = LoraConfig(
         r=8,
@@ -89,13 +89,13 @@ def test_lora_training_one_step(tiny_model, stub_tokenizer, tiny_training_datase
         task_type=TaskType.CAUSAL_LM,
         bias="none",
     )
-    model = get_peft_model(tiny_model, lora_config)
+    model = get_peft_model(fixture_tiny_model, lora_config)
     model.enable_input_require_grads()
     trainer = Trainer(
         model=model,
         args=_cpu_training_args(tmp_path),
-        train_dataset=tiny_training_dataset,
-        data_collator=DataCollatorForTokenClassification(tokenizer=stub_tokenizer),
+        train_dataset=fixture_tiny_training_dataset,
+        data_collator=DataCollatorForTokenClassification(tokenizer=fixture_stub_tokenizer),
     )
     trainer.train()
     assert len(trainer.state.log_history) > 0
@@ -103,7 +103,9 @@ def test_lora_training_one_step(tiny_model, stub_tokenizer, tiny_training_datase
     assert "loss" in last_log or "train_loss" in last_log
 
 
-def test_dp_training_one_step(tiny_model, stub_tokenizer, tiny_training_dataset_with_position_ids, tmp_path):
+def test_dp_training_one_step(
+    fixture_tiny_model, fixture_stub_tokenizer, fixture_tiny_training_dataset_with_position_ids, tmp_path
+):
     """Exercises: OpacusDPTrainer + PrivacyArguments + DataCollatorForPrivateTokenClassification."""
     privacy_args = PrivacyArguments(
         target_epsilon=100.0,
@@ -111,11 +113,11 @@ def test_dp_training_one_step(tiny_model, stub_tokenizer, tiny_training_dataset_
         per_sample_max_grad_norm=1.0,
     )
     args = _cpu_training_args(tmp_path, remove_unused_columns=False, max_grad_norm=0.0)
-    data_collator = DataCollatorForPrivateTokenClassification(tokenizer=stub_tokenizer)
+    data_collator = DataCollatorForPrivateTokenClassification(tokenizer=fixture_stub_tokenizer)
     trainer = OpacusDPTrainer(
-        model=tiny_model,
+        model=fixture_tiny_model,
         args=args,
-        train_dataset=tiny_training_dataset_with_position_ids,
+        train_dataset=fixture_tiny_training_dataset_with_position_ids,
         data_collator=data_collator,
         privacy_args=privacy_args,
         true_dataset_size=8,
@@ -125,21 +127,21 @@ def test_dp_training_one_step(tiny_model, stub_tokenizer, tiny_training_dataset_
     assert len(trainer.state.log_history) > 0
 
 
-def test_training_example_assembler(iris_df, stub_tokenizer, tmp_path):
+def test_training_example_assembler(fixture_iris_df, fixture_stub_tokenizer, tmp_path):
     """Exercises: NSS data preparation pipeline (TrainingExampleAssembler)."""
     from nemo_safe_synthesizer.config import SafeSynthesizerParameters
 
     config = SafeSynthesizerParameters.from_params(
         num_input_records_to_sample=10,
     )
-    hf_dataset = Dataset.from_pandas(iris_df, preserve_index=False)
+    hf_dataset = Dataset.from_pandas(fixture_iris_df, preserve_index=False)
 
     # Build a minimal picklable metadata stub (MagicMock can't be pickled by datasets).
     stub_metadata = _StubModelMetadata()
 
     assembler = TrainingExampleAssembler.from_data(
         dataset=hf_dataset,
-        tokenizer=stub_tokenizer,
+        tokenizer=fixture_stub_tokenizer,
         metadata=stub_metadata,  # ty: ignore[invalid-argument-type] -- deliberate test stub
         config=config,
         seed=42,


### PR DESCRIPTION
## Summary

follow up from #389 , and builds on top of #337's dataset naming consistency changes so the two refactors don't conflict at merge time.


- Rename bare test fixtures to use the `fixture_` prefix for grep-ability and clear separation from test functions and production API names
- Add return type annotations to all renamed fixtures across `evaluation/`, `smoke/`, `config/`, `e2e/`, and root `conftest.py`
- Add one-line docstrings describing what each fixture provides
- Add `from __future__ import annotations` and module-level docstrings to `conftest.py` files

## Renamed fixtures (32)

| conftest | fixtures |
|----------|----------|
| `evaluation/` | `training_df`, `training_df_5k`, `training_df_10k`, `synthetic_df`, `synthetic_df_5k`, `synthetic_df_10k`, `test_df`, `evaluation_datasets_5k`, `skip_privacy_metrics_config`, `dp_enabled_config`, `dp_not_enabled_config`, `column_statistics`, `mia_aia_df`, `mia_aia_df_with_nan_protection`, `training_df_text_only`, `synthetic_df_text_only`, `test_df_text_only`, `training_df_mixed_5k`, `synthetic_df_mixed_5k`, `test_df_mixed` |
| `smoke/` | `tiny_llama_config`, `tiny_model`, `stub_tokenizer`, `tiny_training_dataset`, `tiny_training_dataset_with_position_ids`, `local_tinyllama_dir`, `iris_df`, `timeseries_df`, `smoke_save_path`, `base_smoke_config` |
| `config/` | `training_hyperparams`, `simple_safe_synthesizer_parameters` |

## Test plan

- [x] `make format-check` passes (verified locally)
- [ ] `make test` passes after merge with #337
