### PR TITLE
chore: Add v prefixes to tag examples in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -575,7 +575,7 @@ Before contributing, run `make format` and `make check`. See `AGENTS.md` for ful
 
 ## Releasing
 
-Releases are published to PyPI via the **Release NeMo Safe Synthesizer** GitHub Actions workflow. The workflow builds the wheel from a git tag, publishes to Test PyPI as a pre-flight check, and optionally publishes to the real PyPI and creates a GitHub release.
+Releases are published to PyPI via the **Release NeMo Safe Synthesizer** GitHub Actions workflow. The workflow builds the wheel from a git tag, publishes to Test PyPI as a pre-flight check, publishes to the real PyPI, and creates a GitHub release.
 
 ### 1. Create and push a tag
 
@@ -585,16 +585,16 @@ The GitHub tag always starts with a `v` prefix.
 
 Examples:
 
-| GitHub Tag      | PyPI Version | Valid                                   |
-|:--------------- |:------------ |:--------------------------------------- |
-| `v1.0.0`        | `1.0.0`      | ✅                                      |
-| `v2.1.3`        | `2.1.3`      | ✅                                      |
-| `v0.0.5rc0`     | `0.0.5rc0`   | ✅                                      |
-| `v0.1.2rc5`     | `0.1.2rc5`   | ✅                                      |
-| `1.0.0`         |              | ❌ No `v` prefix                        |
-| `release-1.0`   |              | ❌ Wrong format                         |
-| `v0.0.7-rc4`    |              | ❌ Dash before rc suffix                |
-| `v0.1.3a1`      |              | ❌ Alpha prereleases are not used; use rcN only |
+| GitHub Tag    | PyPI Version | Valid                                           |
+|:------------- |:------------ |:----------------------------------------------- |
+| `v1.0.0`      | `1.0.0`      | ✅                                              |
+| `v2.1.3`      | `2.1.3`      | ✅                                              |
+| `v0.0.5rc0`   | `0.0.5rc0`   | ✅                                              |
+| `v0.1.2rc5`   | `0.1.2rc5`   | ✅                                              |
+| `1.0.0`       |              | ❌ No `v` prefix                                |
+| `release-1.0` |              | ❌ Wrong format                                 |
+| `v0.0.7-rc4`  |              | ❌ Dash before rc suffix                        |
+| `v0.1.3a1`    |              | ❌ Alpha prereleases are not used; use rcN only |
 
 To create and push tags:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -608,7 +608,7 @@ git tag v0.1.0rc1 <commit-sha>
 git push origin <tag>
 ```
 
-### 2. Run the workflow
+### 2. Monitor the workflow run
 
 The [workflow](https://github.com/NVIDIA-NeMo/Safe-Synthesizer/actions/workflows/release.yml) to release is triggered automatically when a tag starting with `v` is pushed to GitHub.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,6 @@ Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 - [Repository Settings](#repository-settings)
   - [Branch Naming Convention](#branch-naming-convention)
   - [Conventional Commits](#conventional-commits)
-  - [Semantic Versioning for Tags](#semantic-versioning-for-tags)
   - [Branch Protection](#branch-protection)
 - [Pull Request Process](#pull-request-process)
 - [Issues and Discussions](#issues-and-discussions)
@@ -300,29 +299,6 @@ Examples:
 
 > Since we use squash merging, your PR title should follow this format as it becomes the commit message.
 
-### Semantic Versioning for Tags
-
-Release tags must follow [Semantic Versioning](https://semver.org/) and must be prefixed with `v` on GitHub:
-
-```text
-vMAJOR.MINOR.PATCH[-prerelease][+build]
-```
-
-The release workflow triggers on `v*` tags, derives the package version from the built wheel filename for publishing, and creates the GitHub release as `v${VERSION}`.
-
-Examples:
-
-
-| Tag                    | Valid           |
-| ---------------------- | --------------- |
-| `v1.0.0`                | ✅               |
-| `v2.1.3`                | ✅               |
-| `v1.0.0-alpha`          | ✅               |
-| `v1.0.0-beta.1`         | ✅               |
-| `v1.0.0-rc.1+build.123` | ✅               |
-| `1.0.0`                 | ❌ No `v` prefix |
-| `release-1.0`           | ❌ Wrong format  |
-
 
 ### Branch Protection
 
@@ -603,7 +579,22 @@ Releases are published to PyPI via the **Release NeMo Safe Synthesizer** GitHub 
 
 ### 1. Create and push a tag
 
-Tags must follow [Semantic Versioning](#semantic-versioning-for-tags). For release candidates, use the `rcN` pre-release suffix:
+Release versions follow [PEP440](https://peps.python.org/pep-0440/) with major, minor, and patch release numbers.
+Prerelease versions append the suffix rcN (no dash as specified by PEP440).
+The GitHub tag always starts with a `v` prefix.
+
+Examples:
+
+| GitHub Tag      | PyPI Version | Valid                    |
+|:--------------- |:------------ |:------------------------ |
+| `v1.0.0`        | `1.0.0`      | ✅                       |
+| `v2.1.3`        | `2.1.3`      | ✅                       |
+| `v0.0.5rc0`     | `0.0.5rc0`   | ✅                       |
+| `v0.1.2rc5`     | `0.1.2rc5`   | ✅                       |
+| `1.0.0`         |              | ❌ No `v` prefix         |
+| `release-1.0`   |              | ❌ Wrong format          |
+| `v0.0.7-rc4`    |              | ❌ Dash before rc suffix |
+| `v0.1.3alpha1`  |              | ❌ Use rc, not alpha     |
 
 ```bash
 # Stable release
