### PR TITLE
fix: Print correct command to self-update mise version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
 
 > Note: Other tools like [uv](https://docs.astral.sh/uv/), [ruff](https://docs.astral.sh/ruff/), [ty](https://github.com/astral-sh/ty), and [gh](https://cli.github.com/) are installed automatically by `make setup` (via [mise](https://mise.jdx.dev/)). Tool versions are declared in `.mise.toml` and locked in `mise.lock` (committed), ensuring reproducible toolchains across developer systems and CI. These should not interfere with locally installed tools.
 
-> Note on mise itself: the mise version is pinned in `Makefile` (`MISE_VERSION`). The first run of `make setup` installs exactly that version via `tools/install-mise.sh`, preferring the GPG-verified installer when the full toolchain (`gpg`, `gpg-agent`, and `dirmngr`) is available and falling back to `https://mise.run` otherwise (with a warning). If you already have a different mise version on `PATH`, `make setup` will stop and tell you -- either run `mise self-update --version <pinned>` or uninstall the existing mise and rerun. It will not silently replace your install.
+> Note on mise itself: the mise version is pinned in `Makefile` (`MISE_VERSION`). The first run of `make setup` installs exactly that version via `tools/install-mise.sh`, preferring the GPG-verified installer when the full toolchain (`gpg`, `gpg-agent`, and `dirmngr`) is available and falling back to `https://mise.run` otherwise (with a warning). If you already have a different mise version on `PATH`, `make setup` will stop and tell you -- either run `mise self-update <pinned>` or uninstall the existing mise and rerun. It will not silently replace your install.
 
 ### Setup
 

--- a/tools/install-mise.sh
+++ b/tools/install-mise.sh
@@ -140,7 +140,7 @@ if command -v mise >/dev/null 2>&1; then
         exit 0
     fi
     echo "ERROR: found mise ${installed} on PATH but this repo pins ${MISE_VERSION}" >&2
-    echo "       run 'mise self-update --version ${expected}' or uninstall the current mise and rerun 'make setup'" >&2
+    echo "       run 'mise self-update ${expected}' or uninstall the current mise and rerun 'make setup'" >&2
     exit 1
 fi
 


### PR DESCRIPTION
# Summary

`mise self-update` has no `--version` flag, instead it takes the version as a positional argument. Updates the error message when mise is at the wrong version with a valid `mise self-update` command.

## Pre-Review Checklist

Not applicable, this error message in setup is not covered by any tests.

Ensure that the following pass:

- [ ] `make format && make check` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

