### PR TITLE
fix(eval): fix a param error in the report; fix test_render

### DIFF
--- a/src/nemo_safe_synthesizer/evaluation/reports/multimodal/multimodal_report.py
+++ b/src/nemo_safe_synthesizer/evaluation/reports/multimodal/multimodal_report.py
@@ -145,8 +145,8 @@ class MultimodalReport(EvaluationReport):
             synthetic=synthetic,
             test=test,
             column_statistics=column_statistics,
-            rows=MultimodalReport._get_config_value("sqs_rows", DEFAULT_RECORD_COUNT, config),
-            cols=MultimodalReport._get_config_value("sqs_columns", DEFAULT_SQS_REPORT_COLUMNS, config),
+            rows=MultimodalReport._get_config_value("sqs_report_rows", DEFAULT_RECORD_COUNT, config),
+            cols=MultimodalReport._get_config_value("sqs_report_columns", DEFAULT_SQS_REPORT_COLUMNS, config),
             mandatory_columns=MultimodalReport._get_config_value("mandatory_columns", [], config),
         )
 
@@ -186,8 +186,8 @@ class MultimodalReport(EvaluationReport):
                     synthetic=synthetic,
                     test=test,
                     column_statistics=column_statistics,
-                    rows=MultimodalReport._get_config_value("sqs_rows", DEFAULT_RECORD_COUNT, config),
-                    cols=MultimodalReport._get_config_value("sqs_columns", DEFAULT_SQS_REPORT_COLUMNS, config),
+                    rows=MultimodalReport._get_config_value("sqs_report_rows", DEFAULT_RECORD_COUNT, config),
+                    cols=MultimodalReport._get_config_value("sqs_report_columns", DEFAULT_SQS_REPORT_COLUMNS, config),
                     mandatory_columns=MultimodalReport._get_config_value("mandatory_columns", [], config),
                     enable_sampling=False,
                 ),

--- a/tests/evaluation/reports/test_multimodal_report.py
+++ b/tests/evaluation/reports/test_multimodal_report.py
@@ -10,6 +10,8 @@ pytest.importorskip(
     reason="sentence_transformers is required for these tests (install with: uv sync --extra cpu)",
 )
 
+from nemo_safe_synthesizer.config.evaluate import EvaluationParameters
+from nemo_safe_synthesizer.config.parameters import SafeSynthesizerParameters
 from nemo_safe_synthesizer.evaluation.data_model.evaluation_datasets import EvaluationDatasets
 from nemo_safe_synthesizer.evaluation.data_model.evaluation_score import Grade
 from nemo_safe_synthesizer.evaluation.reports.multimodal.multimodal_report import MultimodalReport