@@ -617,30 +608,7 @@ git push origin <tag>
 
 ### 2. Run the workflow
 
-Trigger the workflow from the GitHub UI or via `gh`:
-
-**GitHub UI:** Go to **Actions → Release NeMo Safe Synthesizer → Run workflow** and fill in the inputs.
-
-**CLI:**
-
-```bash
-gh workflow run release.yml \
-  --field release-ref=<tag> \
-  --field dry-run=true \
-  --field create-gh-release=false
-```
-
-### 3. Inputs
-
-| Input | Description | Default |
-|---|---|---|
-| `release-ref` | Full SHA or tag to build from | required |
-| `dry-run` | Publish to Test PyPI only; skip real PyPI | `true` |
-| `create-gh-release` | Create a GitHub release and attach the wheel | `true` |
-
-**Dry-run mode** (default): builds the wheel and publishes it to [Test PyPI](https://test.pypi.org/) only. Use this to verify the package before a real release. The workflow always publishes to Test PyPI regardless of `dry-run`.
-
-**Real release**: uncheck `dry-run` (or pass `--field dry-run=false`) to also publish to the real [PyPI](https://pypi.org/). Pre-release tags (`rc`, `alpha`, `beta`, `.dev`) are automatically marked as pre-releases on both PyPI and GitHub.
+The [workflow](https://github.com/NVIDIA-NeMo/Safe-Synthesizer/actions/workflows/release.yml) to release is triggered automatically when a tag starting with `v` is pushed to GitHub.
 
 ## NMP Integration
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -596,6 +596,8 @@ Examples:
 | `v0.0.7-rc4`    |              | ❌ Dash before rc suffix |
 | `v0.1.3alpha1`  |              | ❌ Use rc, not alpha     |
 
+To create and push tags:
+
 ```bash
 # Stable release
 git tag v0.1.0 <commit-sha>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,13 +302,13 @@ Examples:
 
 ### Semantic Versioning for Tags
 
-Release tags must follow [Semantic Versioning](https://semver.org/) with a `v` prefix for github tag:
+Release tags must follow [Semantic Versioning](https://semver.org/) and must be prefixed with `v` on GitHub:
 
 ```text
 vMAJOR.MINOR.PATCH[-prerelease][+build]
 ```
 
-The release workflow will remove the `v` prefix for publishing to pypi and github releases.
+The release workflow triggers on `v*` tags, derives the package version from the built wheel filename for publishing, and creates the GitHub release as `v${VERSION}`.
 
 Examples:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,24 +302,26 @@ Examples:
 
 ### Semantic Versioning for Tags
 
-Release tags must follow [Semantic Versioning](https://semver.org/):
+Release tags must follow [Semantic Versioning](https://semver.org/) with a `v` prefix for github tag:
 
 ```text
-MAJOR.MINOR.PATCH[-prerelease][+build]
+vMAJOR.MINOR.PATCH[-prerelease][+build]
 ```
+
+The release workflow will remove the `v` prefix for publishing to pypi and github releases.
 
 Examples:
 
 
 | Tag                    | Valid           |
 | ---------------------- | --------------- |
-| `1.0.0`                | ✅               |
-| `2.1.3`                | ✅               |
-| `1.0.0-alpha`          | ✅               |
-| `1.0.0-beta.1`         | ✅               |
-| `1.0.0-rc.1+build.123` | ✅               |
-| `v1.0.0`               | ❌ No `v` prefix |
-| `release-1.0`          | ❌ Wrong format  |
+| `v1.0.0`                | ✅               |
+| `v2.1.3`                | ✅               |
+| `v1.0.0-alpha`          | ✅               |
+| `v1.0.0-beta.1`         | ✅               |
+| `v1.0.0-rc.1+build.123` | ✅               |
+| `1.0.0`                 | ❌ No `v` prefix |
+| `release-1.0`           | ❌ Wrong format  |
 
 
 ### Branch Protection
@@ -605,10 +607,10 @@ Tags must follow [Semantic Versioning](#semantic-versioning-for-tags). For relea
 
 ```bash
 # Stable release
-git tag 0.1.0 <commit-sha>
+git tag v0.1.0 <commit-sha>
 
 # Release candidate
-git tag 0.1.0rc1 <commit-sha>
+git tag v0.1.0rc1 <commit-sha>
 
 git push origin <tag>
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -580,21 +580,21 @@ Releases are published to PyPI via the **Release NeMo Safe Synthesizer** GitHub 
 ### 1. Create and push a tag
 
 Release versions follow [PEP440](https://peps.python.org/pep-0440/) with major, minor, and patch release numbers.
-Prerelease versions append the suffix rcN (no dash as specified by PEP440).
+This project uses stable releases and release candidates only; prerelease versions append the suffix rcN (no dash, as specified by PEP440).
 The GitHub tag always starts with a `v` prefix.
 
 Examples:
 
-| GitHub Tag      | PyPI Version | Valid                    |
-|:--------------- |:------------ |:------------------------ |
-| `v1.0.0`        | `1.0.0`      | ✅                       |
-| `v2.1.3`        | `2.1.3`      | ✅                       |
-| `v0.0.5rc0`     | `0.0.5rc0`   | ✅                       |
-| `v0.1.2rc5`     | `0.1.2rc5`   | ✅                       |
-| `1.0.0`         |              | ❌ No `v` prefix         |
-| `release-1.0`   |              | ❌ Wrong format          |
-| `v0.0.7-rc4`    |              | ❌ Dash before rc suffix |
-| `v0.1.3alpha1`  |              | ❌ Use rc, not alpha     |
+| GitHub Tag      | PyPI Version | Valid                                   |
+|:--------------- |:------------ |:--------------------------------------- |
+| `v1.0.0`        | `1.0.0`      | ✅                                      |
+| `v2.1.3`        | `2.1.3`      | ✅                                      |
+| `v0.0.5rc0`     | `0.0.5rc0`   | ✅                                      |
+| `v0.1.2rc5`     | `0.1.2rc5`   | ✅                                      |
+| `1.0.0`         |              | ❌ No `v` prefix                        |
+| `release-1.0`   |              | ❌ Wrong format                         |
+| `v0.0.7-rc4`    |              | ❌ Dash before rc suffix                |
+| `v0.1.3a1`      |              | ❌ Alpha prereleases are not used; use rcN only |
 
 To create and push tags:
 


### PR DESCRIPTION
# Summary

Update example git tags for release versions to use the `v` prefix that our automation expects and tidy up other out-of-date parts of CONTRIBUTING.md regarding releasing and versions.

I went to make a release and immediately used the wrong tag format `0.0.5rc0` (and not `v0.0.5rc0`) since the wrong format is listed in the releasing section of CONTRIBUTING.md.

## Pre-Review Checklist

Ensure that the following pass:

CONTRIBUTING.md only change, tests not applicable.

- [ ] `make format && make check` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)



## Pre-Merge Checklist

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

