### PR TITLE
build: update ty, mise deps, and tighten types

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -24,7 +24,7 @@ ripgrep = "latest"
 dprint = "latest"
 uv = "0.9.30"
 ruff = "0.15.0"
-ty = "0.0.27"
+ty = "0.0.31"
 
 "aqua:j178/prek" = "latest"
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -24,7 +24,7 @@ ripgrep = "latest"
 dprint = "latest"
 uv = "0.9.30"
 ruff = "0.15.0"
-ty = "0.0.31"
+ty = "0.0.32"
 
 "aqua:j178/prek" = "latest"
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,6 @@
 {
     "terminal.integrated.env.linux": {
-        "PATH": "${env:HOME}/.local/bin:${env:PATH}"
+        "PATH": "${env:HOME}/.local/share/mise/shims:${env:HOME}/.local/bin:${env:PATH}"
     },
-    "ruff.path": [
-        "/root/.local/share/mise/shims/ruff"
-    ]
+    "python.defaultInterpreterPath": "${workspaceFolder}/.venv"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
     "terminal.integrated.env.linux": {
         "PATH": "${env:HOME}/.local/bin:${env:PATH}"
-    }
+    },
+    "ruff.path": [
+        "/root/.local/share/mise/shims/ruff"
+    ]
 }

--- a/mise.lock
+++ b/mise.lock
@@ -131,22 +131,22 @@ checksum = "sha256:093d355ac33c6b8e91e80b8497d5581c61b028c0405e265cf38fd88f9a291
 url = "https://github.com/astral-sh/ruff/releases/download/0.15.0/ruff-aarch64-apple-darwin.tar.gz"
 
 [[tools.ty]]
-version = "0.0.27"
+version = "0.0.31"
 backend = "aqua:astral-sh/ty"
 
 [tools.ty."platforms.linux-arm64"]
-checksum = "sha256:b46465dacab53a28222a96b8da7bd4fc8bbab1c2699dec1e49063571ebed743b"
-url = "https://github.com/astral-sh/ty/releases/download/0.0.27/ty-aarch64-unknown-linux-musl.tar.gz"
+checksum = "sha256:c4bf27cd45b7da0500e8edfac19103ac5ffb2c170369e7e9701b7b6150bbe08c"
+url = "https://github.com/astral-sh/ty/releases/download/0.0.31/ty-aarch64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.ty."platforms.linux-x64"]
-checksum = "sha256:7e95adf1e3df1ffceb7545969a8c9731311e4cf8dccfcc0045de6d35a575608a"
-url = "https://github.com/astral-sh/ty/releases/download/0.0.27/ty-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:ee7bcc8746e1ca424b107ad288a00b7033fdc962d79932095c25bc4c4b2c3bdd"
+url = "https://github.com/astral-sh/ty/releases/download/0.0.31/ty-x86_64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.ty."platforms.macos-arm64"]
-checksum = "sha256:fb5dd6fac54bd9b39c3e1e3d06b5286f21bcdb75160fde25774306ab1932960b"
-url = "https://github.com/astral-sh/ty/releases/download/0.0.27/ty-aarch64-apple-darwin.tar.gz"
+checksum = "sha256:26352f9559d09e59d11bf4584b886fc5cc466fcfde9b5d5cd3af417b4427a28c"
+url = "https://github.com/astral-sh/ty/releases/download/0.0.31/ty-aarch64-apple-darwin.tar.gz"
 provenance = "github-attestations"
 
 [[tools.uv]]

--- a/mise.lock
+++ b/mise.lock
@@ -131,22 +131,22 @@ checksum = "sha256:093d355ac33c6b8e91e80b8497d5581c61b028c0405e265cf38fd88f9a291
 url = "https://github.com/astral-sh/ruff/releases/download/0.15.0/ruff-aarch64-apple-darwin.tar.gz"
 
 [[tools.ty]]
-version = "0.0.31"
+version = "0.0.32"
 backend = "aqua:astral-sh/ty"
 
 [tools.ty."platforms.linux-arm64"]
-checksum = "sha256:c4bf27cd45b7da0500e8edfac19103ac5ffb2c170369e7e9701b7b6150bbe08c"
-url = "https://github.com/astral-sh/ty/releases/download/0.0.31/ty-aarch64-unknown-linux-musl.tar.gz"
+checksum = "sha256:de848acf867991f495dc346f5d12a7ac470af3ac464fdad7aff22fb8ee931a17"
+url = "https://github.com/astral-sh/ty/releases/download/0.0.32/ty-aarch64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.ty."platforms.linux-x64"]
-checksum = "sha256:ee7bcc8746e1ca424b107ad288a00b7033fdc962d79932095c25bc4c4b2c3bdd"
-url = "https://github.com/astral-sh/ty/releases/download/0.0.31/ty-x86_64-unknown-linux-musl.tar.gz"
+checksum = "sha256:cc58ee952aa551a0cbca495a43325b093dfcb180f0b314bf2c71068d37833b9e"
+url = "https://github.com/astral-sh/ty/releases/download/0.0.32/ty-x86_64-unknown-linux-musl.tar.gz"
 provenance = "github-attestations"
 
 [tools.ty."platforms.macos-arm64"]
-checksum = "sha256:26352f9559d09e59d11bf4584b886fc5cc466fcfde9b5d5cd3af417b4427a28c"
-url = "https://github.com/astral-sh/ty/releases/download/0.0.31/ty-aarch64-apple-darwin.tar.gz"
+checksum = "sha256:6b03b94d8c2ddcb5db67e6c863ef3c72b83fbcb973e0ff3a4c6daa4352dad009"
+url = "https://github.com/astral-sh/ty/releases/download/0.0.32/ty-aarch64-apple-darwin.tar.gz"
 provenance = "github-attestations"
 
 [[tools.uv]]

--- a/src/nemo_safe_synthesizer/cli/AGENTS.md
+++ b/src/nemo_safe_synthesizer/cli/AGENTS.md
@@ -61,12 +61,12 @@ New common option: Add to `common_run_options` list, pass through to handler, in
 
 Declarative artifact tree rooted at `Workdir`. `DirNode` and `FileNode` are descriptors; child lookups on a `BoundDir` go through `__getattr__` so the runtime tree is driven entirely by the class-level `DirNode(...)` / `FileNode(...)` declarations.
 
-`DirNode` is generic: `DirNode[T_co]` where `T_co` is the `BoundDir` subtype returned by `__get__`. The subtype is a **phantom subclass** (`_TrainDir`, `_AdapterDir`, `_GenerateDir`, `_DatasetDir`) whose body lives inside an `if TYPE_CHECKING:` block and only declares attribute types that mirror the tree — it has no runtime behavior. This gives `ty` enough information to resolve `workdir.train.config`, `workdir.train.adapter.adapter_config`, `workdir.generate.logs`, etc. without `# ty: ignore[unresolved-attribute]` sprinkled at every call site.
+`DirNode` is generic: `DirNode[T_co]` where `T_co` is the `BoundDir` subtype returned by `__get__`. The subtype is a **typed-view subclass** (`_TrainDir`, `_AdapterDir`, `_GenerateDir`, `_DatasetDir`) whose body lives inside an `if TYPE_CHECKING:` block and only declares attribute types that mirror the tree — it has no runtime behaviour. This gives `ty` enough information to resolve `workdir.train.config`, `workdir.train.adapter.adapter_config`, `workdir.generate.logs`, etc. without `# ty: ignore[unresolved-attribute]` sprinkled at every call site. The idiom composes SQLAlchemy's `Mapped[T]`-style generic descriptor with PEP 484's `TYPE_CHECKING` guard; see the section comment in `artifact_structure.py` for external references. (Note: these are *not* "phantom types" in the `phantom-types` library sense — that term means refinement types with runtime predicates.)
 
 When you touch this file:
 
-- Adding a child (`foo = FileNode("foo.json")` or `foo = DirNode(...)`) under an existing `DirNode(...)` tree requires adding the matching annotation to the corresponding phantom subclass. If you don't, `ty` will re-flag `workdir.<parent>.foo` at every call site.
-- Adding a new top-level `DirNode` on `Workdir` needs a new phantom `_FooDir(BoundDir)` subclass, and the `Workdir` attribute should be typed `DirNode[_FooDir]`.
+- Adding a child (`foo = FileNode("foo.json")` or `foo = DirNode(...)`) under an existing `DirNode(...)` tree requires adding the matching annotation to the corresponding typed-view subclass. If you don't, `ty` will re-flag `workdir.<parent>.foo` at every call site.
+- Adding a new top-level `DirNode` on `Workdir` needs a new typed-view `_FooDir(BoundDir)` subclass, and the `Workdir` attribute should be typed `DirNode[_FooDir]`.
 - Don't reintroduce `cast(Path, ...)` on `Workdir` shortcut properties — the generic `DirNode[_T]` already narrows the return type.
 
 ## Read first
@@ -75,5 +75,5 @@ When you touch this file:
 - `run.py` — run commands, `common_run_options`, `common_setup` flow
 - `settings.py` — `CLISettings`, `from_cli_kwargs`, precedence
 - `utils.py` — `common_setup`, `merge_overrides`, `CLI_NESTED_FIELD_SEPARATOR`
-- `artifact_structure.py` — `Workdir`, `DirNode`/`FileNode` descriptors, phantom `_TrainDir` / `_AdapterDir` / `_GenerateDir` / `_DatasetDir` typing subclasses
+- `artifact_structure.py` — `Workdir`, `DirNode`/`FileNode` descriptors, typed-view `_TrainDir` / `_AdapterDir` / `_GenerateDir` / `_DatasetDir` subclasses
 - `configurator/pydantic_click_options.py` — `pydantic_options`, `parse_overrides`

