### PR TITLE
feat: use assembler `tokens_per_example.max` for generation max token

### DIFF
--- a/src/nemo_safe_synthesizer/generation/results.py
+++ b/src/nemo_safe_synthesizer/generation/results.py
@@ -29,6 +29,20 @@ from ..observability import get_logger
 from ..utils import DataActionsFn
 
 NUM_PROMPT_BUFFER = 10
+"""Extra prompts added on top of the records-per-prompt estimate to absorb invalid completions."""
+
+INITIAL_PROBE_PROMPTS = 10
+"""Prompt count used for the first batch when no records-per-prompt history exists yet.
+
+Sending a small probe lets the accumulator measure the records-per-prompt
+ratio cheaply. Subsequent batches escalate to the full ``max_num_prompts_per_batch``
+once at least one prompt has been processed (regardless of whether it produced
+valid records), avoiding the overshoot that an upfront full-batch causes when
+the target count is much larger than the per-prompt yield.
+"""
+
+ADAPTIVE_MAX_PROMPTS_CEILING = 2000
+"""Upper bound for ``target_num_records``-derived ``max_num_prompts_per_batch``."""
 
 logger = get_logger(__name__)
 
@@ -156,7 +170,11 @@ class GenerationBatches:
         target_num_records: Target number of valid records to generate.
         batches: Pre-existing batches to seed the accumulator with.
         max_num_prompts_per_batch: Maximum prompts per LLM generation
