### PR TITLE
chore: Document and update to init files in src/ but not in tests/

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -708,7 +708,7 @@ The before/after examples above demonstrate most rules. These additional points 
   ```
 
   Do not use the Sphinx `:meth:` / `:class:` / `:func:` syntax -- it renders as literal text in MkDocs
-- __init__.py files do not need docstrings.
+- `__init__.py` files belong only in `src/` package directories -- never in `tests/`. They do not need docstrings.
 - Docstrings on Python Click command methods are used for the --help details on the CLI, so may not fully conform to the general method docstring guidance.
   They should be written for the CLI user, and not for a developer working on the code.
   For example, should not include `Args:`, the args are already documented for CLI usage through the `click.options` decorators.
@@ -832,7 +832,9 @@ readonly OUTPUT_DIR="${1:?Usage: $0 <output-dir>}"
 
 ### Package structure
 
-Every directory under `src/` and `tests/` that contains Python files must include an `__init__.py` file, even if empty. This ensures the directory is recognized as a Python package by the import machinery and by tooling (`pytest`, `ruff`, `ty`).
+Every directory under `src/` that contains Python files must include an `__init__.py` file, even if empty. This ensures the directory is recognized as a Python package by the import machinery and by tooling (`pytest`, `ruff`, `ty`).
+
+`__init__.py` files must never be added under `tests/`. Test directories are discovered by `pytest` via its `rootdir` and `testpaths`, not through Python package imports. Adding `__init__.py` files there creates unnecessary coupling, can shadow production package names, and may interfere with `pytest`'s `import-mode=importlib`.
 
 ### Copyright headers
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -830,6 +830,10 @@ readonly OUTPUT_DIR="${1:?Usage: $0 <output-dir>}"
 
 ## General conventions
 
+### Package structure
+
+Every directory under `src/` and `tests/` that contains Python files must include an `__init__.py` file, even if empty. This ensures the directory is recognized as a Python package by the import machinery and by tooling (`pytest`, `ruff`, `ty`).
+
 ### Copyright headers
 
 Every source file requires an SPDX copyright header and `make format` handles this automatically. See [tools/codestyle/copyright_fixer.py](tools/codestyle/copyright_fixer.py).

--- a/pytest.ini
+++ b/pytest.ini
@@ -48,7 +48,7 @@ addopts =
     # Show test durations for slowest tests
     -ra
     # importlib is the recommended mode, and ensures pytest works correctly
-    # with identically names files in different subdirectories of tests/
+    # with identically named files in different subdirectories of tests/
     --import-mode=importlib
 
 # Minimum pytest version

--- a/pytest.ini
+++ b/pytest.ini
@@ -47,6 +47,8 @@ addopts =
     --maxprocesses=8 
     # Show test durations for slowest tests
     -ra
+    # importlib is the recommended mode, and ensures pytest works correctly
+    # with identically names files in different subdirectories of tests/
     --import-mode=importlib
 
 # Minimum pytest version

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,6 @@ python_files = test_*.py *_test.py
 python_classes = Test*
 python_functions = test_*
 pythonpath = ["."]
-importmode = importlib
 
 # Test discovery paths - packages and stable services
 testpaths =
@@ -36,6 +35,8 @@ asyncio_mode = auto
 addopts =
     --verbose
     --strict-markers
+    # Fail on unknown ini options instead of silently ignoring them
+    --strict-config
     --tb=long
     # Coverage options (can be overridden by command line)
     --cov-report=html
@@ -46,6 +47,7 @@ addopts =
     --maxprocesses=8 
     # Show test durations for slowest tests
     -ra
+    --import-mode=importlib
 
 # Minimum pytest version
 minversion = 8.0

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,6 +5,7 @@ python_files = test_*.py *_test.py
 python_classes = Test*
 python_functions = test_*
 pythonpath = ["."]
+importmode = importlib
 
 # Test discovery paths - packages and stable services
 testpaths =

--- a/src/nemo_safe_synthesizer/evaluation/assets/text/__init__.py
+++ b/src/nemo_safe_synthesizer/evaluation/assets/text/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -166,3 +166,4 @@ See [tests/smoke/README.md](smoke/README.md) for additional smoke-specific gotch
 - Tests mirror source structure: `tests/training/`, `tests/generation/`, etc.
 - Naming: fixture names use `fixture_` prefix consistently (e.g., `fixture_iris_dataset`).
 - `print()` is allowed in tests (ruff `T201` is suppressed for `tests/`). Use it freely for debug output in test functions.
+- Importing from another file under `tests/`, such as `tests/cli/helpers.py` does not work due to how pytest operates. A relative import from `conftest.py` is possible when a method (not a pytest fixture which is automatically available without importing) is shared across multiple test files. E.g., `from .conftest import train_with_sdk`.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0

--- a/tests/configurator/__init__.py
+++ b/tests/configurator/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0

--- a/tests/sdk/__init__.py
+++ b/tests/sdk/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0

--- a/tests/smoke/__init__.py
+++ b/tests/smoke/__init__.py
@@ -1,2 +1,0 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
-# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
# Summary

Be consistent that all directories in `src/` containing python files are packages (have a `__init__.py` file), but never use `__init__.py` in `tests/`. Instead we rely on pytest discovery and loading with `--import-mode=importlib`.

The existing setup (`--import-mode=prepend` and inconsistent `__init__.py` in `tests/`) was causing problems with #229 which introduced 2 test files with the same name.

- Add missing `__init__.py` file in `src/`
- Remove `__init__.py` files in `tests/`
- Add directive to STYLE_GUIDE.md to use init files in `src/` but not in `tests/`
- Add info in `TESTING.md` on importing from `tests/` in test files
- Add `importmode = importlib` to `pytest.ini` to be explicit on pytest behavior for importing, this is the recommendation for new projects
- Add `--strict-config` to `pytest.ini` to fail on bad configuration instead of silently ignoring.

## Pre-Review Checklist

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [x] `make test` passes locally
- [ ] `make test-e2e` passes locally
   - Not needed for this PR that's not touching any GPU related aspects.
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)
  - Not needed for this PR that's not touching any GPU related aspects.
 
## Pre-Merge Checklist

- [ ] New or updated tests for any fix or new behavior
- [X] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

Fixing and debugging the issue in #229 was slowed down by bad configuration in pytests.ini being silently ignored, hence adding `--strict-config` in this PR as well.