--- a/src/nemo_safe_synthesizer/cli/AGENTS.md
+++ b/src/nemo_safe_synthesizer/cli/AGENTS.md
@@ -57,10 +57,23 @@ def run_mystage(config_path, data_source, ..., **kwargs):
 
 New common option: Add to `common_run_options` list, pass through to handler, include in `CLISettings.from_cli_kwargs()`.
 
+## artifact_structure.py
+
+Declarative artifact tree rooted at `Workdir`. `DirNode` and `FileNode` are descriptors; child lookups on a `BoundDir` go through `__getattr__` so the runtime tree is driven entirely by the class-level `DirNode(...)` / `FileNode(...)` declarations.
+
+`DirNode` is generic: `DirNode[T_co]` where `T_co` is the `BoundDir` subtype returned by `__get__`. The subtype is a **phantom subclass** (`_TrainDir`, `_AdapterDir`, `_GenerateDir`, `_DatasetDir`) whose body lives inside an `if TYPE_CHECKING:` block and only declares attribute types that mirror the tree — it has no runtime behavior. This gives `ty` enough information to resolve `workdir.train.config`, `workdir.train.adapter.adapter_config`, `workdir.generate.logs`, etc. without `# ty: ignore[unresolved-attribute]` sprinkled at every call site.
+
+When you touch this file:
+
+- Adding a child (`foo = FileNode("foo.json")` or `foo = DirNode(...)`) under an existing `DirNode(...)` tree requires adding the matching annotation to the corresponding phantom subclass. If you don't, `ty` will re-flag `workdir.<parent>.foo` at every call site.
+- Adding a new top-level `DirNode` on `Workdir` needs a new phantom `_FooDir(BoundDir)` subclass, and the `Workdir` attribute should be typed `DirNode[_FooDir]`.
+- Don't reintroduce `cast(Path, ...)` on `Workdir` shortcut properties — the generic `DirNode[_T]` already narrows the return type.
+
 ## Read first
 
 - `cli.py` — root group, command registration
 - `run.py` — run commands, `common_run_options`, `common_setup` flow
 - `settings.py` — `CLISettings`, `from_cli_kwargs`, precedence
 - `utils.py` — `common_setup`, `merge_overrides`, `CLI_NESTED_FIELD_SEPARATOR`
+- `artifact_structure.py` — `Workdir`, `DirNode`/`FileNode` descriptors, phantom `_TrainDir` / `_AdapterDir` / `_GenerateDir` / `_DatasetDir` typing subclasses
 - `configurator/pydantic_click_options.py` — `pydantic_options`, `parse_overrides`

--- a/src/nemo_safe_synthesizer/cli/artifact_structure.py
+++ b/src/nemo_safe_synthesizer/cli/artifact_structure.py
@@ -447,8 +447,8 @@ class Workdir:
         returns the parent's adapter path since that's where the trained adapter lives.
         """
         if self._parent_workdir is not None:
-            return cast(Path, self._parent_workdir.train.adapter.path)  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
-        return cast(Path, self.train.adapter.path)  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+            return self._parent_workdir.train.adapter.path  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        return self.train.adapter.path  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
 
     @property
     def metadata_file(self) -> Path:
@@ -563,14 +563,14 @@ class Workdir:
         if self._current_phase == "generate" and self._parent_workdir is not None:
             # Generation-only run - only create generate directory
             # Train and dataset are in the parent workdir
-            cast(Path, self.generate.path).mkdir(parents=True, exist_ok=True)
+            self.generate.path.mkdir(parents=True, exist_ok=True)
             self._write_generation_info()
         else:
             # Training run or end-to-end - create all directories
-            cast(Path, self.train.cache.path).mkdir(parents=True, exist_ok=True)  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
-            cast(Path, self.train.adapter.path).mkdir(parents=True, exist_ok=True)  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
-            cast(Path, self.generate.path).mkdir(parents=True, exist_ok=True)
-            cast(Path, self.dataset.path).mkdir(parents=True, exist_ok=True)
+            self.train.cache.path.mkdir(parents=True, exist_ok=True)  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+            self.train.adapter.path.mkdir(parents=True, exist_ok=True)  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+            self.generate.path.mkdir(parents=True, exist_ok=True)
+            self.dataset.path.mkdir(parents=True, exist_ok=True)
 
         return self
 

--- a/src/nemo_safe_synthesizer/cli/artifact_structure.py
+++ b/src/nemo_safe_synthesizer/cli/artifact_structure.py
@@ -286,16 +286,48 @@ class BoundDir(os.PathLike[str]):
 
 
 # ---------------------------------------------------------------------------
-# Phantom ``BoundDir`` subclasses declaring the typed shape of each subtree.
+# Typed-view ``BoundDir`` subclasses
+# ---------------------------------------------------------------------------
 #
-# These exist solely so type checkers can see the children of each directory
-# through ``BoundDir.__getattr__``. At runtime they are empty subclasses; the
-# actual instance returned by ``DirNode.__get__`` is always a plain
-# ``BoundDir``. The ``DirNode[T]`` generic parameter links each subtree to its
-# typed view (e.g. ``train = DirNode[_TrainDir]("train", ...)``).
+# Each ``_*Dir`` subclass below declares the typed shape of one subtree.
+# Their bodies live entirely inside ``if TYPE_CHECKING:`` and contain only
+# attribute annotations — they have no runtime behaviour.  The actual object
+# returned by ``DirNode.__get__`` at runtime is always a plain ``BoundDir``;
+# the subclass exists solely as the type parameter to the generic descriptor
+# ``DirNode[T_co]``, so that ``ty`` can resolve nested attribute access like
+# ``workdir.train.adapter.metadata`` to the correct ``Path`` / ``BoundDir``
+# type without ``# ty: ignore[unresolved-attribute]`` at every call site.
 #
-# When adding or renaming a child in a ``DirNode(...)`` tree below, update the
-# corresponding subclass here to match.
+# Prior art
+# ---------
+# This is a composition of two well-established typing patterns:
+#
+# 1. Generic descriptor with overloaded ``__get__`` -- the same idiom
+#    SQLAlchemy 2.0 uses for ``Mapped[T]`` / ``InstrumentedAttribute[T]``
+#    (class access returns the descriptor; instance access returns ``T``).
+#    See https://docs.sqlalchemy.org/en/stable/orm/mapped_attributes.html
+#    Similar shapes appear in attrs ``Field[T]``, Django model fields,
+#    and Pydantic ``FieldInfo``.
+#
+# 2. ``if TYPE_CHECKING:`` runtime-invisible declarations, specified in
+#    PEP 484 (section "Runtime or type checking?"). ``TYPE_CHECKING`` is a
+#    compile-time-true, runtime-false flag used to hide declarations from
+#    the interpreter while keeping them visible to type checkers.
+#
+# Naming note
+# -----------
+# We call these "typed views" internally.  They are *not* "phantom types" in
+# the sense used by the ``phantom-types`` library (refinement types with
+# runtime predicates, per the Haskell/ML tradition); the name collision is
+# unhelpful, so we avoid it.
+#
+# Maintenance contract
+# --------------------
+# When adding or renaming a child in one of the ``DirNode(...)`` trees on
+# ``Workdir``, add/rename the matching attribute annotation on the typed-view
+# subclass below.  The ``TestTypedViewDrift`` class in
+# ``tests/cli/test_artifact_structure.py`` parses this module's AST and
+# fails CI if the two sides drift.
 # ---------------------------------------------------------------------------
 
 
@@ -381,10 +413,10 @@ class Workdir:
     dataset_name: str
     """Stem of the dataset file name, used in the project directory name."""
 
-    run_name: str | None = None
+    run_name: str = ""
     """Run name (auto-generated timestamp or explicit name from CLI).
 
-    When ``None``, a timestamp-based name is generated in ``__post_init__``.
+    When empty, a timestamp-based name is generated in ``__post_init__``.
     """
 
     _run_name_obj: RunName = field(default_factory=RunName, repr=False)
@@ -482,7 +514,7 @@ class Workdir:
         """
         if self._explicit_run_path is not None:
             return self._explicit_run_path
-        return self.project_dir / self.run_name  # ty: ignore[unsupported-operator]
+        return self.project_dir / self.run_name
 
     def phase_dir(self, phase: str | None = None) -> Path:
         """Get the phase directory path.

--- a/src/nemo_safe_synthesizer/cli/artifact_structure.py
+++ b/src/nemo_safe_synthesizer/cli/artifact_structure.py
@@ -25,7 +25,7 @@ import os
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Generic, Self, TypeVar, cast, overload
+from typing import TYPE_CHECKING, Generic, Self, TypeVar, overload
 
 from ..observability import get_logger
 from ..utils import write_json
@@ -501,7 +501,7 @@ class Workdir:
         """Log file path for the current phase."""
         phase = self._current_phase or "unknown"
         if phase == "generate":
-            return cast(Path, self.generate.logs)
+            return self.generate.logs
         return self.run_dir / "logs" / f"{phase}.jsonl"
 
     @property
@@ -512,8 +512,8 @@ class Workdir:
         returns the parent's adapter path since that's where the trained adapter lives.
         """
         if self._parent_workdir is not None:
-            return self._parent_workdir.train.adapter.path  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
-        return self.train.adapter.path  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+            return self._parent_workdir.train.adapter.path
+        return self.train.adapter.path
 
     @property
     def metadata_file(self) -> Path:
@@ -522,8 +522,8 @@ class Workdir:
         Uses parent workdir's path when available.
         """
         if self._parent_workdir is not None:
-            return cast(Path, self._parent_workdir.train.adapter.metadata)  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
-        return cast(Path, self.train.adapter.metadata)  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+            return self._parent_workdir.train.adapter.metadata
+        return self.train.adapter.metadata
 
     @property
     def schema_file(self) -> Path:
@@ -532,8 +532,8 @@ class Workdir:
         Uses parent workdir's path when available.
         """
         if self._parent_workdir is not None:
-            return cast(Path, self._parent_workdir.train.adapter.schema)  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
-        return cast(Path, self.train.adapter.schema)  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+            return self._parent_workdir.train.adapter.schema
+        return self.train.adapter.schema
 
     @property
     def dataset_schema_file(self) -> Path:
@@ -543,17 +543,17 @@ class Workdir:
     @property
     def output_file(self) -> Path:
         """Shortcut to generate.output."""
-        return cast(Path, self.generate.output)
+        return self.generate.output
 
     @property
     def evaluation_report(self) -> Path:
         """Shortcut to generate.report."""
-        return cast(Path, self.generate.report)
+        return self.generate.report
 
     @property
     def evaluation_metrics(self) -> Path:
         """Shortcut to generate.evaluation_metrics."""
-        return cast(Path, self.generate.evaluation_metrics)
+        return self.generate.evaluation_metrics
 
     # =========================================================================
     # Source paths (for generation runs that have a parent training run)
@@ -582,7 +582,7 @@ class Workdir:
             return root_config
 
         # Fallback to train directory config (older training runs)
-        train_config = cast(Path, source_workdir.train.config)
+        train_config = source_workdir.train.config
         if train_config.exists():
             return train_config
 
@@ -632,8 +632,8 @@ class Workdir:
             self._write_generation_info()
         else:
             # Training run or end-to-end - create all directories
-            self.train.cache.path.mkdir(parents=True, exist_ok=True)  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
-            self.train.adapter.path.mkdir(parents=True, exist_ok=True)  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+            self.train.cache.path.mkdir(parents=True, exist_ok=True)
+            self.train.adapter.path.mkdir(parents=True, exist_ok=True)
             self.generate.path.mkdir(parents=True, exist_ok=True)
             self.dataset.path.mkdir(parents=True, exist_ok=True)
 

--- a/src/nemo_safe_synthesizer/cli/artifact_structure.py
+++ b/src/nemo_safe_synthesizer/cli/artifact_structure.py
@@ -25,7 +25,7 @@ import os
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Self, cast, overload
+from typing import TYPE_CHECKING, Generic, Self, TypeVar, cast, overload
 
 from ..observability import get_logger
 from ..utils import write_json
@@ -172,12 +172,26 @@ class FileNode:
                 raise TypeError(f"FileNode can only be used with BoundDir or Workdir, got {type(obj)}")
 
 
-class DirNode:
+# Covariant type parameter of ``DirNode``.
+#
+# At runtime every ``DirNode`` resolves to a plain ``BoundDir``. The parameter
+# exists purely so that type checkers can specialise each usage with a
+# ``BoundDir`` subclass (e.g. ``_TrainDir``) that declares the typed children
+# of that subtree -- mirroring SQLAlchemy's ``Mapped[T]`` pattern.
+T_co = TypeVar("T_co", bound="BoundDir", covariant=True)
+
+
+class DirNode(Generic[T_co]):
     """Descriptor for directory paths within a directory structure.
 
     Supports nested children (both FileNode and DirNode).
     When accessed on a class, returns the descriptor itself.
     When accessed on an instance, returns a BoundDir with the resolved path.
+
+    The generic parameter ``T_co`` lets callers specialise instance-access with
+    a :class:`BoundDir` subclass that declares typed children (see
+    :class:`_TrainDir` et al.). Runtime always returns a plain ``BoundDir``;
+    the subscripted type is a typing-only fiction.
 
     Args:
         name: The directory name (e.g., "train").
@@ -193,10 +207,10 @@ class DirNode:
         self._attr_name = name
 
     @overload
-    def __get__(self, obj: None, objtype: type | None = None) -> DirNode: ...
+    def __get__(self, obj: None, objtype: type | None = None) -> Self: ...
 
     @overload
-    def __get__(self, obj: BoundDir | Workdir, objtype: type | None = None) -> BoundDir: ...
+    def __get__(self, obj: BoundDir | Workdir, objtype: type | None = None) -> T_co: ...
 
     def __get__(self, obj: object | None, objtype: type | None = None) -> DirNode | BoundDir:
         """Resolve to the descriptor itself (class access) or a ``BoundDir`` (instance access)."""
@@ -269,6 +283,59 @@ class BoundDir(os.PathLike[str]):
                 return BoundDir(self._path / dirname, children)
             case other:
                 raise TypeError(f"Unknown child type: {type(other)}")
+
+
+# ---------------------------------------------------------------------------
+# Phantom ``BoundDir`` subclasses declaring the typed shape of each subtree.
+#
+# These exist solely so type checkers can see the children of each directory
+# through ``BoundDir.__getattr__``. At runtime they are empty subclasses; the
+# actual instance returned by ``DirNode.__get__`` is always a plain
+# ``BoundDir``. The ``DirNode[T]`` generic parameter links each subtree to its
+# typed view (e.g. ``train = DirNode[_TrainDir]("train", ...)``).
+#
+# When adding or renaming a child in a ``DirNode(...)`` tree below, update the
+# corresponding subclass here to match.
+# ---------------------------------------------------------------------------
+
+
+class _AdapterDir(BoundDir):
+    """Typed view of the ``train/adapter`` subtree."""
+
+    if TYPE_CHECKING:
+        adapter_config: Path
+        metadata: Path
+        schema: Path
+
+
+class _TrainDir(BoundDir):
+    """Typed view of the ``train`` subtree."""
+
+    if TYPE_CHECKING:
+        config: Path
+        cache: BoundDir
+        adapter: _AdapterDir
+
+
+class _GenerateDir(BoundDir):
+    """Typed view of the ``generate`` subtree."""
+
+    if TYPE_CHECKING:
+        logs: Path
+        output: Path
+        report: Path
+        evaluation_metrics: Path
+        info: Path
+
+
+class _DatasetDir(BoundDir):
+    """Typed view of the ``dataset`` subtree."""
+
+    if TYPE_CHECKING:
+        training: Path
+        test: Path
+        validation: Path
+        transformed_training: Path
 
 
 @dataclass
@@ -344,13 +411,11 @@ class Workdir:
     """Location for WandB run ID file."""
 
     # Train directory structure
-    train = DirNode(
+    train = DirNode[_TrainDir](
         "train",
         config=FileNode("safe-synthesizer-config.json"),
-        cache=DirNode(
-            "cache",
-        ),
-        adapter=DirNode(
+        cache=DirNode("cache"),
+        adapter=DirNode[_AdapterDir](
             "adapter",
             adapter_config=FileNode("adapter_config.json"),
             metadata=FileNode("metadata_v2.json"),
@@ -360,7 +425,7 @@ class Workdir:
     """Location and contents of train directory structure."""
 
     # Generate directory structure
-    generate = DirNode(
+    generate = DirNode[_GenerateDir](
         "generate",
         logs=FileNode("logs.jsonl"),
         output=FileNode("synthetic_data.csv"),
@@ -371,7 +436,7 @@ class Workdir:
     """Location and contents of generate directory structure."""
 
     # Dataset directory structure
-    dataset = DirNode(
+    dataset = DirNode[_DatasetDir](
         "dataset",
         training=FileNode("training.csv"),
         test=FileNode("test.csv"),

--- a/src/nemo_safe_synthesizer/data_processing/actions/dates.py
+++ b/src/nemo_safe_synthesizer/data_processing/actions/dates.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from random import randint
-from typing import Optional
+from typing import Optional, cast
 
 import pandas as pd
 
@@ -141,7 +141,12 @@ def date_component_permutations() -> list[tuple[str, str, str, str, str]]:
     Each tuple is indexed by (year, month, day, hms, tz) and can be
     passed into a formatter from ``date_component_orders``.
     """
-    return list(itertools.product(*component_formats.values()))
+    # itertools.product returns variable-length tuples; the five fixed keys in
+    # ``component_formats`` guarantee 5-tuples at runtime.
+    return cast(
+        "list[tuple[str, str, str, str, str]]",
+        list(itertools.product(*component_formats.values())),
+    )
 
 
 def gen_date_str_fmt_permutations() -> set[str]:

--- a/src/nemo_safe_synthesizer/data_processing/actions/dates.py
+++ b/src/nemo_safe_synthesizer/data_processing/actions/dates.py
@@ -17,7 +17,7 @@ from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from random import randint
-from typing import Optional, cast
+from typing import Optional
 
 import pandas as pd
 
@@ -141,11 +141,17 @@ def date_component_permutations() -> list[tuple[str, str, str, str, str]]:
     Each tuple is indexed by (year, month, day, hms, tz) and can be
     passed into a formatter from ``date_component_orders``.
     """
-    # itertools.product returns variable-length tuples; the five fixed keys in
-    # ``component_formats`` guarantee 5-tuples at runtime.
-    return cast(
-        "list[tuple[str, str, str, str, str]]",
-        list(itertools.product(*component_formats.values())),
+    # Passing the five iterables positionally (rather than ``*dict.values()``)
+    # lets the type checker resolve ``itertools.product``'s 5-iterable overload
+    # and infer ``tuple[str, str, str, str, str]`` directly.
+    return list(
+        itertools.product(
+            component_formats["y"],
+            component_formats["m"],
+            component_formats["d"],
+            component_formats["hms"],
+            component_formats["tz"],
+        )
     )
 
 

--- a/src/nemo_safe_synthesizer/data_processing/records/fragment.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/fragment.py
@@ -257,7 +257,7 @@ def build_ner_metadata(preds: list[dict]) -> Metadata:
     return meta.as_dict()
 
 
-def create_ner_api_response(records: list[dict], predictions: list[dict], pure_dict: bool = False) -> list[dict]:
+def create_ner_api_response(records: list[dict], predictions: list[list[dict]], pure_dict: bool = False) -> list[dict]:
     """Build an API-compatible list of ``{data, model_metadata}`` dicts.
 
     Args:

--- a/src/nemo_safe_synthesizer/llm/metadata.py
+++ b/src/nemo_safe_synthesizer/llm/metadata.py
@@ -372,7 +372,7 @@ class ModelMetadata(BaseModel):
         """
         if self.workdir is None:
             raise ValueError("Cannot get adapter_path: workdir is not set")
-        return self.workdir.train.adapter.path.resolve()  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        return self.workdir.train.adapter.path.resolve()
 
     @property
     def metadata_path(self) -> Path:
@@ -414,7 +414,7 @@ class ModelMetadata(BaseModel):
             raise ValueError("Cannot save metadata: workdir is not set")
         write_json(
             self.model_dump(mode="json"),
-            path=self.workdir.train.adapter.metadata,  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+            path=self.workdir.train.adapter.metadata,
             indent=4,
         )
 

--- a/src/nemo_safe_synthesizer/sdk/library_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/library_builder.py
@@ -349,8 +349,9 @@ class SafeSynthesizer(ConfigBuilder):
             self._total_start = time.monotonic()
 
         # Clean up trainer model if it exists (only present when train->generate in same session)
-        if hasattr(self, "trainer") and self.trainer is not None:
-            self.trainer.delete_trainable_model()  # ty: ignore[unresolved-attribute] -- delete_trainable_model is defined on HuggingFaceBackend but not the abstract TrainingBackend base
+        trainer = getattr(self, "trainer", None)
+        if trainer is not None:
+            trainer.teardown()
 
         assert self._workdir is not None
         # Select backend based on time_series configuration

--- a/src/nemo_safe_synthesizer/training/AGENTS.md
+++ b/src/nemo_safe_synthesizer/training/AGENTS.md
@@ -11,7 +11,7 @@ Train LoRA adapters on tabular or time-series data for synthetic generation. Sup
 
 ## Backend Hierarchy
 
-- TrainingBackend (ABC) — defines `prepare_training_data`, `prepare_config`, `prepare_params`, `maybe_quantize`, `load_model`, `train`, `save_model`. Subclasshook checks for these methods.
+- TrainingBackend (ABC) — defines `prepare_training_data`, `prepare_config`, `prepare_params`, `maybe_quantize`, `load_model`, `train`, `save_model`, `teardown`. Subclasshook checks for these methods. `teardown()` is the lifecycle cleanup hook (frees GPU memory, destroys distributed process groups, clears trainer/model state); it must be idempotent and callers should wrap `train()` in `try/finally` to guarantee it runs on error paths.
 - HuggingFaceBackend — uses `AutoModelForCausalLM`, HuggingFace `Trainer`, LoRA via PEFT.
 
 ## FIXED_RUNTIME_TRAINING_ARGS

--- a/src/nemo_safe_synthesizer/training/backend.py
+++ b/src/nemo_safe_synthesizer/training/backend.py
@@ -193,21 +193,21 @@ class TrainingBackend(metaclass=abc.ABCMeta):
 
     @classmethod
     def __subclasshook__(cls, subclass):
-        return (
-            hasattr(subclass, "prepare_training_data")
-            and callable(subclass.prepare_training_data)
-            and hasattr(subclass, "load_model")
-            and callable(subclass.load_model)
-            and hasattr(subclass, "prepare_training_args")
-            and callable(subclass.prepare_params)
-            and hasattr(subclass, "maybe_quantize")
-            and callable(subclass.maybe_quantize)
-            and hasattr(subclass, "train")
-            and callable(subclass.train)
-            and hasattr(subclass, "save_model")
-            and callable(subclass.save_model)
-            or NotImplemented
+        if cls is not TrainingBackend:
+            return NotImplemented
+        required = (
+            "prepare_training_data",
+            "prepare_config",
+            "prepare_params",
+            "maybe_quantize",
+            "load_model",
+            "train",
+            "save_model",
+            "teardown",
         )
+        if all(callable(getattr(subclass, name, None)) for name in required):
+            return True
+        return NotImplemented
 
     @abc.abstractmethod
     def prepare_training_data(self) -> None:
@@ -282,6 +282,21 @@ class TrainingBackend(metaclass=abc.ABCMeta):
         model from GPU memory after saving.
         """
         ...
+
+    @abc.abstractmethod
+    def teardown(self) -> None:
+        """Release all resources held by this backend.
+
+        Frees GPU memory, destroys distributed process groups, and
+        cleans up trainer/model state. Must be idempotent -- safe to
+        call multiple times. Implementations should use the
+        ``_torn_down`` guard flag and isolate each cleanup step so one
+        failure doesn't prevent subsequent cleanup.
+
+        Callers should wrap ``train()`` in ``try/finally`` to guarantee
+        this runs even when training raises.
+        """
+        pass
 
     def _trust_remote_code_for_model(self) -> bool:
         """Determine whether the model should be loaded with ``trust_remote_code=True``.

--- a/src/nemo_safe_synthesizer/training/huggingface_backend.py
+++ b/src/nemo_safe_synthesizer/training/huggingface_backend.py
@@ -708,11 +708,12 @@ class HuggingFaceBackend(TrainingBackend):
         self.trainer.train()
         training_time_sec = time.monotonic() - training_start
 
-        # Save log_history before save_model() which may delete the trainer
+        # Capture log_history before teardown deletes the trainer.
         log_history = self.trainer.state.log_history
         is_complete = "training_incomplete" not in sum([list(d.keys()) for d in log_history], [])
 
         self.save_model()
+        self.teardown()
 
         self.results = NSSTrainerResult(
             training_df=self.training_df,
@@ -724,11 +725,13 @@ class HuggingFaceBackend(TrainingBackend):
             elapsed_time=training_time_sec,
         )
 
-    def save_model(self, delete_trainable_model: bool = True) -> None:
-        """Save the fine-tuning adapter and related artifacts to the given path.
+    def save_model(self) -> None:
+        """Save the fine-tuning adapter and related artifacts under ``self.workdir``.
 
-        Args:
-            delete_trainable_model: If True, delete the model from memory after saving.
+        Does not release resources -- callers should invoke :meth:`teardown`
+        explicitly when they are done with the backend (the abstract contract
+        on :class:`TrainingBackend` keeps save and teardown as separate
+        lifecycle events).
         """
         if self.dataset_schema is None:
             raise ParameterError("dataset_schema must be set before saving model")
@@ -751,26 +754,40 @@ class HuggingFaceBackend(TrainingBackend):
             path=self.workdir.train.config,
             indent=4,
         )
-        if delete_trainable_model:
-            self.delete_trainable_model()
 
-    def delete_trainable_model(self) -> None:
-        """Delete the trainable model, trainer, and clean up GPU memory and distributed resources."""
+    def teardown(self) -> None:
+        """Release GPU memory, distributed resources, and trainer state. Idempotent -- safe to call multiple times."""
+        if getattr(self, "_torn_down", False):
+            return
+        self._torn_down = True
+
         import torch.distributed as dist
 
-        # Delete the trainer first, as it holds references to the model
-        if hasattr(self, "trainer"):
-            del self.trainer
-        if hasattr(self, "model"):
-            del self.model
-        cleanup_memory()
-        # Clean up distributed process group if it was initialized by the Trainer
+        try:
+            if hasattr(self, "trainer"):
+                del self.trainer
+        except Exception:  # pragma: no cover -- defensive; del on an instance attr does not raise
+            logger.warning("trainer cleanup failed during teardown", exc_info=True)
+
+        try:
+            if hasattr(self, "model"):
+                del self.model
+        except Exception:  # pragma: no cover -- defensive; del on an instance attr does not raise
+            logger.warning("model cleanup failed during teardown", exc_info=True)
+
+        try:
+            cleanup_memory()
+        except Exception:
+            logger.warning("cleanup_memory failed during teardown", exc_info=True)
 
         if TYPE_CHECKING:
             assert hasattr(dist, "destroy_process_group")
             assert hasattr(dist, "is_initialized")
-        if dist.is_initialized():
-            dist.destroy_process_group()
+        try:
+            if dist.is_initialized():
+                dist.destroy_process_group()
+        except Exception:
+            logger.warning("destroy_process_group failed during teardown", exc_info=True)
 
     def __str__(self):
         f = f"HuggingFaceBackend(pretrained_model={self.params.training.pretrained_model}, params={self.params})"

