### PR TITLE
fix(generation): bound target overshoot via probe-batch + adaptive si…

### DIFF
--- a/src/nemo_safe_synthesizer/generation/results.py
+++ b/src/nemo_safe_synthesizer/generation/results.py
@@ -29,6 +29,15 @@ from ..observability import get_logger
 from ..utils import DataActionsFn
 
 NUM_PROMPT_BUFFER = 10
+# Small first-batch prompt count used to measure records-per-prompt before
+# the adaptive batch sizing kicks in. Prior behavior was to send
+# ``max_num_prompts_per_batch`` (100) on the first batch assuming one
+# record per prompt — this overshoots severely when the model packs many
+# records per prompt (JSON always; positional once multi-record-per-prompt
+# generation is enabled). A small probe limits the first-batch overshoot
+# to ``INITIAL_PROBE_PROMPTS * observed_records_per_prompt`` records at
+# worst, after which the adaptive path corrects.
+INITIAL_PROBE_PROMPTS = 10
 
 logger = get_logger(__name__)
 
@@ -176,7 +185,7 @@ class GenerationBatches:
         self,
         target_num_records: int | None = None,
         batches: list[Batch] | None = None,
-        max_num_prompts_per_batch: int = MAX_NUM_PROMPTS_PER_BATCH,
+        max_num_prompts_per_batch: int | None = None,
         invalid_fraction_threshold: float | None = None,
         patience: int | None = None,
         data_actions_fn: DataActionsFn | None = None,
@@ -184,6 +193,17 @@ class GenerationBatches:
         self._batches = batches or []
         self._start_time = time.perf_counter()
         self.target_num_records = target_num_records
+        # Auto-scale the per-batch prompt cap with target size so large
+        # targets don't pay 10-100× synchronous-batch overhead. Floor at
+        # MAX_NUM_PROMPTS_PER_BATCH for small targets, grow with target, cap
+        # at 2000 to stay within reasonable vLLM queue sizes.
+        if max_num_prompts_per_batch is None:
+            if target_num_records is None:
+                max_num_prompts_per_batch = MAX_NUM_PROMPTS_PER_BATCH
+            else:
+                max_num_prompts_per_batch = min(
+                    2000, max(MAX_NUM_PROMPTS_PER_BATCH, target_num_records // 20)
+                )
         self.max_num_prompts_per_batch = max_num_prompts_per_batch
         self.status = GenerationStatus.IN_PROGRESS
         self.running_stopping_metric = RunningStatistics()
@@ -347,11 +367,18 @@ class GenerationBatches:
             valid_records_per_prompt = self.num_valid_records / self.num_prompts
             num_prompts_needed = round(num_records_remaining / (valid_records_per_prompt + EPS))
             num_prompts = min(num_prompts, num_prompts_needed + NUM_PROMPT_BUFFER)
+        elif self.num_prompts == 0:
+            # Truly first batch: no records-per-prompt history yet. Send a
+            # small probe batch to learn the ratio cheaply; the adaptive
+            # branch above correctly sizes subsequent batches once
+            # num_valid_records > 0.
+            num_prompts = min(num_prompts, INITIAL_PROBE_PROMPTS, num_records_remaining + NUM_PROMPT_BUFFER)
         else:
-            # First batch: no records-per-prompt history yet.  Assume at
-            # least 1 record per prompt (the actual ratio is typically much
-            # higher) to avoid sending max_num_prompts_per_batch prompts
-            # when the target is small.
+            # Prompts already sent but still no valid records. Don't keep
+            # probing — escalate to full batches to give the model more
+            # attempts per cycle. NSS's patience mechanism
+            # (``STOP_NO_RECORDS``) is the ultimate backstop for pathological
+            # datasets.
             num_prompts = min(num_prompts, num_records_remaining + NUM_PROMPT_BUFFER)
 
         return num_prompts


### PR DESCRIPTION
# Summary

Fixes a significant generation-time overshoot in `GenerationBatches`. The pipeline assumes 1 valid record per prompt on the first batch and sends the full `max_num_prompts_per_batch` (100), but well-trained models pack 10-170 records per prompt — producing 11k-17k records for a 1k target
(11-17× overshoot), all wasted compute.

Three related changes to `generation/results.py`:

1. **Probe-batch** — new `INITIAL_PROBE_PROMPTS = 10` used for the truly-first batch to measure records-per-prompt cheaply before the adaptive path takes over.
2. **Fallback escalation** — distinguish *"first batch"* from *"prompts sent but no valid records yet"*, so pathological datasets escalate to full batches rather than spinning on tiny probes.
3. **Adaptive `max_num_prompts_per_batch`** — auto-scale with `target_num_records` (floor 100, ceiling 2000, linear above `target / 20`) so large targets (100k+) don't pay 100+ synchronous-batch cycles.

Benchmarked on the top-12 datasets × 4 configs (positional/JSON × 6,250/25,000 train). Overshoot bounded to ~5-10%; gen-time improvements 1.3-29× across cells with quality unchanged (±0.1 SQS, valid% equal or higher).

| Cell | pre-fix gen | post-fix gen | Speedup |
|---|---:|---:|---:|
| `beijing` × json25k | 493s | 17s | **29×** |
| `disaster_response_messages` × pos6k | 801s | 145s | 5.5× |
| `adult` × json6k | 455s | 102s | 4.5× |
| `EKG_100` × json25k | 148s | 41s | 3.6× |

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `make format && make check` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

- Backward compatibility: `max_num_prompts_per_batch: int = MAX_NUM_PROMPTS_PER_BATCH` → `int | None = None`. Callers passing an explicit int are unaffected; callers relying on the default now get adaptive sizing which is always ≥ the old default. No changes to public method signatures or
return types.
- Follow-up (out of scope): a streaming `AsyncLLMEngine` integration would allow true mid-batch abort and drive overshoot to ~0% — orthogonal ~50 LOC piece in the vLLM backend.
- Closes #<issue>