@@ -34,6 +36,39 @@ def test_jinja_context_job_id_set_when_nemo_job_id_present(monkeypatch: pytest.M
     report = _minimal_multimodal_report()
     ctx = report.jinja_context
     assert ctx["job_id"] == "cluster-job-abc123"
+
+
+def test_from_dataframes_applies_sqs_report_config(training_df, synthetic_df, test_df) -> None:
+    """``sqs_report_rows`` / ``sqs_report_columns`` from config drive the actual subsampling.
+
+    Regression: previously the multimodal report looked up ``sqs_rows`` /
+    ``sqs_columns`` -- keys that do not exist on ``EvaluationParameters`` --
+    so user-supplied row/column limits were silently ignored.
+    """
+    target_rows = 37
+    target_cols = 3
+    config = SafeSynthesizerParameters(
+        evaluation=EvaluationParameters(
+            mia_enabled=False,
+            aia_enabled=False,
+            pii_replay_enabled=False,
+            sqs_report_rows=target_rows,
+            sqs_report_columns=target_cols,
+        ),
+    )
+
+    report = MultimodalReport.from_dataframes(
+        training=training_df,
+        synthetic=synthetic_df,
+        test=test_df,
+        config=config,
+    )
+
+    assert report.evaluation_datasets is not None
+    assert report.evaluation_datasets.training_rows == target_rows
+    assert report.evaluation_datasets.synthetic_rows == target_rows
+    assert report.evaluation_datasets.training_cols == target_cols
+    assert report.evaluation_datasets.synthetic_cols == target_cols
 
 
 @pytest.mark.skip(reason="Times out")

--- a/tests/evaluation/reports/test_multimodal_report.py
+++ b/tests/evaluation/reports/test_multimodal_report.py
@@ -38,7 +38,7 @@ def test_jinja_context_job_id_set_when_nemo_job_id_present(monkeypatch: pytest.M
     assert ctx["job_id"] == "cluster-job-abc123"
 
 
-def test_from_dataframes_applies_sqs_report_config(training_df, synthetic_df, test_df) -> None:
+def test_from_dataframes_applies_sqs_report_config(fixture_training_df, fixture_synthetic_df, fixture_test_df) -> None:
     """``sqs_report_rows`` / ``sqs_report_columns`` from config drive the actual subsampling.
 
     Regression: previously the multimodal report looked up ``sqs_rows`` /
@@ -58,9 +58,9 @@ def test_from_dataframes_applies_sqs_report_config(training_df, synthetic_df, te
     )
 
     report = MultimodalReport.from_dataframes(
-        training=training_df,
-        synthetic=synthetic_df,
-        test=test_df,
+        training=fixture_training_df,
+        synthetic=fixture_synthetic_df,
+        test=fixture_test_df,
         config=config,
     )
 
@@ -71,7 +71,6 @@ def test_from_dataframes_applies_sqs_report_config(training_df, synthetic_df, te
     assert report.evaluation_datasets.synthetic_cols == target_cols
 
 
-@pytest.mark.skip(reason="Times out")
 def test_multimodal_report(
     fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df, fixture_skip_privacy_metrics_config
 ):
@@ -89,7 +88,7 @@ def test_multimodal_report(
     report_dict = report.get_dict()
     assert len(report_dict) == 6
     assert report_dict["Synthetic Quality Score"] == {
-        "raw_score": 9.8215,
+        "raw_score": 9.7935,
         "grade": "Excellent",
         "score": 9.8,
         "notes": None,
@@ -97,6 +96,6 @@ def test_multimodal_report(
 
     report_json = report.get_json()
     assert (
-        '"Synthetic Quality Score": {"raw_score": 9.8215, "grade": "Excellent", "score": 9.8, "notes": null}}'
+        '"Synthetic Quality Score": {"raw_score": 9.7935, "grade": "Excellent", "score": 9.8, "notes": null}}'
         in report_json
     )

--- a/tests/evaluation/reports/test_multimodal_report.py
+++ b/tests/evaluation/reports/test_multimodal_report.py
@@ -38,6 +38,7 @@ def test_jinja_context_job_id_set_when_nemo_job_id_present(monkeypatch: pytest.M
     assert ctx["job_id"] == "cluster-job-abc123"
 
 
+@pytest.mark.slow
 def test_from_dataframes_applies_sqs_report_config(fixture_training_df, fixture_synthetic_df, fixture_test_df) -> None:
     """``sqs_report_rows`` / ``sqs_report_columns`` from config drive the actual subsampling.
 
@@ -71,6 +72,7 @@ def test_from_dataframes_applies_sqs_report_config(fixture_training_df, fixture_
     assert report.evaluation_datasets.synthetic_cols == target_cols
 
 
+@pytest.mark.slow
 def test_multimodal_report(
     fixture_training_df_5k, fixture_synthetic_df_5k, fixture_test_df, fixture_skip_privacy_metrics_config
 ):

--- a/tests/evaluation/test_render.py
+++ b/tests/evaluation/test_render.py
@@ -9,6 +9,7 @@ pytest.importorskip(
     reason="sentence_transformers is required for these tests (install with: uv sync --extra cpu)",
 )
 
+from nemo_safe_synthesizer.config.evaluate import DEFAULT_RECORD_COUNT
 from nemo_safe_synthesizer.evaluation.render import render_report
 from nemo_safe_synthesizer.evaluation.reports.multimodal.multimodal_report import MultimodalReport
 
@@ -29,8 +30,8 @@ def test_render(
         column_statistics=fixture_column_statistics,
     )
     output = render_report(report, "multi_modal_report.j2")
-    assert output is not None
     # output = render_report(report, "multi_modal_report.j2", "/tmp/test_mm_report.html")
+    assert output is not None
     assert len(output) > 0
 
     # Section headings rendered (catch wholesale template breakage)
@@ -40,7 +41,7 @@ def test_render(
 
     # Dynamic values from Pydantic models made it into HTML (catch silent blanks
     # from Jinja variable typos -- default Undefined renders as empty string)
-    assert "10000" in output
+    assert str(DEFAULT_RECORD_COUNT) in output
     assert "Missing %" in output
 
 
@@ -67,7 +68,7 @@ def test_render_dp_enabled(
     assert "Dataset Statistics" in output
     assert "Synthetic Quality Score" in output
     assert "Data Privacy Score" in output
-    assert "5000" in output
+    assert str(DEFAULT_RECORD_COUNT) in output
 
 
 @pytest.mark.slow
@@ -93,4 +94,4 @@ def test_render_dp_not_enabled(
     assert "Dataset Statistics" in output
     assert "Synthetic Quality Score" in output
     assert "Data Privacy Score" in output
-    assert "5000" in output
+    assert str(DEFAULT_RECORD_COUNT) in output


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->
Two (unrelated) fixes, but since i was working in the evaluate/ path:
- `test_render.py`: it broke but we didn't catch it before due to it being marked slow
- `multimodal_report.py`: the following configs are actually not being respected due to param name mismatch
```
evaluation:
  sqs_report_rows: 100
  sqs_report_columns: 10
```

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [x] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #432 

## Testing Plan
- [x] `pytest tests/evaluation/test_render.py --tb=no -q -n0`
- [x] Run `safe-synthesizer run --config /root/configs/quick-tinyllama-unsloth.yaml --data-source /root/datasets/clinc_oos.csv` with the above portion added to the config