--- a/src/nemo_safe_synthesizer/utils.py
+++ b/src/nemo_safe_synthesizer/utils.py
@@ -211,7 +211,7 @@ def grouped_train_test_split(
     # importing like this to avoid a dep for testing on the sdk side
     from .holdout import holdout as nss_holdout
 
-    return nss_holdout.grouped_train_test_split(input_df=df, test_size=test_size, group_by=group_by, random_state=seed)  # ty: ignore[invalid-argument-type]
+    return nss_holdout.grouped_train_test_split(input_df=df, test_size=test_size, group_by=group_by, random_state=seed)
 
 
 class DataActionsFn(Protocol):

--- a/src/nemo_safe_synthesizer/utils.py
+++ b/src/nemo_safe_synthesizer/utils.py
@@ -178,7 +178,8 @@ def time_function(func: Callable[..., Any]) -> Callable[..., Any]:
         result = func(*args, **kwargs)
         time_elapsed = time.perf_counter() - start
         time_elapsed = f"{time_elapsed:.2f} sec" if time_elapsed <= 120 else f"{time_elapsed / 60:.2f} min"
-        logger.info(f"⏱️  Function: {func.__name__}, Time: {time_elapsed}\n")  # ty: ignore[unresolved-attribute]
+        func_name = getattr(func, "__name__", None) or repr(func)
+        logger.info(f"⏱️  Function: {func_name}, Time: {time_elapsed}\n")
         return result
 
     return time_closure

--- a/tests/cli/test_artifact_structure.py
+++ b/tests/cli/test_artifact_structure.py
@@ -713,12 +713,17 @@ def _dir_node_phantom_and_children(call: ast.Call) -> tuple[str, set[str]] | Non
 
     Returns ``None`` for bare ``DirNode(...)`` calls (no phantom type parameter).
     """
-    match call.func:
-        case ast.Subscript(value=ast.Name(id="DirNode"), slice=ast.Name(id=phantom_name)):
-            kwargs = {kw.arg for kw in call.keywords if kw.arg is not None}
-            return phantom_name, kwargs
-        case _:
-            return None
+    func = call.func
+    if (
+        isinstance(func, ast.Subscript)
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "DirNode"
+        and isinstance(func.slice, ast.Name)
+    ):
+        phantom_name = func.slice.id
+        kwargs = {kw.arg for kw in call.keywords if kw.arg is not None}
+        return phantom_name, kwargs
+    return None
 
 
 def _collect_dir_node_calls(node: ast.AST) -> list[ast.Call]:

--- a/tests/cli/test_artifact_structure.py
+++ b/tests/cli/test_artifact_structure.py
@@ -316,14 +316,14 @@ class TestWorkdir:
 
     def test_train_adapter_path(self, workdir: Workdir):
         """train.adapter.path is train/adapter."""
-        assert workdir.train.adapter.path == workdir.train.path / "adapter"  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        assert workdir.train.adapter.path == workdir.train.path / "adapter"
 
     def test_train_model_files(self, workdir: Workdir):
         """Adapter directory contains expected files."""
         adapter = workdir.train.adapter
-        assert adapter.adapter_config == adapter.path / "adapter_config.json"  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
-        assert adapter.metadata == adapter.path / "metadata_v2.json"  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
-        assert adapter.schema == adapter.path / "dataset_schema.json"  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        assert adapter.adapter_config == adapter.path / "adapter_config.json"
+        assert adapter.metadata == adapter.path / "metadata_v2.json"
+        assert adapter.schema == adapter.path / "dataset_schema.json"
 
     # =========================================================================
     # Generate directory structure
@@ -362,15 +362,15 @@ class TestWorkdir:
 
     def test_adapter_path_alias(self, workdir: Workdir):
         """adapter_path shortcut matches full path."""
-        assert workdir.adapter_path == workdir.train.adapter.path  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        assert workdir.adapter_path == workdir.train.adapter.path
 
     def test_metadata_file_alias(self, workdir: Workdir):
         """metadata_file shortcut matches full path."""
-        assert workdir.metadata_file == workdir.train.adapter.metadata  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        assert workdir.metadata_file == workdir.train.adapter.metadata
 
     def test_schema_file_alias(self, workdir: Workdir):
         """schema_file shortcut matches full path."""
-        assert workdir.schema_file == workdir.train.adapter.schema  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        assert workdir.schema_file == workdir.train.adapter.schema
 
     def test_output_file_alias(self, workdir: Workdir):
         """output_file shortcut matches full path."""
@@ -392,7 +392,7 @@ class TestWorkdir:
         """ensure_directories creates the expected directory structure."""
         workdir_tmp.ensure_directories()
 
-        assert workdir_tmp.train.adapter.path.is_dir()  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        assert workdir_tmp.train.adapter.path.is_dir()
         assert workdir_tmp.generate.path.is_dir()
         assert workdir_tmp.dataset.path.is_dir()
 
@@ -406,7 +406,7 @@ class TestWorkdir:
         workdir_tmp.ensure_directories()
         workdir_tmp.ensure_directories()  # Should not raise
 
-        assert workdir_tmp.train.adapter.path.is_dir()  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        assert workdir_tmp.train.adapter.path.is_dir()
 
     # =========================================================================
     # from_path tests
@@ -415,7 +415,7 @@ class TestWorkdir:
     def test_from_path_with_run_dir(self, workdir_tmp: Workdir):
         """from_path correctly loads a workdir from a run_dir."""
         # Create adapter directory and dummy safetensors file
-        adapter_dir = workdir_tmp.train.adapter.path  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        adapter_dir = workdir_tmp.train.adapter.path
         adapter_dir.mkdir(parents=True, exist_ok=True)
         adapter_file = adapter_dir / "adapter_model.safetensors"
         adapter_file.touch()
@@ -429,7 +429,7 @@ class TestWorkdir:
     def test_from_path_with_project_dir(self, workdir_tmp: Workdir):
         """from_path finds latest run when given a project_dir."""
         # Create adapter directory and dummy safetensors file
-        adapter_dir = workdir_tmp.train.adapter.path  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        adapter_dir = workdir_tmp.train.adapter.path
         adapter_dir.mkdir(parents=True, exist_ok=True)
         adapter_file = adapter_dir / "adapter_model.safetensors"
         adapter_file.touch()
@@ -443,7 +443,7 @@ class TestWorkdir:
     def test_from_path_with_base_path(self, workdir_tmp: Workdir):
         """from_path finds latest run across all projects when given a base_path."""
         # Create adapter directory and dummy safetensors file
-        adapter_dir = workdir_tmp.train.adapter.path  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        adapter_dir = workdir_tmp.train.adapter.path
         adapter_dir.mkdir(parents=True, exist_ok=True)
         adapter_file = adapter_dir / "adapter_model.safetensors"
         adapter_file.touch()
@@ -560,7 +560,7 @@ class TestWorkdir:
     def test_new_generation_run_adapter_path_uses_parent(self, workdir_tmp: Workdir):
         """Child workdir's adapter_path returns parent's adapter path."""
         # Create adapter in parent
-        adapter_dir = workdir_tmp.train.adapter.path  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        adapter_dir = workdir_tmp.train.adapter.path
         adapter_dir.mkdir(parents=True, exist_ok=True)
         adapter_file = adapter_dir / "adapter_model.safetensors"
         adapter_file.touch()
@@ -568,7 +568,7 @@ class TestWorkdir:
         child = workdir_tmp.new_generation_run()
 
         # Child's adapter_path should point to parent's adapter
-        assert child.adapter_path == workdir_tmp.train.adapter.path  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+        assert child.adapter_path == workdir_tmp.train.adapter.path
         assert child.adapter_path.exists()
 
     def test_new_generation_run_source_config_uses_parent(self, workdir_tmp: Workdir):

--- a/tests/cli/test_artifact_structure.py
+++ b/tests/cli/test_artifact_structure.py
@@ -262,7 +262,7 @@ class TestWorkdir:
 
     def test_run_dir(self, workdir: Workdir):
         """run_dir is project_dir/run_name."""
-        assert workdir.run_name is not None
+        assert workdir.run_name, "run_name should be populated by __post_init__"
         assert workdir.run_dir == workdir.project_dir / workdir.run_name
 
     def test_workdir_with_arbitrary_run_name(self, fixture_session_cache_dir: Path):
@@ -677,27 +677,29 @@ class TestParseProjectName:
 
 
 # =============================================================================
-# Phantom Subclass Drift Guard
+# Typed-View Drift Guard
 # =============================================================================
 #
-# The `Workdir` class declares its directory tree using `DirNode[_PhantomDir](...)`.
-# `_PhantomDir` is a `BoundDir` subclass whose body lives under `if TYPE_CHECKING:`
+# The `Workdir` class declares its directory tree using `DirNode[_FooDir](...)`.
+# `_FooDir` is a `BoundDir` subclass whose body lives under `if TYPE_CHECKING:`
 # and exists only to declare the typed children of that subtree so `ty` (and
-# editors) can resolve attribute access through `BoundDir.__getattr__`.
+# editors) can resolve attribute access through `BoundDir.__getattr__`. We
+# call these subclasses "typed views" internally (see the section comment in
+# `artifact_structure.py` for context and prior art).
 #
 # If someone adds or renames a child in a `DirNode(...)` tree but forgets to
-# update the matching phantom subclass (or vice versa), type checking will
+# update the matching typed-view subclass (or vice versa), type checking will
 # silently weaken: the code still runs (thanks to `__getattr__`) but static
 # analysis loses precision and ``ty: ignore`` comments start creeping back.
 #
-# This test reads `artifact_structure.py` with `ast` (phantom annotations are
-# gated by `TYPE_CHECKING` and therefore absent at runtime) and asserts that
-# every `DirNode[_Foo](...)` call's keyword-argument names exactly match the
-# attribute names declared on `_Foo`'s `if TYPE_CHECKING:` block.
+# This test reads `artifact_structure.py` with `ast` (typed-view annotations
+# are gated by `TYPE_CHECKING` and therefore absent at runtime) and asserts
+# that every `DirNode[_Foo](...)` call's keyword-argument names exactly match
+# the attribute names declared on `_Foo`'s `if TYPE_CHECKING:` block.
 
 
-def _phantom_type_checking_annotations(cls_node: ast.ClassDef) -> set[str]:
-    """Extract attribute names from a phantom class's ``if TYPE_CHECKING:`` body."""
+def _typed_view_annotations(cls_node: ast.ClassDef) -> set[str]:
+    """Extract attribute names from a typed-view class's ``if TYPE_CHECKING:`` body."""
     names: set[str] = set()
     for stmt in cls_node.body:
         if isinstance(stmt, ast.If) and isinstance(stmt.test, ast.Name) and stmt.test.id == "TYPE_CHECKING":
@@ -707,10 +709,10 @@ def _phantom_type_checking_annotations(cls_node: ast.ClassDef) -> set[str]:
     return names
 
 
-def _dir_node_phantom_and_children(call: ast.Call) -> tuple[str, set[str]] | None:
-    """Return ``(phantom_name, child_kwarg_names)`` for ``DirNode[_Foo](name, **kwargs)``.
+def _dir_node_view_and_children(call: ast.Call) -> tuple[str, set[str]] | None:
+    """Return ``(view_name, child_kwarg_names)`` for ``DirNode[_Foo](name, **kwargs)``.
 
-    Returns ``None`` for bare ``DirNode(...)`` calls (no phantom type parameter).
+    Returns ``None`` for bare ``DirNode(...)`` calls (no typed-view type parameter).
     """
     func = call.func
     if (
@@ -719,9 +721,9 @@ def _dir_node_phantom_and_children(call: ast.Call) -> tuple[str, set[str]] | Non
         and func.value.id == "DirNode"
         and isinstance(func.slice, ast.Name)
     ):
-        phantom_name = func.slice.id
+        view_name = func.slice.id
         kwargs = {kw.arg for kw in call.keywords if kw.arg is not None}
-        return phantom_name, kwargs
+        return view_name, kwargs
     return None
 
 
@@ -730,11 +732,38 @@ def _collect_dir_node_calls(node: ast.AST) -> list[ast.Call]:
     return [child for child in ast.walk(node) if isinstance(child, ast.Call)]
 
 
-class TestPhantomSubclassDrift:
+def _compute_drift_mismatches(
+    view_annotations: dict[str, set[str]],
+    dir_node_usages: list[tuple[str, set[str]]],
+) -> list[str]:
+    """Diff each ``DirNode[_Foo](...)`` call's kwargs against ``_Foo``'s annotations.
+
+    Returns an empty list when every usage's kwargs exactly equal the
+    annotations on its referenced typed view, otherwise one human-readable
+    diagnostic per mismatch.
+    """
+    mismatches: list[str] = []
+    for view_name, child_kwargs in dir_node_usages:
+        annotated = view_annotations.get(view_name)
+        if annotated is None:
+            mismatches.append(f"DirNode[{view_name}] references unknown typed-view class")
+            continue
+        if annotated != child_kwargs:
+            only_in_view = sorted(annotated - child_kwargs)
+            only_in_dir_node = sorted(child_kwargs - annotated)
+            mismatches.append(
+                f"DirNode[{view_name}]: "
+                f"only in {view_name} annotations = {only_in_view}; "
+                f"only in DirNode kwargs = {only_in_dir_node}"
+            )
+    return mismatches
+
+
+class TestTypedViewDrift:
     """Guards that `DirNode[_Foo](...)` keys match `_Foo`'s typed attributes.
 
     Failures here mean somebody added/renamed a child on one side of the
-    ``DirNode[_PhantomDir]`` ↔ phantom-subclass pair without updating the
+    ``DirNode[_FooDir]`` ↔ typed-view-subclass pair without updating the
     other. The cli/AGENTS.md ``artifact_structure.py`` section covers the
     convention.
     """
@@ -746,51 +775,92 @@ class TestPhantomSubclassDrift:
         return ast.parse(inspect.getsource(module))
 
     @pytest.fixture(scope="class")
-    def phantom_annotations(self, module_ast: ast.Module) -> dict[str, set[str]]:
-        """Map phantom class name → attribute names declared under ``TYPE_CHECKING``."""
+    def typed_view_annotations(self, module_ast: ast.Module) -> dict[str, set[str]]:
+        """Map typed-view class name → attribute names declared under ``TYPE_CHECKING``."""
         return {
-            node.name: _phantom_type_checking_annotations(node)
+            node.name: _typed_view_annotations(node)
             for node in module_ast.body
             if isinstance(node, ast.ClassDef) and node.name.startswith("_") and node.name.endswith("Dir")
         }
 
     @pytest.fixture(scope="class")
     def dir_node_usages(self, module_ast: ast.Module) -> list[tuple[str, set[str]]]:
-        """List of every ``DirNode[_Foo](...)`` call's (phantom name, child kwarg names)."""
+        """List of every ``DirNode[_Foo](...)`` call's (typed-view name, child kwarg names)."""
         usages: list[tuple[str, set[str]]] = []
         for call in _collect_dir_node_calls(module_ast):
-            result = _dir_node_phantom_and_children(call)
+            result = _dir_node_view_and_children(call)
             if result is not None:
                 usages.append(result)
         return usages
 
-    def test_phantom_classes_discovered(self, phantom_annotations: dict[str, set[str]]):
-        """Sanity check: ensure we actually found the phantom subclasses."""
-        assert {"_AdapterDir", "_TrainDir", "_GenerateDir", "_DatasetDir"} <= set(phantom_annotations)
+    def test_typed_view_classes_discovered(self, typed_view_annotations: dict[str, set[str]]):
+        """Sanity check: ensure we actually found the typed-view subclasses."""
+        assert {"_AdapterDir", "_TrainDir", "_GenerateDir", "_DatasetDir"} <= set(typed_view_annotations)
 
     def test_dir_node_usages_discovered(self, dir_node_usages: list[tuple[str, set[str]]]):
         """Sanity check: ensure we actually found at least the top-level typed DirNodes."""
-        phantoms_used = {phantom for phantom, _ in dir_node_usages}
-        assert {"_TrainDir", "_AdapterDir", "_GenerateDir", "_DatasetDir"} <= phantoms_used
+        views_used = {view for view, _ in dir_node_usages}
+        assert {"_TrainDir", "_AdapterDir", "_GenerateDir", "_DatasetDir"} <= views_used
 
-    def test_dir_node_keys_match_phantom_annotations(
+    def test_dir_node_keys_match_typed_view_annotations(
         self,
-        phantom_annotations: dict[str, set[str]],
+        typed_view_annotations: dict[str, set[str]],
         dir_node_usages: list[tuple[str, set[str]]],
     ):
         """Every ``DirNode[_Foo](...)`` kwargs must equal ``_Foo``'s TYPE_CHECKING attrs."""
-        mismatches: list[str] = []
-        for phantom_name, child_kwargs in dir_node_usages:
-            annotated = phantom_annotations.get(phantom_name)
-            if annotated is None:
-                mismatches.append(f"DirNode[{phantom_name}] references unknown phantom class")
-                continue
-            if annotated != child_kwargs:
-                only_in_phantom = sorted(annotated - child_kwargs)
-                only_in_dir_node = sorted(child_kwargs - annotated)
-                mismatches.append(
-                    f"DirNode[{phantom_name}]: "
-                    f"only in {phantom_name} annotations = {only_in_phantom}; "
-                    f"only in DirNode kwargs = {only_in_dir_node}"
-                )
-        assert not mismatches, "Phantom/DirNode drift:\n  " + "\n  ".join(mismatches)
+        mismatches = _compute_drift_mismatches(typed_view_annotations, dir_node_usages)
+        assert not mismatches, "Typed-view / DirNode drift:\n  " + "\n  ".join(mismatches)
+
+
+class TestTypedViewDriftHelpers:
+    """Direct unit tests for the typed-view drift helper functions.
+
+    These exercise the error-reporting branches that the real module never
+    hits (unknown typed view, kwargs mismatch, bare ``DirNode(...)`` calls).
+    """
+
+    @staticmethod
+    def _parse_single_call(source: str) -> ast.Call:
+        """Parse a one-expression snippet and return its single ``ast.Call`` node."""
+        tree = ast.parse(source, mode="eval")
+        assert isinstance(tree.body, ast.Call)
+        return tree.body
+
+    def test_dir_node_view_and_children_extracts_subscripted_call(self):
+        """``DirNode[_Foo](name, a=..., b=...)`` → ``('_Foo', {'a', 'b'})``."""
+        call = self._parse_single_call('DirNode[_FooDir]("foo", a=1, b=2)')
+        assert _dir_node_view_and_children(call) == ("_FooDir", {"a", "b"})
+
+    def test_dir_node_view_and_children_returns_none_for_bare_dir_node(self):
+        """Unsubscripted ``DirNode(...)`` calls yield ``None`` (typed view unknown)."""
+        call = self._parse_single_call('DirNode("foo", a=1)')
+        assert _dir_node_view_and_children(call) is None
+
+    def test_dir_node_view_and_children_returns_none_for_other_calls(self):
+        """Calls that aren't ``DirNode[...](...)`` at all yield ``None``."""
+        call = self._parse_single_call("FileNode('foo.json')")
+        assert _dir_node_view_and_children(call) is None
+
+    def test_compute_drift_mismatches_clean(self):
+        """No mismatches when every usage lines up with its typed-view annotations."""
+        views = {"_FooDir": {"a", "b"}}
+        usages = [("_FooDir", {"a", "b"})]
+        assert _compute_drift_mismatches(views, usages) == []
+
+    def test_compute_drift_mismatches_unknown_view(self):
+        """``DirNode[_Missing]`` with no matching class is reported by name."""
+        mismatches = _compute_drift_mismatches(
+            view_annotations={},
+            dir_node_usages=[("_Missing", {"x"})],
+        )
+        assert mismatches == ["DirNode[_Missing] references unknown typed-view class"]
+
+    def test_compute_drift_mismatches_reports_both_sides(self):
+        """Diagnostic splits extras into 'only in typed view' vs 'only in DirNode kwargs'."""
+        views = {"_FooDir": {"a", "b", "c"}}
+        usages = [("_FooDir", {"a", "d"})]
+        mismatches = _compute_drift_mismatches(views, usages)
+        assert len(mismatches) == 1
+        msg = mismatches[0]
+        assert "only in _FooDir annotations = ['b', 'c']" in msg
+        assert "only in DirNode kwargs = ['d']" in msg

--- a/tests/cli/test_artifact_structure.py
+++ b/tests/cli/test_artifact_structure.py
@@ -3,11 +3,14 @@
 
 """Tests for the artifact_structure module."""
 
+import ast
+import inspect
 import os
 from pathlib import Path
 
 import pytest
 
+import nemo_safe_synthesizer.cli.artifact_structure as artifact_structure_module
 from nemo_safe_synthesizer.cli.artifact_structure import (
     PROJECT_NAME_DELIMITER,
     BoundDir,
@@ -672,3 +675,117 @@ class TestParseProjectName:
         config, dataset = _parse_project_name(workdir.project_name)
         assert config == "test-config"
         assert dataset == "test-dataset"
+
+
+# =============================================================================
+# Phantom Subclass Drift Guard
+# =============================================================================
+#
+# The `Workdir` class declares its directory tree using `DirNode[_PhantomDir](...)`.
+# `_PhantomDir` is a `BoundDir` subclass whose body lives under `if TYPE_CHECKING:`
+# and exists only to declare the typed children of that subtree so `ty` (and
+# editors) can resolve attribute access through `BoundDir.__getattr__`.
+#
+# If someone adds or renames a child in a `DirNode(...)` tree but forgets to
+# update the matching phantom subclass (or vice versa), type checking will
+# silently weaken: the code still runs (thanks to `__getattr__`) but static
+# analysis loses precision and ``ty: ignore`` comments start creeping back.
+#
+# This test reads `artifact_structure.py` with `ast` (phantom annotations are
+# gated by `TYPE_CHECKING` and therefore absent at runtime) and asserts that
+# every `DirNode[_Foo](...)` call's keyword-argument names exactly match the
+# attribute names declared on `_Foo`'s `if TYPE_CHECKING:` block.
+
+
+def _phantom_type_checking_annotations(cls_node: ast.ClassDef) -> set[str]:
+    """Extract attribute names from a phantom class's ``if TYPE_CHECKING:`` body."""
+    names: set[str] = set()
+    for stmt in cls_node.body:
+        if isinstance(stmt, ast.If) and isinstance(stmt.test, ast.Name) and stmt.test.id == "TYPE_CHECKING":
+            for inner in stmt.body:
+                if isinstance(inner, ast.AnnAssign) and isinstance(inner.target, ast.Name):
+                    names.add(inner.target.id)
+    return names
+
+
+def _dir_node_phantom_and_children(call: ast.Call) -> tuple[str, set[str]] | None:
+    """Return ``(phantom_name, child_kwarg_names)`` for ``DirNode[_Foo](name, **kwargs)``.
+
+    Returns ``None`` for bare ``DirNode(...)`` calls (no phantom type parameter).
+    """
+    match call.func:
+        case ast.Subscript(value=ast.Name(id="DirNode"), slice=ast.Name(id=phantom_name)):
+            kwargs = {kw.arg for kw in call.keywords if kw.arg is not None}
+            return phantom_name, kwargs
+        case _:
+            return None
+
+
+def _collect_dir_node_calls(node: ast.AST) -> list[ast.Call]:
+    """Walk an AST subtree and return every ``ast.Call`` node."""
+    return [child for child in ast.walk(node) if isinstance(child, ast.Call)]
+
+
+class TestPhantomSubclassDrift:
+    """Guards that `DirNode[_Foo](...)` keys match `_Foo`'s typed attributes.
+
+    Failures here mean somebody added/renamed a child on one side of the
+    ``DirNode[_PhantomDir]`` ↔ phantom-subclass pair without updating the
+    other. The cli/AGENTS.md ``artifact_structure.py`` section covers the
+    convention.
+    """
+
+    @pytest.fixture(scope="class")
+    def module_ast(self) -> ast.Module:
+        source = inspect.getsource(artifact_structure_module)
+        return ast.parse(source)
+
+    @pytest.fixture(scope="class")
+    def phantom_annotations(self, module_ast: ast.Module) -> dict[str, set[str]]:
+        """Map phantom class name → attribute names declared under ``TYPE_CHECKING``."""
+        return {
+            node.name: _phantom_type_checking_annotations(node)
+            for node in module_ast.body
+            if isinstance(node, ast.ClassDef) and node.name.startswith("_") and node.name.endswith("Dir")
+        }
+
+    @pytest.fixture(scope="class")
+    def dir_node_usages(self, module_ast: ast.Module) -> list[tuple[str, set[str]]]:
+        """List of every ``DirNode[_Foo](...)`` call's (phantom name, child kwarg names)."""
+        usages: list[tuple[str, set[str]]] = []
+        for call in _collect_dir_node_calls(module_ast):
+            result = _dir_node_phantom_and_children(call)
+            if result is not None:
+                usages.append(result)
+        return usages
+
+    def test_phantom_classes_discovered(self, phantom_annotations: dict[str, set[str]]):
+        """Sanity check: ensure we actually found the phantom subclasses."""
+        assert {"_AdapterDir", "_TrainDir", "_GenerateDir", "_DatasetDir"} <= set(phantom_annotations)
+
+    def test_dir_node_usages_discovered(self, dir_node_usages: list[tuple[str, set[str]]]):
+        """Sanity check: ensure we actually found at least the top-level typed DirNodes."""
+        phantoms_used = {phantom for phantom, _ in dir_node_usages}
+        assert {"_TrainDir", "_AdapterDir", "_GenerateDir", "_DatasetDir"} <= phantoms_used
+
+    def test_dir_node_keys_match_phantom_annotations(
+        self,
+        phantom_annotations: dict[str, set[str]],
+        dir_node_usages: list[tuple[str, set[str]]],
+    ):
+        """Every ``DirNode[_Foo](...)`` kwargs must equal ``_Foo``'s TYPE_CHECKING attrs."""
+        mismatches: list[str] = []
+        for phantom_name, child_kwargs in dir_node_usages:
+            annotated = phantom_annotations.get(phantom_name)
+            if annotated is None:
+                mismatches.append(f"DirNode[{phantom_name}] references unknown phantom class")
+                continue
+            if annotated != child_kwargs:
+                only_in_phantom = sorted(annotated - child_kwargs)
+                only_in_dir_node = sorted(child_kwargs - annotated)
+                mismatches.append(
+                    f"DirNode[{phantom_name}]: "
+                    f"only in {phantom_name} annotations = {only_in_phantom}; "
+                    f"only in DirNode kwargs = {only_in_dir_node}"
+                )
+        assert not mismatches, "Phantom/DirNode drift:\n  " + "\n  ".join(mismatches)

--- a/tests/cli/test_artifact_structure.py
+++ b/tests/cli/test_artifact_structure.py
@@ -10,7 +10,6 @@ from pathlib import Path
 
 import pytest
 
-import nemo_safe_synthesizer.cli.artifact_structure as artifact_structure_module
 from nemo_safe_synthesizer.cli.artifact_structure import (
     PROJECT_NAME_DELIMITER,
     BoundDir,
@@ -742,8 +741,9 @@ class TestPhantomSubclassDrift:
 
     @pytest.fixture(scope="class")
     def module_ast(self) -> ast.Module:
-        source = inspect.getsource(artifact_structure_module)
-        return ast.parse(source)
+        module = inspect.getmodule(Workdir)
+        assert module is not None, "Workdir must be importable from a real source file"
+        return ast.parse(inspect.getsource(module))
 
     @pytest.fixture(scope="class")
     def phantom_annotations(self, module_ast: ast.Module) -> dict[str, set[str]]:

--- a/tests/evaluation/components/test_composite_score.py
+++ b/tests/evaluation/components/test_composite_score.py
@@ -25,16 +25,12 @@ from nemo_safe_synthesizer.evaluation.data_model.evaluation_score import Evaluat
 
 @pytest.fixture
 def column_correlation_stability():
-    return Correlation(
-        score=EvaluationScore(name="Column Correlation Stability", raw_score=5.0, score=5.0, grade=Grade.UNAVAILABLE)  # ty: ignore[unknown-argument] -- pydantic kwarg
-    )
+    return Correlation(score=EvaluationScore(raw_score=5.0, score=5.0, grade=Grade.UNAVAILABLE))
 
 
 @pytest.fixture
 def deep_structure_stability():
-    return DeepStructure(
-        score=EvaluationScore(name="Deep Structure Stability", raw_score=2.0, score=2.0, grade=Grade.UNAVAILABLE)  # ty: ignore[unknown-argument] -- pydantic kwarg
-    )
+    return DeepStructure(score=EvaluationScore(raw_score=2.0, score=2.0, grade=Grade.UNAVAILABLE))
 
 
 @pytest.fixture
@@ -44,16 +40,12 @@ def column_distribution_stability(evaluation_datasets_5k):
 
 @pytest.fixture
 def text_semantic_stability():
-    return TextSemanticSimilarity(
-        score=EvaluationScore(name="Text Semantic Similarity", raw_score=7.0, score=7.0, grade=Grade.UNAVAILABLE)  # ty: ignore[unknown-argument] -- pydantic kwarg
-    )
+    return TextSemanticSimilarity(score=EvaluationScore(raw_score=7.0, score=7.0, grade=Grade.UNAVAILABLE))
 
 
 @pytest.fixture
 def text_structure_stability():
-    return TextStructureSimilarity(
-        score=EvaluationScore(name="Text Structure Similarity", raw_score=3.0, score=3.0, grade=Grade.UNAVAILABLE)  # ty: ignore[unknown-argument] -- pydantic kwarg
-    )
+    return TextStructureSimilarity(score=EvaluationScore(raw_score=3.0, score=3.0, grade=Grade.UNAVAILABLE))
 
 
 # @pytest.fixture

--- a/tests/generation/test_vllm_backend.py
+++ b/tests/generation/test_vllm_backend.py
@@ -53,7 +53,7 @@ def mock_workdir(fixture_session_cache_dir):
     assert workdir.run_dir.exists(), f"Run dir not created: {workdir.run_dir}"
     assert workdir.train.path.exists(), f"Train dir not created: {workdir.train.path}"
     assert workdir.generate.path.exists(), f"Generate dir not created: {workdir.generate.path}"
-    assert workdir.train.adapter.path.exists(), f"Adapter path not created: {workdir.train.adapter.path}"  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+    assert workdir.train.adapter.path.exists(), f"Adapter path not created: {workdir.train.adapter.path}"
 
     return workdir
 

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -144,7 +144,7 @@ def assert_adapter_saved(workdir: Workdir) -> None:
 
     Reusable assertion helper for any test that trains via the SDK.
     """
-    adapter_dir = workdir.train.adapter.path  # ty: ignore[unresolved-attribute] -- BoundDir delegates via __getattr__
+    adapter_dir = workdir.train.adapter.path
     assert (adapter_dir / "adapter_config.json").exists(), "adapter_config.json missing"
     assert any(adapter_dir.glob("*.safetensors")), "No safetensors files found"
 

--- a/tests/training/test_backend_lifecycle.py
+++ b/tests/training/test_backend_lifecycle.py
@@ -1,0 +1,106 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lifecycle tests for ``HuggingFaceBackend.teardown``.
+
+Covers the two contract guarantees that don't need a GPU to verify:
+
+- Idempotency: a second call after ``_torn_down`` is set is a no-op, so
+  callers that wrap ``train()`` in ``try/finally`` can call ``teardown``
+  on every exit path without double-freeing resources.
+- Per-step error isolation: each cleanup step is wrapped in its own
+  ``try/except`` so a torch / NCCL failure in one step doesn't prevent
+  the others from running and doesn't escape the call.
+
+The branch on ``dist.is_initialized()`` is also exercised here because
+calling ``destroy_process_group()`` when no group is initialised would
+raise -- a regression in the conditional would surface in test runs that
+never set up distributed training (i.e. all of them).
+
+The actual GPU / distributed cleanup behaviour is covered end-to-end by
+the integration suite; here everything below the lifecycle logic is
+mocked out.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from nemo_safe_synthesizer.training.huggingface_backend import HuggingFaceBackend
+
+
+def _bare_hf_backend() -> HuggingFaceBackend:
+    """Build a ``HuggingFaceBackend`` without running ``__init__``.
+
+    ``__init__`` requires a populated ``SafeSynthesizerParameters`` and a
+    ``Workdir``, neither of which the lifecycle tests need. Bypassing it lets
+    each test install only the attributes it cares about.
+    """
+    return HuggingFaceBackend.__new__(HuggingFaceBackend)
+
+
+class TestHuggingFaceBackendTeardown:
+    def test_idempotent_after_first_call(self):
+        backend = _bare_hf_backend()
+        backend.trainer = MagicMock()  # type: ignore[attr-defined]
+        backend.model = MagicMock()  # type: ignore[attr-defined]
+
+        with (
+            patch("nemo_safe_synthesizer.training.huggingface_backend.cleanup_memory") as cleanup,
+            patch("torch.distributed.is_initialized", return_value=False),
+        ):
+            backend.teardown()
+            backend.teardown()
+
+        assert cleanup.call_count == 1
+        assert backend._torn_down is True
+
+    def test_destroys_process_group_only_when_initialized(self):
+        # Calling destroy_process_group() with no group initialised raises;
+        # the conditional is the only thing keeping non-distributed runs sane.
+        backend = _bare_hf_backend()
+
+        with (
+            patch("nemo_safe_synthesizer.training.huggingface_backend.cleanup_memory"),
+            patch("torch.distributed.is_initialized", return_value=False),
+            patch("torch.distributed.destroy_process_group") as destroy,
+        ):
+            backend.teardown()
+
+        destroy.assert_not_called()
+
+        backend2 = _bare_hf_backend()
+        with (
+            patch("nemo_safe_synthesizer.training.huggingface_backend.cleanup_memory"),
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch("torch.distributed.destroy_process_group") as destroy,
+        ):
+            backend2.teardown()
+
+        destroy.assert_called_once()
+
+    def test_isolates_per_step_failures(self):
+        # Each cleanup step is wrapped independently so a torch / NCCL
+        # failure in one (e.g. cleanup_memory or destroy_process_group)
+        # doesn't prevent the rest from running, and ``_torn_down`` still
+        # flips so a retry no-ops instead of compounding the failure.
+        backend = _bare_hf_backend()
+        backend.trainer = MagicMock()  # type: ignore[attr-defined]
+        backend.model = MagicMock()  # type: ignore[attr-defined]
+
+        with (
+            patch(
+                "nemo_safe_synthesizer.training.huggingface_backend.cleanup_memory",
+                side_effect=RuntimeError("simulated cleanup failure"),
+            ) as cleanup,
+            patch("torch.distributed.is_initialized", return_value=True),
+            patch(
+                "torch.distributed.destroy_process_group",
+                side_effect=RuntimeError("simulated nccl teardown failure"),
+            ) as destroy,
+        ):
+            backend.teardown()
+
+        cleanup.assert_called_once()
+        destroy.assert_called_once()
+        assert backend._torn_down is True

--- a/tools/codestyle/format.sh
+++ b/tools/codestyle/format.sh
@@ -12,7 +12,13 @@
 #   ./format.sh --check src/foo.py       # check mode on specific files
 #
 # Lint-rule violations (ruff check without --fix) are handled by ruff_check.sh.
+# Type-checking is handled by typecheck.sh.
 # Copyright headers are handled separately by copyright_fixer.py.
+#
+# Note: `ty check --fix` (ty 0.0.32+) is intentionally not wired in here yet.
+# The autofix surface is still small and the CLI semantics (file discovery vs.
+# explicit paths, rule suppression, exit codes) are evolving. When we do wire
+# it, it goes in the fix branch below; see the commented placeholder.
 #
 
 set -euo pipefail
@@ -30,4 +36,11 @@ else
     ruff format "${PY_FILES[@]}"
     # this does import sorting and autofixes
     ruff check --fix "${PY_FILES[@]}"
+    # Future: ty autofix goes here once the --fix surface stabilizes. Shape:
+    #   ty check --fix --exit-zero --force-exclude "${PY_FILES[@]}"
+    # --force-exclude so [tool.ty.src.exclude] in pyproject.toml is honored
+    # when paths are passed explicitly; --exit-zero so non-fixable diagnostics
+    # don't fail `make format` (`make typecheck` is the gate). When enabling,
+    # also add "./.agents/" to [tool.ty.src.exclude] -- PEP 723 uv scripts
+    # there would otherwise show up when PY_FILES is passed on the CLI.
 fi


### PR DESCRIPTION
## Summary

Bumps `ty` to 0.0.32 and makes `DirNode` generic so the `Workdir` directory tree carries its shape to the type checker. Drops 27 `# ty: ignore[unresolved-attribute]` and 9 `cast(Path, ...)` calls. The rest is follow-on cleanup the checker surfaced.

## Changes

- `DirNode[T_co]` + typed-view subclasses (`_TrainDir`, `_AdapterDir`, `_GenerateDir`, `_DatasetDir`). Empty `BoundDir` subclasses declare each subtree's children under `TYPE_CHECKING`. `DirNode.__get__` is *typed* to return `T_co` on instance access; at runtime it always returns a plain `BoundDir` -- the typed-view subclasses have no runtime body and are never instantiated. Same idiom as SQLAlchemy `Mapped[T]`. `TestTypedViewDrift` AST-parses the module and fails CI on drift. Documented in `cli/AGENTS.md` and the module comment.
- `TrainingBackend.teardown()` lifted to the ABC (was `HuggingFaceBackend.delete_trainable_model`). Adds a `_torn_down` idempotency guard and per-step `try/except`. Also fixes a pre-existing `__subclasshook__` that checked `hasattr(..., "prepare_training_args")` against `callable(...prepare_params)`, and now guards the structural check with `cls is TrainingBackend` so it doesn't leak into derived backends.
- `Workdir.run_name`: `str | None = None` → `str = ""` -- always populated by `__post_init__` before any reader runs.
- Four `EvaluationScore(name=...)` fixtures were silently dropped by Pydantic `extra="ignore"`. The `ty: ignore[unknown-argument]` was masking the bug, not suppressing a false positive. Removed the kwargs.
- `time_function` uses `getattr(func, '__name__', repr(func))`; `itertools.product` in `dates.py` called positionally so ty infers the 5-tuple without a `cast`; `create_ner_api_response` annotation corrected to `list[list[dict]]`.

## Follow-ups

- `tools/codestyle/format.sh` has a placeholder for `ty check --fix`. Deferred while the autofix surface is small.
- Systemic `extra="forbid"` on evaluation models. Separate PR.

## Test plan

- [x] `make check`
- [x] `pytest tests/cli/test_artifact_structure.py` -- 74/74
- [x] `pytest tests/training` -- green
- [ ] CI