-            call.
+            call. ``None`` (the default) derives the cap adaptively from
+            ``target_num_records`` -- ``min(2000, max(MAX_NUM_PROMPTS_PER_BATCH,
+            target_num_records // 20))`` -- so small jobs do not request
+            an oversized batch and large jobs do not stall on a single
+            small batch.
         invalid_fraction_threshold: Fraction of invalid records that
             triggers stopping after ``patience`` consecutive batches.
         patience: Consecutive batch count before the threshold triggers
@@ -176,7 +194,7 @@ class GenerationBatches:
         self,
         target_num_records: int | None = None,
         batches: list[Batch] | None = None,
-        max_num_prompts_per_batch: int = MAX_NUM_PROMPTS_PER_BATCH,
+        max_num_prompts_per_batch: int | None = None,
         invalid_fraction_threshold: float | None = None,
         patience: int | None = None,
         data_actions_fn: DataActionsFn | None = None,
@@ -184,7 +202,9 @@ class GenerationBatches:
         self._batches = batches or []
         self._start_time = time.perf_counter()
         self.target_num_records = target_num_records
-        self.max_num_prompts_per_batch = max_num_prompts_per_batch
+        self.max_num_prompts_per_batch = self._resolve_max_num_prompts_per_batch(
+            max_num_prompts_per_batch, target_num_records
+        )
         self.status = GenerationStatus.IN_PROGRESS
         self.running_stopping_metric = RunningStatistics()
 
@@ -199,6 +219,25 @@ class GenerationBatches:
 
         self.data_actions_fn = data_actions_fn
         self._batches_df: pd.DataFrame | None = None
+
+    @staticmethod
+    def _resolve_max_num_prompts_per_batch(
+        max_num_prompts_per_batch: int | None,
+        target_num_records: int | None,
+    ) -> int:
+        """Resolve the per-batch prompt cap from explicit or adaptive defaults.
+
+        An explicit value is honored as-is for backwards compatibility.
+        ``None`` falls back to ``MAX_NUM_PROMPTS_PER_BATCH`` when no target
+        is set; otherwise it scales with ``target_num_records`` -- one
+        prompt per ~20 desired records, floored at ``MAX_NUM_PROMPTS_PER_BATCH``
+        and capped at ``ADAPTIVE_MAX_PROMPTS_CEILING``.
+        """
+        if max_num_prompts_per_batch is not None:
+            return max_num_prompts_per_batch
+        if target_num_records is None:
+            return MAX_NUM_PROMPTS_PER_BATCH
+        return min(ADAPTIVE_MAX_PROMPTS_CEILING, max(MAX_NUM_PROMPTS_PER_BATCH, target_num_records // 20))
 
     def _apply_data_actions_fn(self, batch: Batch) -> None:
         """Post-process and validate a batch via ``data_actions_fn``.
@@ -335,26 +374,39 @@ class GenerationBatches:
         self._batches.append(batch)
 
     def get_next_num_prompts(self) -> int:
-        """Return an estimate of the optimal number of prompts to process in the next batch."""
+        """Return an estimate of the optimal number of prompts to process in the next batch.
+
+        The accumulator scales the per-batch prompt count through three
+        regimes:
+
+        * Truly-first batch (no prompts ever sent) -- send a small probe
+          batch of ``INITIAL_PROBE_PROMPTS`` so the records-per-prompt
+          ratio can be measured before committing to a full batch.
+        * Prompts sent but no valid records yet -- escalate to the full
+          ``max_num_prompts_per_batch`` budget so the patience-based
+          stopping path can decide whether to abort.
+        * Have valid records -- size the next batch from the observed
+          records-per-prompt ratio, plus ``NUM_PROMPT_BUFFER`` to absorb
+          invalid completions.
+        """
         num_prompts = self.max_num_prompts_per_batch
 
         if self.target_num_records is None:
             return num_prompts
 
         num_records_remaining = self.target_num_records - self.num_valid_records
+        records_per_prompt_known = self.num_valid_records > 0 and self.num_prompts > 0
+        is_first_batch = self.num_prompts == 0
 
-        if self.num_valid_records > 0 and self.num_prompts > 0:
+        if records_per_prompt_known:
             valid_records_per_prompt = self.num_valid_records / self.num_prompts
             num_prompts_needed = round(num_records_remaining / (valid_records_per_prompt + EPS))
-            num_prompts = min(num_prompts, num_prompts_needed + NUM_PROMPT_BUFFER)
-        else:
-            # First batch: no records-per-prompt history yet.  Assume at
-            # least 1 record per prompt (the actual ratio is typically much
-            # higher) to avoid sending max_num_prompts_per_batch prompts
-            # when the target is small.
-            num_prompts = min(num_prompts, num_records_remaining + NUM_PROMPT_BUFFER)
+            return min(num_prompts, num_prompts_needed + NUM_PROMPT_BUFFER)
 
-        return num_prompts
+        if is_first_batch:
+            return min(num_prompts, INITIAL_PROBE_PROMPTS, num_records_remaining + NUM_PROMPT_BUFFER)
+
+        return min(num_prompts, num_records_remaining + NUM_PROMPT_BUFFER)
 
     def job_complete(self) -> None:
         """Update the generation job status to a finished state and log the results."""

--- a/src/nemo_safe_synthesizer/generation/timeseries_backend.py
+++ b/src/nemo_safe_synthesizer/generation/timeseries_backend.py
@@ -237,6 +237,28 @@ class TimeseriesBackend(VllmBackend):
         self._group_prefills: dict[str, str] = initial_prefill_value
         self._groups: list[str] = list(self._group_prefills.keys())
 
+    def _get_prompt_token_count(self) -> int:
+        """Return the longest active prompt length for ``SamplingParams``.
+
+        Time-series generation prepends a per-group prefill to the templated
+        prompt. SamplingParams is constructed once per ``generate()`` call,
+        so the safe choice is the longest prompt any active group will see
+        in this run -- templated prompt + longest initial prefill.
+
+        Falls back to the templated prompt's token count alone when the
+        engine has not yet been initialized or no group prefills are
+        populated.
+        """
+        base = super()._get_prompt_token_count()
+        if self.llm is None or not self._group_prefills:
+            return base
+        tokenizer = self.llm.get_tokenizer()
+        longest_prefill_tokens = max(
+            (len(tokenizer.encode(prefill)) for prefill in self._group_prefills.values() if prefill),
+            default=0,
+        )
+        return base + longest_prefill_tokens
+
     def _build_progress_snapshots(self, total: int, is_group_based: bool = False) -> list[ProgressSnapshot]:
         """Build progress snapshots for saving intermediate results.
 
@@ -898,7 +920,7 @@ class TimeseriesBackend(VllmBackend):
             top_p=self.config.generation.top_p,
             top_k=FIXED_RUNTIME_GENERATE_ARGS["top_k"],
             min_p=FIXED_RUNTIME_GENERATE_ARGS["min_p"],
-            max_tokens=self.model_metadata.max_seq_length,
+            max_tokens=self.model_metadata.generation_max_tokens_for(self._get_prompt_token_count()),
             skip_special_tokens=True,
             include_stop_str_in_output=False,
             ignore_eos=False,

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -135,6 +135,7 @@ class VllmBackend(GeneratorBackend):
             prompt_template=self.model_metadata.prompt_config.template,
         )
         self.llm: vLLM | None = None
+        self._prompt_token_count: int | None = None
 
         # Do not generate detailed error messages in production to avoid leaking sensitive data.
         self.use_detailed_logs = kwargs.pop("use_detailed_logs", False)
@@ -218,6 +219,22 @@ class VllmBackend(GeneratorBackend):
             self.config,
             tokenizer=tokenizer,
         )
+
+    def _get_prompt_token_count(self) -> int:
+        """Return the templated prompt's tokenized length, cached after first call.
+
+        Uses the loaded vLLM tokenizer so encoding matches what the engine
+        will see at runtime. Returns ``0`` when the engine has not yet been
+        initialized -- callers fall back to a prompt-agnostic ceiling in
+        that case.
+        """
+        if self._prompt_token_count is not None:
+            return self._prompt_token_count
+        if self.llm is None:
+            return 0
+        tokenizer = self.llm.get_tokenizer()
+        self._prompt_token_count = len(tokenizer.encode(self.prompt))
+        return self._prompt_token_count
 
     def _build_structured_output_params(self) -> StructuredOutputsParams | None:
         """Build structured output parameters based on generation config.
@@ -523,7 +540,7 @@ class VllmBackend(GeneratorBackend):
             top_p=self.config.generation.top_p,
             top_k=FIXED_RUNTIME_GENERATE_ARGS["top_k"],
             min_p=FIXED_RUNTIME_GENERATE_ARGS["min_p"],
-            max_tokens=self.model_metadata.max_seq_length,
+            max_tokens=self.model_metadata.generation_max_tokens_for(self._get_prompt_token_count()),
             skip_special_tokens=not need_special_token_outputs,
             include_stop_str_in_output=need_special_token_outputs,
             ignore_eos=False,

--- a/src/nemo_safe_synthesizer/llm/metadata.py
+++ b/src/nemo_safe_synthesizer/llm/metadata.py
@@ -55,6 +55,11 @@ logger = get_logger(__name__)
 DEFAULT_MAX_SEQ_LENGTH = 2048
 GLOBAL_MAX_SEQ_LENGTH = 2048 * 6
 
+GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER = 1.2
+"""Margin applied to ``max_tokens_per_example`` when sizing generation
+``SamplingParams.max_tokens``. The stat is the actual tokenized max
+observed during training, so a small jitter margin is sufficient."""
+
 
 class LLMPromptConfig(BaseModel):
     """Prompt template and special-token settings for an LLM.
@@ -323,6 +328,16 @@ class ModelMetadata(BaseModel):
     )
     """Currently used for time series data. May be a single string or a per-column dict."""
 
+    max_tokens_per_example: int | None = Field(
+        default=None,
+        description="Maximum tokenized example length observed during training.",
+    )
+    """Populated by the training backend from the assembler's
+    ``tokens_per_example`` running statistic. Consumed by
+    ``generation_max_tokens_for`` to size ``SamplingParams.max_tokens`` so
+    fine-tuned LoRAs that fail to emit EOS on short structured outputs do
+    not decode wasted tokens to the full context-window cap."""
+
     @model_validator(mode="before")
     @classmethod
     def populate_derived_fields(cls, data: dict) -> dict:
@@ -403,6 +418,37 @@ class ModelMetadata(BaseModel):
         if isinstance(self.rope_scaling, RopeScaling) and self.rope_scaling.factor > 1.0:
             rsf = self.rope_scaling.factor
         return int((self.base_max_seq_length or DEFAULT_MAX_SEQ_LENGTH) * rsf)
+
+    def generation_max_tokens_for(self, prompt_len: int) -> int:
+        """Per-sample ``max_tokens`` ceiling, prompt-aware.
+
+        Returns the smaller of:
+
+        1. ``int(max_tokens_per_example * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)``
+           when the assembler stat is populated, else ``max_seq_length``.
+        2. ``max_seq_length - prompt_len`` -- vLLM raises when
+           ``len(prompt) + max_tokens > max_model_len``
+           (`vllm#33418 <https://github.com/vllm-project/vllm/issues/33418>`_).
+
+        ``max_tokens_per_example`` already includes the prompt: it is the
+        tokenized length of ``prompt + packed records`` produced by the
+        assembler, so the scaled value is an upper bound on any rollout
+        rather than a tight output budget. The explicit ``- prompt_len``
+        clamp is a defensive belt for legacy adapters where the assembler
+        stat is missing and for prompts longer than those seen in training.
+
+        Args:
+            prompt_len: Tokenized length of the prompt this sample will
+                run against. Pass ``0`` to disable the prompt clamp.
+
+        Returns:
+            Non-negative ``max_tokens`` value safe to feed to ``SamplingParams``.
+        """
+        if self.max_tokens_per_example and self.max_tokens_per_example > 0:
+            sized = int(self.max_tokens_per_example * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)
+        else:
+            sized = self.max_seq_length
+        return max(0, min(sized, self.max_seq_length - prompt_len))
 
     def save_metadata(self) -> None:
         """Save model metadata to JSON file.

--- a/src/nemo_safe_synthesizer/training/callbacks.py
+++ b/src/nemo_safe_synthesizer/training/callbacks.py
@@ -138,7 +138,7 @@ class InferenceEvalCallback(TrainerCallback):
             outputs = model.generate(
                 input_ids=input_ids,
                 attention_mask=attention_mask,
-                max_new_tokens=tokenizer.model_max_length - len(input_ids[0]),
+                max_new_tokens=self.metadata.generation_max_tokens_for(len(input_ids[0])),
                 do_sample=True,
                 use_cache=True,
                 **self.generate_kwargs,

--- a/src/nemo_safe_synthesizer/training/huggingface_backend.py
+++ b/src/nemo_safe_synthesizer/training/huggingface_backend.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import io
 import logging
+import math
 import time
 from collections.abc import Callable
 from contextlib import redirect_stdout
@@ -694,6 +695,23 @@ class HuggingFaceBackend(TrainingBackend):
 
         if self.params.time_series.is_timeseries:
             self.model_metadata.initial_prefill = assembler._get_initial_prefill()  # ty: ignore[unresolved-attribute]
+
+        self._propagate_max_tokens_per_example()
+
+    def _propagate_max_tokens_per_example(self) -> None:
+        """Copy the assembler's ``tokens_per_example.max`` onto ``ModelMetadata``.
+
+        Sized from the actual tokenized examples rather than a char-count
+        heuristic, this bound feeds ``ModelMetadata.generation_max_tokens_for``
+        so ``SamplingParams.max_tokens`` caps decoding at output lengths
+        the model was trained to produce. Tight caps let the engine retire
+        EOS-failed sequences promptly (a known fine-tuned-LoRA failure
+        mode) instead of letting them decode wasted tokens to the full
+        context window. No-op when the stat is absent or unpopulated.
+        """
+        tokens_per_example = self.training_examples.stats.get("tokens_per_example")
+        if tokens_per_example is not None and tokens_per_example.count > 0:
+            self.model_metadata.max_tokens_per_example = int(math.ceil(tokens_per_example.max))
 
     @utils.time_function
     def train(self, **training_args: Any) -> None:

--- a/tests/generation/test_generation.py
+++ b/tests/generation/test_generation.py
@@ -17,7 +17,7 @@ from nemo_safe_synthesizer.errors import GenerationError
 from nemo_safe_synthesizer.generation.batch import Batch
 from nemo_safe_synthesizer.generation.processors import ParsedRecord, ParsedResponse
 from nemo_safe_synthesizer.generation.results import (
-    NUM_PROMPT_BUFFER,
+    INITIAL_PROBE_PROMPTS,
     GenerateJobResults,
     GenerationBatches,
     GenerationStatus,
@@ -168,20 +168,18 @@ def test_get_next_num_prompts(fixture_stub_batches):
     assert generation_with_target.get_next_num_prompts() == 16
 
 
-# Purpose: First batch (no history) caps prompts to target + buffer instead of max.
-# Data: Empty GenerationBatches with small target_num_records and no prior batches.
-# Asserts: Returns target + NUM_PROMPT_BUFFER when that's less than max; returns max otherwise.
+# Purpose: First batch (no history) ships a small probe so the records-per-prompt
+# ratio can be measured before committing to a full batch.
+# Data: Empty GenerationBatches with various target_num_records and no prior batches.
+# Asserts: Returns INITIAL_PROBE_PROMPTS regardless of target whenever the records-remaining
+# bound (target + NUM_PROMPT_BUFFER) is at least the probe size.
 @pytest.mark.parametrize(
-    "target, expected",
-    [
-        (10, 10 + NUM_PROMPT_BUFFER),
-        (50, 50 + NUM_PROMPT_BUFFER),
-        (200, 100),  # target + buffer exceeds max (100), so capped
-    ],
+    "target",
+    [10, 50, 200],
 )
-def test_get_next_num_prompts_first_batch(target, expected):
+def test_get_next_num_prompts_first_batch(target):
     generation = GenerationBatches(target_num_records=target)
-    assert generation.get_next_num_prompts() == expected
+    assert generation.get_next_num_prompts() == INITIAL_PROBE_PROMPTS
 
 
 # Purpose: Build a DataFrame of valid records across batches, honoring max record cap and validity.

--- a/tests/generation/test_results.py
+++ b/tests/generation/test_results.py
@@ -1,0 +1,150 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``GenerationBatches`` probe-batch and adaptive sizing logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from nemo_safe_synthesizer.config.generate import ValidationParameters
+from nemo_safe_synthesizer.data_processing.record_utils import ParsedRecord
+from nemo_safe_synthesizer.defaults import EPS, MAX_NUM_PROMPTS_PER_BATCH
+from nemo_safe_synthesizer.generation.batch import Batch
+from nemo_safe_synthesizer.generation.processors import ParsedResponse, TabularDataProcessor
+from nemo_safe_synthesizer.generation.results import (
+    ADAPTIVE_MAX_PROMPTS_CEILING,
+    INITIAL_PROBE_PROMPTS,
+    NUM_PROMPT_BUFFER,
+    GenerationBatches,
+)
+
+
+@pytest.fixture
+def fixture_processor() -> TabularDataProcessor:
+    """Concrete ``TabularDataProcessor`` -- exercised only as the ``Batch`` owner."""
+    return TabularDataProcessor(schema={"properties": {}}, config=ValidationParameters())
+
+
+def _make_batch(
+    processor: TabularDataProcessor,
+    *,
+    num_prompts: int,
+    num_valid: int = 0,
+    num_invalid: int = 0,
+) -> Batch:
+    """Return a ``Batch`` whose aggregate counts match the requested totals.
+
+    Distributes ``num_valid`` valid records across the first prompt and
+    ``num_invalid`` invalid records across the same prompt so that
+    ``Batch.num_prompts == num_prompts`` regardless of the counts.
+    """
+    batch = Batch(processor=processor)
+    for prompt_index in range(num_prompts):
+        records: list[ParsedRecord] = []
+        if prompt_index == 0:
+            records.extend(
+                ParsedRecord(text=f'{{"col": "valid-{prompt_index}-{i}"}}', parsed={"col": f"valid-{prompt_index}-{i}"})
+                for i in range(num_valid)
+            )
+            records.extend(
+                ParsedRecord(text=f"invalid-{prompt_index}-{i}", error=("validation failed", "schema"))
+                for i in range(num_invalid)
+            )
+        batch._responses.append(ParsedResponse(records=records, prompt_number=prompt_index))
+    return batch
+
+
+class TestInitialProbeBatch:
+    """The first batch from a fresh accumulator is sized to ``INITIAL_PROBE_PROMPTS``."""
+
+    def test_results_first_batch_uses_probe_size(self):
+        """Fresh accumulator with ``target_num_records`` returns the probe size."""
+        batches = GenerationBatches(target_num_records=10_000)
+
+        assert batches.get_next_num_prompts() == INITIAL_PROBE_PROMPTS
+
+    def test_results_first_batch_clipped_by_remaining_records(self):
+        """The probe count is also bounded by ``records_remaining + NUM_PROMPT_BUFFER``."""
+        batches = GenerationBatches(target_num_records=3)
+
+        # The records-remaining bound is ``3 + NUM_PROMPT_BUFFER`` -- larger than the probe,
+        # so the probe still wins; this test guards the three-way ``min`` against regressions.
+        assert batches.get_next_num_prompts() == min(INITIAL_PROBE_PROMPTS, 3 + NUM_PROMPT_BUFFER)
+
+    def test_results_first_batch_without_target_returns_full_budget(self):
+        """Without ``target_num_records``, the helper returns the full per-batch cap (no probe)."""
+        batches = GenerationBatches(target_num_records=None)
+
+        assert batches.get_next_num_prompts() == batches.max_num_prompts_per_batch
+
+
+class TestEscalateAfterFailedProbe:
+    """A probe that produced no valid records escalates to the full prompt budget."""
+
+    def test_results_escalates_to_full_budget_after_zero_valid_probe(self, fixture_processor):
+        """Stopping is intentionally disabled so the next call exercises the escalation branch."""
+        batches = GenerationBatches(
+            target_num_records=10_000,
+            invalid_fraction_threshold=1.0,
+            patience=10,
+        )
+        first_batch = _make_batch(fixture_processor, num_prompts=INITIAL_PROBE_PROMPTS, num_valid=0, num_invalid=5)
+        batches.add_batch(first_batch)
+
+        next_count = batches.get_next_num_prompts()
+
+        # Escalation: full ``max_num_prompts_per_batch`` clipped only by remaining records.
+        records_remaining = 10_000 - batches.num_valid_records
+        assert next_count == min(batches.max_num_prompts_per_batch, records_remaining + NUM_PROMPT_BUFFER)
+        assert next_count > INITIAL_PROBE_PROMPTS
+
+    def test_results_uses_records_per_prompt_estimate_after_successful_probe(self, fixture_processor):
+        """Once valid records exist, sizing follows the records-per-prompt estimate."""
+        batches = GenerationBatches(target_num_records=1_000)
+        # 5 prompts * 1 valid record each = 5 valid; future budget = remaining / 1 per prompt.
+        first_batch = _make_batch(fixture_processor, num_prompts=5, num_valid=5, num_invalid=0)
+        batches.add_batch(first_batch)
+
+        next_count = batches.get_next_num_prompts()
+
+        records_remaining = 1_000 - 5
+        valid_per_prompt = 5 / 5  # 1.0
+        expected = min(
+            batches.max_num_prompts_per_batch,
+            round(records_remaining / (valid_per_prompt + EPS)) + NUM_PROMPT_BUFFER,
+        )
+        assert next_count == expected
+
+
+class TestAdaptiveMaxNumPromptsPerBatch:
+    """``max_num_prompts_per_batch=None`` derives the cap from ``target_num_records``."""
+
+    @pytest.mark.parametrize(
+        "target_num_records, expected_cap",
+        [
+            pytest.param(None, MAX_NUM_PROMPTS_PER_BATCH, id="no_target_uses_default"),
+            pytest.param(500, MAX_NUM_PROMPTS_PER_BATCH, id="small_target_floors_at_default"),
+            pytest.param(1_000, MAX_NUM_PROMPTS_PER_BATCH, id="exactly_at_floor"),
+            pytest.param(5_000, 250, id="moderate_target_scales_up"),
+            pytest.param(100_000, ADAPTIVE_MAX_PROMPTS_CEILING, id="huge_target_capped_at_ceiling"),
+        ],
+    )
+    def test_results_adaptive_default_scales_with_target(self, target_num_records, expected_cap):
+        """Adaptive default = ``min(2000, max(MAX_NUM_PROMPTS_PER_BATCH, target_num_records // 20))``."""
+        batches = GenerationBatches(target_num_records=target_num_records)
+
+        assert batches.max_num_prompts_per_batch == expected_cap
+
+    @pytest.mark.parametrize(
+        "explicit_value",
+        [42, 1, MAX_NUM_PROMPTS_PER_BATCH, 5_000],
+    )
+    def test_results_explicit_max_num_prompts_per_batch_is_honored(self, explicit_value):
+        """Backwards-compat: an explicit value bypasses the adaptive derivation."""
+        batches = GenerationBatches(
+            target_num_records=10_000,
+            max_num_prompts_per_batch=explicit_value,
+        )
+
+        assert batches.max_num_prompts_per_batch == explicit_value

--- a/tests/generation/test_timeseries_backend.py
+++ b/tests/generation/test_timeseries_backend.py
@@ -3,7 +3,7 @@
 
 """Unit tests for the TimeseriesBackend class private methods."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
@@ -24,7 +24,11 @@ from nemo_safe_synthesizer.generation.timeseries_backend import (
     GroupState,
     TimeseriesBackend,
 )
-from nemo_safe_synthesizer.llm.metadata import LLMPromptConfig, ModelMetadata
+from nemo_safe_synthesizer.llm.metadata import (
+    GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER,
+    LLMPromptConfig,
+    ModelMetadata,
+)
 
 PROMPT_TEMPLATE = "[INST] {instruction} {schema} [/INST]"
 
@@ -457,3 +461,79 @@ class TestBuildModifiedSamplingParamsStopPropagation:
         assert modified.ignore_eos is False
         assert modified.stop == []
         assert modified.stop_token_ids == []
+
+
+class TestGenerationMaxTokensPlumbing:
+    """``SamplingParams.max_tokens`` is sourced from ``metadata.generation_max_tokens_for``."""
+
+    @staticmethod
+    def _capture_sampling_params(
+        backend,
+        *,
+        groups: list[str] | None = None,
+        group_prefills: dict[str, str] | None = None,
+        prompt_token_count: int | None = None,
+    ) -> SamplingParams:
+        """Invoke ``generate`` with ``_generate_parallel_groups`` stubbed out.
+
+        Returns the ``SamplingParams`` the backend constructed. ``groups``
+        and ``group_prefills`` seed minimal state so ``generate()`` reaches
+        SamplingParams construction; ``prompt_token_count`` overrides the
+        backend's prompt-token helper to drive the prompt-length clamp
+        deterministically without standing up a real vLLM engine.
+        """
+        captured: dict[str, SamplingParams] = {}
+
+        def _capture(*, batches, sampling_params, progress_snapshots):  # noqa: ARG001
+            captured["sp"] = sampling_params
+            raise StopIteration("short-circuit")
+
+        backend._generate_parallel_groups = _capture
+        backend._groups = groups if groups is not None else []
+        backend._group_prefills = group_prefills if group_prefills is not None else {}
+        if prompt_token_count is not None:
+            backend._get_prompt_token_count = MagicMock(return_value=prompt_token_count)
+
+        with pytest.raises(StopIteration):
+            backend.generate()
+
+        return captured["sp"]
+
+    def test_uses_helper_when_stat_set_and_prompt_short(
+        self, timeseries_base_params, timeseries_model_metadata, mock_workdir
+    ):
+        """When the prompt is short, the scaled stat drives ``max_tokens``."""
+        timeseries_model_metadata.max_tokens_per_example = 1000
+        backend = create_timeseries_backend(timeseries_base_params, timeseries_model_metadata, mock_workdir)
+
+        sp = self._capture_sampling_params(backend)
+
+        expected = timeseries_model_metadata.generation_max_tokens_for(0)
+        assert sp.max_tokens == expected
+        assert sp.max_tokens == int(1000 * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)
+
+    def test_falls_back_to_remaining_context_when_stat_unset(
+        self, timeseries_base_params, timeseries_model_metadata, mock_workdir
+    ):
+        """Without the stat, SamplingParams.max_tokens == ``max_seq_length - prompt_len``."""
+        assert timeseries_model_metadata.max_tokens_per_example is None
+        backend = create_timeseries_backend(timeseries_base_params, timeseries_model_metadata, mock_workdir)
+
+        sp = self._capture_sampling_params(backend)
+
+        # No engine -> prompt-token count is 0 -> clamp gives full window back.
+        assert sp.max_tokens == timeseries_model_metadata.max_seq_length
+
+    def test_prompt_length_clamps_below_scaled_stat(
+        self, timeseries_base_params, timeseries_model_metadata, mock_workdir
+    ):
+        """Long prompts trigger the ``max_seq_length - prompt_len`` clamp instead of the stat."""
+        # Stat * 1.2 = 1800; clamp = 2048 - 1500 = 548 wins.
+        timeseries_model_metadata.max_tokens_per_example = 1500
+        backend = create_timeseries_backend(timeseries_base_params, timeseries_model_metadata, mock_workdir)
+
+        sp = self._capture_sampling_params(backend, prompt_token_count=1500)
+
+        assert sp.max_tokens is not None
+        assert sp.max_tokens == timeseries_model_metadata.max_seq_length - 1500
+        assert sp.max_tokens < int(1500 * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)

--- a/tests/generation/test_vllm_backend.py
+++ b/tests/generation/test_vllm_backend.py
@@ -18,19 +18,25 @@ from nemo_safe_synthesizer.config.generate import ValidationParameters
 from nemo_safe_synthesizer.defaults import DEFAULT_SAMPLING_PARAMETERS
 from nemo_safe_synthesizer.generation.processors import TabularDataProcessor
 from nemo_safe_synthesizer.generation.vllm_backend import VllmBackend  # noqa: F401
+from nemo_safe_synthesizer.llm.metadata import ModelMetadata
 
 
 @pytest.fixture
 def mock_model_metadata(fixture_session_cache_dir):
-    """Create a mock model metadata object."""
-    metadata = MagicMock()
-    metadata.save_path = fixture_session_cache_dir / "save"
+    """Spec'd mock for ``ModelMetadata`` -- guards against signature drift on the helper."""
+    metadata = MagicMock(spec=ModelMetadata)
     metadata.adapter_path = fixture_session_cache_dir / "adapter"
     metadata.instruction = "Generate data"
     metadata.prompt_config = MagicMock()
     metadata.prompt_config.template = "[INST] {instruction} {schema} [/INST]"
     metadata.prompt_config.bos_token = "<s>"
     metadata.prompt_config.eos_token = "</s>"
+    # Default: generation uses the full context window (mirrors the real
+    # helper's fallback when ``max_tokens_per_example`` is unset).
+    # Individual tests override per-prompt return values where needed.
+    metadata.max_seq_length = 2048
+    metadata.max_tokens_per_example = None
+    metadata.generation_max_tokens_for.return_value = 2048
     return metadata
 
 
@@ -521,6 +527,7 @@ class TestGroupedGenerationStopKwargs:
         mock_model_metadata.prompt_config.eos_token = "</s>"
         mock_model_metadata.prompt_config.eos_token_id = 2
         mock_model_metadata.max_seq_length = 2048
+        mock_model_metadata.generation_max_tokens_for.return_value = 2048
 
         backend = create_backend(base_params, mock_model_metadata, mock_schema, mock_workdir)
         assert not isinstance(backend.processor, TabularDataProcessor)
@@ -546,6 +553,7 @@ class TestGroupedGenerationStopKwargs:
         kwargs are passed, ignore_eos is False, and special-token outputs are off.
         """
         mock_model_metadata.max_seq_length = 2048
+        mock_model_metadata.generation_max_tokens_for.return_value = 2048
 
         backend = create_backend(base_params, mock_model_metadata, mock_schema, mock_workdir)
         backend.processor = TabularDataProcessor(schema=mock_schema, config=ValidationParameters())
@@ -580,6 +588,7 @@ class TestGroupedGenerationStopKwargs:
         mock_model_metadata.prompt_config.eos_token = "</s>"
         mock_model_metadata.prompt_config.eos_token_id = 2
         mock_model_metadata.max_seq_length = 8192
+        mock_model_metadata.generation_max_tokens_for.return_value = 8192
 
         backend = create_backend(base_params, mock_model_metadata, mock_schema, mock_workdir)
         assert not isinstance(backend.processor, TabularDataProcessor)
@@ -599,3 +608,66 @@ class TestGroupedGenerationStopKwargs:
         assert "stop" not in captured
         assert "stop_token_ids" not in captured
         assert captured["ignore_eos"] is False
+
+
+class TestGenerationMaxTokensPlumbing:
+    """``SamplingParams.max_tokens`` is sourced from ``metadata.generation_max_tokens_for``."""
+
+    def test_uses_generation_max_tokens_for_with_cached_prompt_len(
+        self, base_params, mock_model_metadata, mock_schema, mock_workdir
+    ):
+        """The helper drives ``max_tokens`` and is invoked with the cached prompt-token count."""
+        mock_model_metadata.max_seq_length = 12_288
+        mock_model_metadata.generation_max_tokens_for.return_value = 4_200
+
+        backend = create_backend(base_params, mock_model_metadata, mock_schema, mock_workdir)
+
+        captured = {}
+
+        def capture_and_stop(**kwargs):
+            captured.update(kwargs)
+            raise StopIteration("short-circuit")
+
+        backend.prepare_params = capture_and_stop
+
+        with pytest.raises(StopIteration):
+            backend.generate()
+
+        assert captured["max_tokens"] == 4_200
+        # Engine is not initialized in this plumbing test, so the cached
+        # prompt-token count falls back to 0; the helper is still called
+        # exactly once with that value.
+        mock_model_metadata.generation_max_tokens_for.assert_called_once_with(0)
+
+    def test_passes_cached_prompt_token_count_when_engine_initialized(
+        self, base_params, mock_model_metadata, mock_schema, mock_workdir
+    ):
+        """When the vLLM engine exists, the cached prompt-token count is forwarded to the helper."""
+        mock_model_metadata.max_seq_length = 12_288
+        mock_model_metadata.generation_max_tokens_for.return_value = 4_096
+
+        backend = create_backend(base_params, mock_model_metadata, mock_schema, mock_workdir)
+
+        # Stand in for an initialized engine; the backend tokenizes its templated
+        # prompt once via ``llm.get_tokenizer().encode`` and caches the count.
+        fake_tokenizer = MagicMock()
+        fake_tokenizer.encode.return_value = list(range(37))
+        backend.llm = MagicMock()
+        backend.llm.get_tokenizer.return_value = fake_tokenizer
+
+        captured = {}
+
+        def capture_and_stop(**kwargs):
+            captured.update(kwargs)
+            raise StopIteration("short-circuit")
+
+        backend.prepare_params = capture_and_stop
+
+        with pytest.raises(StopIteration):
+            backend.generate()
+
+        assert captured["max_tokens"] == 4_096
+        mock_model_metadata.generation_max_tokens_for.assert_called_once_with(37)
+        # Cached: a second access does not retokenize.
+        assert backend._get_prompt_token_count() == 37
+        fake_tokenizer.encode.assert_called_once_with(backend.prompt)

--- a/tests/llm/test_metadata.py
+++ b/tests/llm/test_metadata.py
@@ -28,6 +28,7 @@ from nemo_safe_synthesizer.defaults import (
 )
 from nemo_safe_synthesizer.llm.metadata import (
     DEFAULT_MAX_SEQ_LENGTH,
+    GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER,
     GLOBAL_MAX_SEQ_LENGTH,
     Llama32,
     LLMPromptConfig,
@@ -563,6 +564,98 @@ class TestModelMetadata:
         """Test from_str_or_path raises ValueError for unknown model names."""
         with pytest.raises(ValueError, match="Unknown model name or path"):
             ModelMetadata.from_str_or_path("unknown-model-xyz")
+
+
+class TestGenerationMaxTokensFor:
+    """Tests for ``ModelMetadata.generation_max_tokens_for(prompt_len)``."""
+
+    def test_metadata_generation_max_tokens_for_returns_stat_when_prompt_is_small(self, sample_model_metadata):
+        """Stat-derived ceiling wins when the prompt leaves enough headroom."""
+        sample_model_metadata.max_tokens_per_example = 1000
+
+        expected = int(1000 * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)
+        # ``max_seq_length=2048`` and ``prompt_len=10`` leave 2038 headroom > 1200.
+        assert sample_model_metadata.generation_max_tokens_for(10) == expected
+
+    def test_metadata_generation_max_tokens_for_clamps_when_prompt_is_large(self, sample_model_metadata):
+        """Prompt clamp wins when ``max_seq_length - prompt_len`` is tighter than the stat."""
+        # ``base_max_seq_length=2048`` and no RoPE scaling.
+        assert sample_model_metadata.max_seq_length == 2048
+        sample_model_metadata.max_tokens_per_example = 1500  # * 1.2 = 1800
+
+        prompt_len = 1000  # 2048 - 1000 = 1048 < 1800
+        assert sample_model_metadata.generation_max_tokens_for(prompt_len) == 1048
+
+    def test_metadata_generation_max_tokens_for_falls_back_to_remaining_context_when_stat_unset(
+        self, sample_model_metadata
+    ):
+        """Unset stat falls back to ``max_seq_length - prompt_len``."""
+        assert sample_model_metadata.max_tokens_per_example is None
+
+        prompt_len = 256
+        assert sample_model_metadata.generation_max_tokens_for(prompt_len) == (
+            sample_model_metadata.max_seq_length - prompt_len
+        )
+
+    @pytest.mark.parametrize("value", [0, -1, -100])
+    def test_metadata_generation_max_tokens_for_treats_non_positive_stat_as_missing(self, sample_model_metadata, value):
+        """Non-positive stats fall through to the remaining-context branch."""
+        sample_model_metadata.max_tokens_per_example = value
+        prompt_len = 32
+        assert sample_model_metadata.generation_max_tokens_for(prompt_len) == (
+            sample_model_metadata.max_seq_length - prompt_len
+        )
+
+    def test_metadata_generation_max_tokens_for_zero_prompt_recovers_legacy_property(self, sample_model_metadata):
+        """``prompt_len=0`` reproduces the old prompt-agnostic ceiling."""
+        sample_model_metadata.max_tokens_per_example = 1000
+        expected = int(1000 * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)
+        assert sample_model_metadata.generation_max_tokens_for(0) == expected
+
+        # Stat unset path: the legacy property returned ``max_seq_length``.
+        sample_model_metadata.max_tokens_per_example = None
+        assert sample_model_metadata.generation_max_tokens_for(0) == sample_model_metadata.max_seq_length
+
+    def test_metadata_generation_max_tokens_for_never_returns_negative(self, sample_model_metadata):
+        """Prompts at or beyond ``max_seq_length`` produce a non-negative ceiling."""
+        sample_model_metadata.max_tokens_per_example = 500
+        # Beyond-context prompts still produce a safe value vLLM can accept.
+        assert sample_model_metadata.generation_max_tokens_for(sample_model_metadata.max_seq_length + 64) == 0
+
+    def test_metadata_max_tokens_per_example_round_trips_through_metadata_json(self, sample_model_metadata):
+        """``max_tokens_per_example`` persists through save → load."""
+        sample_model_metadata.max_tokens_per_example = 1500
+        sample_model_metadata.save_metadata()
+
+        with patch("nemo_safe_synthesizer.llm.metadata.AutoConfig") as mock_ac:
+            mock_ac.from_pretrained.return_value = sample_model_metadata.autoconfig
+            reloaded = ModelMetadata.from_metadata_json(
+                sample_model_metadata.workdir.train.adapter.metadata,  # ty: ignore[unresolved-attribute]
+                workdir=sample_model_metadata.workdir,
+            )
+
+        assert reloaded.max_tokens_per_example == 1500
+        # prompt_len=0 reproduces the old prompt-agnostic budget for round-trip parity.
+        assert reloaded.generation_max_tokens_for(0) == int(1500 * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)
+
+    @patch("nemo_safe_synthesizer.llm.metadata.AutoConfig")
+    @patch("nemo_safe_synthesizer.llm.metadata.load_json")
+    def test_metadata_legacy_json_without_max_tokens_per_example_loads(
+        self, mock_load_json, mock_auto_config, sample_prompt_config, mock_autoconfig_obj, tmp_path, sample_workdir
+    ):
+        """Metadata files written before this field was added still load."""
+        mock_auto_config.from_pretrained.return_value = mock_autoconfig_obj
+        # Legacy payload: no ``max_tokens_per_example`` key.
+        mock_load_json.return_value = {
+            "model_name_or_path": "legacy-model",
+            "prompt_config": sample_prompt_config.model_dump(),
+            "base_max_seq_length": 2048,
+        }
+
+        metadata = ModelMetadata.from_metadata_json(tmp_path / "metadata.json", workdir=sample_workdir)
+
+        assert metadata.max_tokens_per_example is None
+        assert metadata.generation_max_tokens_for(0) == metadata.max_seq_length
 
 
 class TestResolveModelClass:

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from nemo_safe_synthesizer.data_processing.record_utils import ParsedRecord
+from nemo_safe_synthesizer.generation.processors import ParsedResponse, TabularDataProcessor
+from nemo_safe_synthesizer.llm.metadata import ModelMetadata
+from nemo_safe_synthesizer.training.callbacks import InferenceEvalCallback
+
+
+@pytest.fixture
+def fixture_mock_metadata():
+    """``ModelMetadata`` stub exposing the fields ``InferenceEvalCallback`` reads."""
+    metadata = MagicMock(spec=ModelMetadata)
+    metadata.instruction = "Generate a record."
+    metadata.prompt_config = MagicMock()
+    metadata.prompt_config.template = "{instruction} {schema} {prefill}"
+    return metadata
+
+
+@pytest.fixture
+def fixture_mock_processor():
+    """Minimal ``Processor`` stub that yields a single valid ``ParsedResponse`` per call."""
+    processor = MagicMock(spec=TabularDataProcessor)
+    processor.name = "mock-processor"
+    processor.return_value = ParsedResponse(
+        records=[ParsedRecord(text='{"col_a": "value"}', parsed={"col_a": "value"})],
+        prompt_number=0,
+    )
+    return processor
+
+
+@pytest.fixture
+def fixture_mock_model():
+    """Model stub whose ``generate`` returns a single dummy sequence."""
+    model = MagicMock()
+    model.device = torch.device("cpu")
+    model.generate.return_value = torch.tensor([[0, 1, 2]])
+    return model
+
+
+def _build_tokenizer(model_max_length: int, prompt_token_ids: list[int]) -> MagicMock:
+    """Build a tokenizer stub that returns ``prompt_token_ids`` for any prompt."""
+    tokenizer = MagicMock()
+    tokenizer.model_max_length = model_max_length
+    tokenizer.return_value = {
+        "input_ids": torch.tensor([prompt_token_ids]),
+        "attention_mask": torch.ones((1, len(prompt_token_ids)), dtype=torch.long),
+    }
+    tokenizer.batch_decode.return_value = ["{}"]
+    # ``None`` routes the post-generate completion-token counter through the
+    # shape-based fallback, which works with the integer-tensor stub above.
+    tokenizer.pad_token_id = None
+    return tokenizer
+
+
+def _invoke_on_evaluate(callback: InferenceEvalCallback, model: MagicMock, tokenizer: MagicMock) -> None:
+    """Drive ``on_evaluate`` with world-process-zero state."""
+    state = MagicMock()
+    state.is_world_process_zero = True
+    state.log_history = []
+    callback.on_evaluate(
+        args=MagicMock(),
+        state=state,
+        control=MagicMock(),
+        model=model,
+        tokenizer=tokenizer,
+    )
+
+
+class TestInferenceEvalCallbackMaxNewTokens:
+    """Ensure ``max_new_tokens`` is derived from ``metadata.generation_max_tokens_for``."""
+
+    def test_callback_uses_generation_max_tokens_for_when_helper_is_tighter(
+        self,
+        fixture_mock_metadata,
+        fixture_mock_processor,
+        fixture_mock_model,
+    ):
+        """Training-informed helper output drives ``max_new_tokens`` directly."""
+        fixture_mock_metadata.generation_max_tokens_for.return_value = 500
+        prompt_token_ids = list(range(10))
+        tokenizer = _build_tokenizer(model_max_length=5000, prompt_token_ids=prompt_token_ids)
+
+        callback = InferenceEvalCallback(
+            schema={"properties": {"col_a": {"type": "string"}}},
+            metadata=fixture_mock_metadata,
+            processor=fixture_mock_processor,
+            num_prompts_per_batch=1,
+            num_batches=1,
+        )
+
+        _invoke_on_evaluate(callback, fixture_mock_model, tokenizer)
+
+        assert fixture_mock_model.generate.call_args.kwargs["max_new_tokens"] == 500
+        fixture_mock_metadata.generation_max_tokens_for.assert_called_once_with(len(prompt_token_ids))
+
+    def test_callback_uses_helper_remaining_context_when_stat_unset(
+        self,
+        fixture_mock_metadata,
+        fixture_mock_processor,
+        fixture_mock_model,
+    ):
+        """Legacy metadata routes through the helper's ``max_seq_length - prompt_len`` clamp."""
+        prompt_token_ids = list(range(10))
+        # Helper would return ``max_seq_length - prompt_len`` -- mirror that here.
+        remaining = 500 - len(prompt_token_ids)
+        fixture_mock_metadata.generation_max_tokens_for.return_value = remaining
+        tokenizer = _build_tokenizer(model_max_length=500, prompt_token_ids=prompt_token_ids)
+
+        callback = InferenceEvalCallback(
+            schema={"properties": {"col_a": {"type": "string"}}},
+            metadata=fixture_mock_metadata,
+            processor=fixture_mock_processor,
+            num_prompts_per_batch=1,
+            num_batches=1,
+        )
+
+        _invoke_on_evaluate(callback, fixture_mock_model, tokenizer)
+
+        assert fixture_mock_model.generate.call_args.kwargs["max_new_tokens"] == remaining
+        fixture_mock_metadata.generation_max_tokens_for.assert_called_once_with(len(prompt_token_ids))
+
+    @pytest.mark.parametrize("prompt_length", [1, 16, 128])
+    def test_callback_forwards_prompt_length_to_helper(
+        self,
+        prompt_length,
+        fixture_mock_metadata,
+        fixture_mock_processor,
+        fixture_mock_model,
+    ):
+        """The helper is invoked with the actual tokenized prompt length, regardless of size."""
+        model_max_length = 1024
+        fixture_mock_metadata.generation_max_tokens_for.side_effect = lambda prompt_len: model_max_length - prompt_len
+        tokenizer = _build_tokenizer(
+            model_max_length=model_max_length,
+            prompt_token_ids=list(range(prompt_length)),
+        )
+
+        callback = InferenceEvalCallback(
+            schema={"properties": {"col_a": {"type": "string"}}},
+            metadata=fixture_mock_metadata,
+            processor=fixture_mock_processor,
+            num_prompts_per_batch=1,
+            num_batches=1,
+        )
+
+        _invoke_on_evaluate(callback, fixture_mock_model, tokenizer)
+
+        assert fixture_mock_model.generate.call_args.kwargs["max_new_tokens"] == model_max_length - prompt_length
+        fixture_mock_metadata.generation_max_tokens_for.assert_called_once_with(prompt_length)

--- a/tests/training/test_huggingface_backend.py
+++ b/tests/training/test_huggingface_backend.py
@@ -651,3 +651,65 @@ class TestPrepareConfigIntegration:
 
         assert backend.framework_load_params is not None
         assert backend.framework_load_params["pretrained_model_name_or_path"] == "test-model"
+
+
+class TestPropagateMaxTokensPerExample:
+    """Tests for HuggingFaceBackend._propagate_max_tokens_per_example."""
+
+    @staticmethod
+    def _make_stat(count: int, max_value: float) -> MagicMock:
+        """Create a stub mirroring ``RunningStatistics`` shape."""
+        stat = MagicMock()
+        stat.count = count
+        stat.max = max_value
+        return stat
+
+    def _set_training_examples_stats(self, backend: HuggingFaceBackend, stats: dict) -> None:
+        """Attach a minimal ``training_examples`` stub exposing ``.stats``."""
+        training_examples = MagicMock()
+        training_examples.stats = stats
+        backend.training_examples = training_examples
+
+    def test_copies_max_onto_metadata(self, backend):
+        """Populated stat is written as ``math.ceil`` onto metadata."""
+        self._set_training_examples_stats(
+            backend,
+            {"tokens_per_example": self._make_stat(count=7, max_value=2251.5)},
+        )
+
+        backend._propagate_max_tokens_per_example()
+
+        # math.ceil(2251.5) = 2252
+        assert backend.model_metadata.max_tokens_per_example == 2252
+
+    def test_noop_when_stat_missing(self, backend):
+        """Missing ``tokens_per_example`` key leaves the metadata untouched."""
+        backend.model_metadata.max_tokens_per_example = None
+        self._set_training_examples_stats(backend, {"records_per_example": self._make_stat(1, 10)})
+
+        backend._propagate_max_tokens_per_example()
+
+        assert backend.model_metadata.max_tokens_per_example is None
+
+    def test_noop_when_stat_unpopulated(self, backend):
+        """Stat with ``count == 0`` is treated as absent."""
+        backend.model_metadata.max_tokens_per_example = None
+        self._set_training_examples_stats(
+            backend,
+            {"tokens_per_example": self._make_stat(count=0, max_value=float("-inf"))},
+        )
+
+        backend._propagate_max_tokens_per_example()
+
+        assert backend.model_metadata.max_tokens_per_example is None
+
+    def test_rounds_up_fractional_max(self, backend):
+        """Fractional ``max`` (from running mean interactions) rounds up."""
+        self._set_training_examples_stats(
+            backend,
+            {"tokens_per_example": self._make_stat(count=3, max_value=1000.01)},
+        )
+
+        backend._propagate_max_tokens_per_example()
+
+        assert backend.model_metadata.max_tokens_per_example == 1001


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

# Summary

Size generation `max_tokens` from the actual training-observed tokenized example length instead of the full context window, and absorb the narrow probe-batch + adaptive batch-sizing scope of #435 so the two improvements ship together.

## Implementation

### `max_tokens` plumbed end-to-end

- `assembler.py` already tracks `tokens_per_example` as a `RunningStatistics` (count / mean / min / max / stddev) over `prompt + packed records`. The HuggingFace training backend now copies `tokens_per_example.max` into `ModelMetadata.max_tokens_per_example` at adapter-save time, so the stat survives `adapter_metadata.json` round-trips.
- `ModelMetadata.generation_max_tokens_for(prompt_len)` (replaces the no-arg property per binaryaaron) returns `max(0, min(int(stat * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER), max_seq_length - prompt_len))`. The `- prompt_len` clamp is the defensive belt for [vllm#33418](https://github.com/vllm-project/vllm/issues/33418) -- vLLM raises when `len(prompt) + max_tokens > max_model_len`. Docstring spells out that `max_tokens_per_example` already includes the prompt, so the scaled value is an upper bound on any rollout rather than a tight output budget.
- Three call sites consume the helper:
  - `VllmBackend` -- caches the templated prompt's tokenized length (lazily, via `self.llm.get_tokenizer()`) and passes it on each `generate()` call.
  - `TimeseriesBackend` -- overrides `_get_prompt_token_count` to return `templated_prompt + max(active prefill)`, since `SamplingParams` is built once per `generate()` but per-group prefills vary in length.
  - `InferenceEvalCallback` (HF Trainer) -- replaces the inline `min(metadata.generation_max_tokens, tokenizer.model_max_length - len(input_ids[0]))` with `metadata.generation_max_tokens_for(len(input_ids[0]))`, removing the duplicate clamp.

### Absorbed from #435 (narrow scope)

`generation/results.py`:

- `INITIAL_PROBE_PROMPTS = 10` -- the truly-first batch ships a small probe so `valid_records / num_prompts` can be measured cheaply before committing to a full batch.
- `max_num_prompts_per_batch` becomes `int | None` -- when `None` and `target_num_records` is set, derive `min(ADAPTIVE_MAX_PROMPTS_CEILING=2000, max(MAX_NUM_PROMPTS_PER_BATCH, target_num_records // 20))`. Explicit values are honored (back-compat).
- `get_next_num_prompts` is now a three-branch guard: probe on the truly-first batch, escalate to full-budget when prompts have been sent but produced zero valid records, otherwise size from the records-per-prompt estimate.

## Tests

- `tests/llm/test_metadata.py::TestGenerationMaxTokensFor` -- four cases covering (stat populated + small prompt), (stat populated + large prompt), (stat unset), and `prompt_len == 0` regression guard for legacy adapters; JSON round-trip preserves `max_tokens_per_example`.
- `tests/generation/test_vllm_backend.py` -- `mock_model_metadata` is now `MagicMock(spec=ModelMetadata)` (signature-drift guard); plumbing tests assert `SamplingParams.max_tokens` equals `metadata.generation_max_tokens_for(...)` and verify the cached prompt-token count is the argument, including the engine-not-yet-initialized fallback (count = 0).
- `tests/generation/test_timeseries_backend.py` -- dropped the literal `1200` assertion in favor of symbolic equality with `int(stat * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)`; added a prompt-length-clamp case.
- `tests/training/test_callbacks.py` -- mocks `generation_max_tokens_for` instead of the removed property; existing tighter / fallback / prompt-length-subtraction scenarios kept.
- `tests/generation/test_results.py` (new) -- `TestInitialProbeBatch`, `TestEscalateAfterFailedProbe`, parametrized `TestAdaptiveMaxNumPromptsPerBatch` matrix covering `None`, small, large, ceiling-capped, and explicit-value cases.

Half complete wandb test (many jobs failed due to HF rate limit)
[this PR](https://wandb.ai/nemo-llm-service/pr422-exp/table?nw=nwuserseanyang), [main](https://wandb.ai/nemo-llm-service/pr422-control/table?nw=nwuserseanyang)

## Pre-Review Checklist

- [x] `make format && make check` or prek validation
- [x] `make test` passes locally
- [x] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

- [x] New or updated tests for any fix or new behavior
- [x] Updated docstrings for `ModelMetadata.max_tokens_per_example` and `generation_max_tokens_for`; `INITIAL_PROBE_PROMPTS` / `ADAPTIVE_MAX_PROMPTS_CEILING` docstrings explain the probe-vs-full-batch contract


## Other Notes

- Closes #<issue>
- Cite prior internal work
[2026-02-17 Candidate Models Hyperparam Tuning Round 2](https://nvidia.atlassian.net/wiki/spaces/SDGR/pages/3090453569) established that "the most effective approach is limiting the number of tokens we can pack inside an example" for Safe Synthesizer runtime.