### PR TITLE
fix: preserve finish reasons for adaptive generation

### DIFF
--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -293,16 +293,20 @@ effect visible.
 If this stage takes more than 10 minutes, you might need to train the model
 more or examine the training parameters.
 
-To diagnose, run with `-v` (debug logging). The logs will show:
+To diagnose, check the batch summary logs first. When vLLM reports why
+outputs stopped, the `Batch Generation Summary` includes aggregate
+`finish_reasons` counts. Run with `-v` (debug logging) for per-prompt
+details:
 
 - Sampling parameters, including EOS token configuration, `max_tokens`,
   and stop conditions
 - Per-prompt output: token count, `finish_reason`, and `stop_reason`
 
-If every prompt shows `finish_reason=stop`, the stop condition is working
-and the generation time is real inference time. If any prompt shows
-`finish_reason=length`, it ran to `max_tokens` without producing an EOS
-token -- this typically indicates insufficient training (see
+If outputs show `finish_reason=stop`, the stop condition is working and
+the generation time is real inference time. If outputs show
+`finish_reason=length`, they ran to `max_tokens` without producing an EOS
+token or a complete parseable record -- this can indicate insufficient
+training or an overly tight output-token budget (see
 [Grouped Data Produces Very Few Training Examples](#grouped-data-produces-very-few-training-examples)).
 
 ### GenerationError
@@ -316,7 +320,11 @@ Generation stopped prematurely due to no valid records
 : The first batch produced zero valid records. The model may be underfitting
   or the schema may not match the training data. Increase
   `training.num_input_records_to_sample` to give the model more context,
-  and check training logs for quality issues.
+  and check training logs for quality issues. If the batch summary shows
+  `finish_reasons` dominated by `length`, generation reached `max_tokens`
+  before producing valid records; inspect prompt size, schema size, and
+  grouped/time-series prefill length before treating it as model quality
+  alone.
 
 ```text
 Generation stopped prematurely because the average fraction of invalid records was higher than...

--- a/src/nemo_safe_synthesizer/generation/batch.py
+++ b/src/nemo_safe_synthesizer/generation/batch.py
@@ -94,6 +94,7 @@ class Batch:
         self._responses: list[ParsedResponse] = []
         self._processor = processor
         self._total_completion_tokens: int = 0
+        self.finish_reasons: Counter[str] = Counter()
 
     @property
     def num_prompts(self) -> int:
@@ -130,6 +131,11 @@ class Batch:
     def total_completion_tokens(self) -> int:
         """Total tokens across all completions in this batch (from vLLM output)."""
         return self._total_completion_tokens
+
+    @property
+    def num_length_truncated_completions(self) -> int:
+        """Number of completions that stopped because they reached ``max_tokens``."""
+        return self.finish_reasons["length"]
 
     def _record_token_totals(self) -> tuple[int, int]:
         """Return ``(valid_tokens, invalid_tokens)`` from a single scan of ``_responses``."""
@@ -259,12 +265,14 @@ class Batch:
         err_stats: pd.DataFrame = self.error_statistics(detailed_errors=detailed_errors)
 
         # Build structured summary data - processor renders as table for console
-        summary_data: dict[str, int | float] = {
+        summary_data: dict[str, object] = {
             "num_prompts": self.num_prompts,
             "num_valid_records": self.num_valid_records,
             "num_invalid_records": self.num_invalid_records,
             "valid_record_fraction": round(self.valid_record_fraction, 2),
         }
+        if self.finish_reasons:
+            summary_data["finish_reasons"] = dict(self.finish_reasons)
         if self.num_data_config_rejected_records:
             summary_data["num_data_config_rejected_records"] = self.num_data_config_rejected_records
         if self._total_completion_tokens > 0:

--- a/src/nemo_safe_synthesizer/generation/results.py
+++ b/src/nemo_safe_synthesizer/generation/results.py
@@ -351,14 +351,35 @@ class GenerationBatches:
         """Total completions that stopped because they reached ``max_tokens``."""
         return sum(batch.num_length_truncated_completions for batch in self._batches)
 
+    @staticmethod
+    def _has_no_valid_records(batch: Batch) -> bool:
+        """Return whether a batch produced zero valid records."""
+        return batch.num_valid_records == 0
+
+    @classmethod
+    def _is_inconclusive_zero_valid_batch(cls, batch: Batch) -> bool:
+        """Return whether every completion in a zero-valid batch reached ``max_tokens``."""
+        return (
+            cls._has_no_valid_records(batch)
+            and batch.num_prompts > 0
+            and batch.num_length_truncated_completions == batch.num_prompts
+        )
+
+    @classmethod
+    def _should_stop_after_first_zero_valid_batch(cls, batch: Batch) -> bool:
+        """Return whether a first zero-valid batch has enough signal to stop immediately."""
+        return cls._has_no_valid_records(batch) and not cls._is_inconclusive_zero_valid_batch(batch)
+
     def add_batch(self, batch: Batch) -> None:
         """Add a batch and update the generation status.
 
         Stopping rules:
 
-        * The very first batch producing zero valid records triggers
-          ``STOP_NO_RECORDS`` unless it was length-truncated and a
-          patience-based ``stop_condition`` is configured.
+        * The very first batch producing zero valid records normally
+          triggers ``STOP_NO_RECORDS``. A fully length-truncated probe is
+          the exception: every completion may have been cut off before it
+          could emit a complete record, so a patience-based
+          ``stop_condition`` gets to decide whether to continue.
         * When a ``stop_condition`` is configured, subsequent batches
           with zero valid records are tolerated until the patience-based
           threshold is reached.
@@ -372,10 +393,10 @@ class GenerationBatches:
         self._apply_data_actions_fn(batch)
         self.running_stopping_metric.update(batch.stopping_metric)
         if self.stop_condition is None:
-            if batch.num_valid_records == 0:
+            if self._has_no_valid_records(batch):
                 self.status = GenerationStatus.STOP_NO_RECORDS
         else:
-            if batch.num_valid_records == 0 and self.num_batches == 0 and batch.num_length_truncated_completions == 0:
+            if self.num_batches == 0 and self._should_stop_after_first_zero_valid_batch(batch):
                 self.status = GenerationStatus.STOP_NO_RECORDS
             elif self.stop_condition.has_been_reached(self.running_stopping_metric.mean):
                 self.status = GenerationStatus.STOP_METRIC_REACHED
@@ -392,8 +413,9 @@ class GenerationBatches:
           batch of ``INITIAL_PROBE_PROMPTS`` so the records-per-prompt
           ratio can be measured before committing to a full batch.
         * Prompts sent but no valid records yet -- escalate to the full
-          ``max_num_prompts_per_batch`` budget unless completions were
-          length-truncated, in which case keep probing conservatively.
+          ``max_num_prompts_per_batch`` budget unless the latest batch
+          was fully length-truncated, in which case keep probing
+          conservatively instead of expanding GPU work.
         * Have valid records -- size the next batch from the observed
           records-per-prompt ratio, plus ``NUM_PROMPT_BUFFER`` to absorb
           invalid completions.
@@ -416,11 +438,7 @@ class GenerationBatches:
         if is_first_batch:
             return min(num_prompts, INITIAL_PROBE_PROMPTS, num_records_remaining + NUM_PROMPT_BUFFER)
 
-        if (
-            last_batch is not None
-            and last_batch.num_valid_records == 0
-            and last_batch.num_length_truncated_completions > 0
-        ):
+        if last_batch is not None and self._is_inconclusive_zero_valid_batch(last_batch):
             return min(num_prompts, INITIAL_PROBE_PROMPTS, num_records_remaining + NUM_PROMPT_BUFFER)
 
         return min(num_prompts, num_records_remaining + NUM_PROMPT_BUFFER)

--- a/src/nemo_safe_synthesizer/generation/results.py
+++ b/src/nemo_safe_synthesizer/generation/results.py
@@ -346,13 +346,19 @@ class GenerationBatches:
         """Wall-clock seconds spent tokenizing records across all batches."""
         return sum(batch.total_tokenization_time_sec for batch in self._batches)
 
+    @property
+    def num_length_truncated_completions(self) -> int:
+        """Total completions that stopped because they reached ``max_tokens``."""
+        return sum(batch.num_length_truncated_completions for batch in self._batches)
+
     def add_batch(self, batch: Batch) -> None:
         """Add a batch and update the generation status.
 
         Stopping rules:
 
-        * The very first batch producing zero valid records always
-          triggers ``STOP_NO_RECORDS``.
+        * The very first batch producing zero valid records triggers
+          ``STOP_NO_RECORDS`` unless it was length-truncated and a
+          patience-based ``stop_condition`` is configured.
         * When a ``stop_condition`` is configured, subsequent batches
           with zero valid records are tolerated until the patience-based
           threshold is reached.
@@ -369,7 +375,7 @@ class GenerationBatches:
             if batch.num_valid_records == 0:
                 self.status = GenerationStatus.STOP_NO_RECORDS
         else:
-            if batch.num_valid_records == 0 and self.num_batches == 0:
+            if batch.num_valid_records == 0 and self.num_batches == 0 and batch.num_length_truncated_completions == 0:
                 self.status = GenerationStatus.STOP_NO_RECORDS
             elif self.stop_condition.has_been_reached(self.running_stopping_metric.mean):
                 self.status = GenerationStatus.STOP_METRIC_REACHED
@@ -386,8 +392,8 @@ class GenerationBatches:
           batch of ``INITIAL_PROBE_PROMPTS`` so the records-per-prompt
           ratio can be measured before committing to a full batch.
         * Prompts sent but no valid records yet -- escalate to the full
-          ``max_num_prompts_per_batch`` budget so the patience-based
-          stopping path can decide whether to abort.
+          ``max_num_prompts_per_batch`` budget unless completions were
+          length-truncated, in which case keep probing conservatively.
         * Have valid records -- size the next batch from the observed
           records-per-prompt ratio, plus ``NUM_PROMPT_BUFFER`` to absorb
           invalid completions.
@@ -400,6 +406,7 @@ class GenerationBatches:
         num_records_remaining = self.target_num_records - self.num_valid_records
         records_per_prompt_known = self.num_valid_records > 0 and self.num_prompts > 0
         is_first_batch = self.num_prompts == 0
+        last_batch = self._batches[-1] if self._batches else None
 
         if records_per_prompt_known:
             valid_records_per_prompt = self.num_valid_records / self.num_prompts
@@ -407,6 +414,13 @@ class GenerationBatches:
             return min(num_prompts, num_prompts_needed + NUM_PROMPT_BUFFER)
 
         if is_first_batch:
+            return min(num_prompts, INITIAL_PROBE_PROMPTS, num_records_remaining + NUM_PROMPT_BUFFER)
+
+        if (
+            last_batch is not None
+            and last_batch.num_valid_records == 0
+            and last_batch.num_length_truncated_completions > 0
+        ):
             return min(num_prompts, INITIAL_PROBE_PROMPTS, num_records_remaining + NUM_PROMPT_BUFFER)
 
         return min(num_prompts, num_records_remaining + NUM_PROMPT_BUFFER)

--- a/src/nemo_safe_synthesizer/generation/timeseries_backend.py
+++ b/src/nemo_safe_synthesizer/generation/timeseries_backend.py
@@ -794,6 +794,7 @@ class TimeseriesBackend(VllmBackend):
                 group_state = active_states[prompt_idx]
                 batch = group_batches[group_state.group_id]
                 for completion_idx, completion in enumerate(output.outputs):
+                    batch.finish_reasons[str(completion.finish_reason or "unknown")] += 1
                     batch.process(completion_idx, completion.text, completion_tokens=len(completion.token_ids))
 
             duration = time.perf_counter() - start_time

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -471,6 +471,7 @@ class VllmBackend(GeneratorBackend):
 
         for idx, output in enumerate(outputs):
             out = output.outputs[0]
+            batch.finish_reasons[str(out.finish_reason or "unknown")] += 1
             if logger.isEnabledFor(logging.DEBUG):
                 logger.debug(
                     f"prompt {idx}: {len(out.token_ids)} tokens, "

--- a/src/nemo_safe_synthesizer/observability.py
+++ b/src/nemo_safe_synthesizer/observability.py
@@ -38,7 +38,7 @@ import sys
 import threading
 import time
 import warnings
-from collections.abc import Callable, Generator, MutableMapping
+from collections.abc import Callable, Generator, Mapping, MutableMapping
 from datetime import datetime
 from enum import Enum
 from functools import wraps
@@ -196,6 +196,16 @@ def _move_category_for_column(logger: logging.Logger, method_name: str, event_di
     return event_dict
 
 
+def _format_table_value(key: str, value: object) -> str:
+    """Format values for user-facing Rich tables."""
+    if isinstance(value, float):
+        is_fraction = 0 < value < 1 and key not in ("loss", "eval_loss") and not key.endswith(("_sec", "_seconds"))
+        return f"{value:.2%}" if is_fraction else f"{value:.2f}"
+    if isinstance(value, Mapping):
+        return ", ".join(f"{mapping_key}: {value[mapping_key]}" for mapping_key in sorted(value))
+    return str(value)
+
+
 def _render_rich_table(data: dict, title: str | None = None) -> str:
     """Render a dictionary as a Rich ASCII table string."""
     table = Table(title=title, box=box.ASCII)
@@ -219,13 +229,7 @@ def _render_rich_table(data: dict, title: str | None = None) -> str:
         table.add_column("Value")
         for key, value in data.items():
             display_key = key.replace("_", " ").title()
-            if isinstance(value, float):
-                is_fraction = (
-                    0 < value < 1 and key not in ("loss", "eval_loss") and not key.endswith(("_sec", "_seconds"))
-                )
-                display_value = f"{value:.2%}" if is_fraction else f"{value:.2f}"
-            else:
-                display_value = str(value)
+            display_value = _format_table_value(key, value)
             table.add_row(display_key, display_value)
 
     return _convert_rich_table_to_string(table)

--- a/tests/generation/test_generation.py
+++ b/tests/generation/test_generation.py
@@ -98,6 +98,20 @@ def test_generation_add_batch_stop_no_records_status_first_batch(fixture_stub_ba
     assert generation_with_stop_params.status == GenerationStatus.STOP_NO_RECORDS
 
 
+def test_generation_add_batch_length_truncated_first_batch_uses_patience(fixture_stub_batches):
+    _, bad_batches = fixture_stub_batches
+    bad_batches[0].finish_reasons["length"] = bad_batches[0].num_prompts
+
+    generation_with_stop_params = GenerationBatches(
+        target_num_records=5,
+        invalid_fraction_threshold=0.9,
+        patience=3,
+    )
+    generation_with_stop_params.add_batch(bad_batches[0])
+
+    assert generation_with_stop_params.status == GenerationStatus.IN_PROGRESS
+
+
 # Purpose: Sequence good → bad → good under stricter policy triggers STOP_METRIC_REACHED mid-flight.
 # Data: Threshold 0.2, patience 3.
 # Asserts: status STOP_METRIC_REACHED after third add.

--- a/tests/generation/test_generation.py
+++ b/tests/generation/test_generation.py
@@ -112,6 +112,24 @@ def test_generation_add_batch_length_truncated_first_batch_uses_patience(fixture
     assert generation_with_stop_params.status == GenerationStatus.IN_PROGRESS
 
 
+def test_generation_add_batch_partially_length_truncated_first_batch_stops(
+    fixture_mock_processor_without_valid_records,
+):
+    batch = Batch(fixture_mock_processor_without_valid_records)
+    for prompt_idx in range(INITIAL_PROBE_PROMPTS):
+        batch.process(prompt_idx, "stub")
+    batch.finish_reasons.update({"length": 1, "stop": INITIAL_PROBE_PROMPTS - 1})
+
+    generation_with_stop_params = GenerationBatches(
+        target_num_records=5,
+        invalid_fraction_threshold=0.9,
+        patience=3,
+    )
+    generation_with_stop_params.add_batch(batch)
+
+    assert generation_with_stop_params.status == GenerationStatus.STOP_NO_RECORDS
+
+
 # Purpose: Sequence good → bad → good under stricter policy triggers STOP_METRIC_REACHED mid-flight.
 # Data: Threshold 0.2, patience 3.
 # Asserts: status STOP_METRIC_REACHED after third add.

--- a/tests/generation/test_results.py
+++ b/tests/generation/test_results.py
@@ -32,6 +32,7 @@ def _make_batch(
     num_prompts: int,
     num_valid: int = 0,
     num_invalid: int = 0,
+    finish_reasons: dict[str, int] | None = None,
 ) -> Batch:
     """Return a ``Batch`` whose aggregate counts match the requested totals.
 
@@ -52,6 +53,8 @@ def _make_batch(
                 for i in range(num_invalid)
             )
         batch._responses.append(ParsedResponse(records=records, prompt_number=prompt_index))
+    if finish_reasons is not None:
+        batch.finish_reasons.update(finish_reasons)
     return batch
 
 
@@ -95,6 +98,63 @@ class TestEscalateAfterFailedProbe:
         next_count = batches.get_next_num_prompts()
 
         # Escalation: full ``max_num_prompts_per_batch`` clipped only by remaining records.
+        records_remaining = 10_000 - batches.num_valid_records
+        assert next_count == min(batches.max_num_prompts_per_batch, records_remaining + NUM_PROMPT_BUFFER)
+        assert next_count > INITIAL_PROBE_PROMPTS
+
+    def test_results_keeps_probe_size_after_length_truncated_zero_valid_probe(self, fixture_processor):
+        """A zero-valid probe that hit ``max_tokens`` should not be treated as under-sized sampling."""
+        batches = GenerationBatches(
+            target_num_records=10_000,
+            invalid_fraction_threshold=1.0,
+            patience=10,
+        )
+        first_batch = _make_batch(
+            fixture_processor,
+            num_prompts=INITIAL_PROBE_PROMPTS,
+            num_valid=0,
+            num_invalid=5,
+            finish_reasons={"length": INITIAL_PROBE_PROMPTS},
+        )
+        batches.add_batch(first_batch)
+
+        next_count = batches.get_next_num_prompts()
+
+        records_remaining = 10_000 - batches.num_valid_records
+        assert next_count == min(
+            batches.max_num_prompts_per_batch,
+            INITIAL_PROBE_PROMPTS,
+            records_remaining + NUM_PROMPT_BUFFER,
+        )
+
+    def test_results_only_uses_latest_batch_finish_reason_for_zero_valid_probe(self, fixture_processor):
+        """An earlier length truncation should not suppress escalation after a later non-truncated batch."""
+        batches = GenerationBatches(
+            target_num_records=10_000,
+            invalid_fraction_threshold=1.0,
+            patience=10,
+        )
+        batches.add_batch(
+            _make_batch(
+                fixture_processor,
+                num_prompts=INITIAL_PROBE_PROMPTS,
+                num_valid=0,
+                num_invalid=5,
+                finish_reasons={"length": INITIAL_PROBE_PROMPTS},
+            )
+        )
+        batches.add_batch(
+            _make_batch(
+                fixture_processor,
+                num_prompts=INITIAL_PROBE_PROMPTS,
+                num_valid=0,
+                num_invalid=5,
+                finish_reasons={"stop": INITIAL_PROBE_PROMPTS},
+            )
+        )
+
+        next_count = batches.get_next_num_prompts()
+
         records_remaining = 10_000 - batches.num_valid_records
         assert next_count == min(batches.max_num_prompts_per_batch, records_remaining + NUM_PROMPT_BUFFER)
         assert next_count > INITIAL_PROBE_PROMPTS

--- a/tests/generation/test_results.py
+++ b/tests/generation/test_results.py
@@ -103,7 +103,7 @@ class TestEscalateAfterFailedProbe:
         assert next_count > INITIAL_PROBE_PROMPTS
 
     def test_results_keeps_probe_size_after_length_truncated_zero_valid_probe(self, fixture_processor):
-        """A zero-valid probe that hit ``max_tokens`` should not be treated as under-sized sampling."""
+        """An all-length-truncated zero-valid probe retries at probe size."""
         batches = GenerationBatches(
             target_num_records=10_000,
             invalid_fraction_threshold=1.0,
@@ -126,6 +126,28 @@ class TestEscalateAfterFailedProbe:
             INITIAL_PROBE_PROMPTS,
             records_remaining + NUM_PROMPT_BUFFER,
         )
+
+    def test_results_escalates_after_partially_length_truncated_zero_valid_probe(self, fixture_processor):
+        """A mixed-finish zero-valid probe should not be treated as fully inconclusive."""
+        batches = GenerationBatches(
+            target_num_records=10_000,
+            invalid_fraction_threshold=1.0,
+            patience=10,
+        )
+        first_batch = _make_batch(
+            fixture_processor,
+            num_prompts=INITIAL_PROBE_PROMPTS,
+            num_valid=0,
+            num_invalid=5,
+            finish_reasons={"length": 1, "stop": INITIAL_PROBE_PROMPTS - 1},
+        )
+        batches.add_batch(first_batch)
+
+        next_count = batches.get_next_num_prompts()
+
+        records_remaining = 10_000 - batches.num_valid_records
+        assert next_count == min(batches.max_num_prompts_per_batch, records_remaining + NUM_PROMPT_BUFFER)
+        assert next_count > INITIAL_PROBE_PROMPTS
 
     def test_results_only_uses_latest_batch_finish_reason_for_zero_valid_probe(self, fixture_processor):
         """An earlier length truncation should not suppress escalation after a later non-truncated batch."""

--- a/tests/generation/test_timeseries_backend.py
+++ b/tests/generation/test_timeseries_backend.py
@@ -3,11 +3,14 @@
 
 """Unit tests for the TimeseriesBackend class private methods."""
 
+import json
+import re
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
 from transformers import PretrainedConfig
+from vllm.exceptions import VLLMValidationError
 from vllm.sampling_params import SamplingParams
 
 from nemo_safe_synthesizer.cli.artifact_structure import Workdir
@@ -466,6 +469,18 @@ class TestBuildModifiedSamplingParamsStopPropagation:
 class TestGenerationMaxTokensPlumbing:
     """``SamplingParams.max_tokens`` is sourced from ``metadata.generation_max_tokens_for``."""
 
+    class _WhitespaceTokenizer:
+        """Tiny tokenizer stand-in that makes long text payloads countable."""
+
+        @staticmethod
+        def encode(text: str) -> list[str]:
+            return re.compile(r"\s+").split(text)
+
+    @staticmethod
+    def _jsonl_prefill_from_dataframe(df: pd.DataFrame, rows: int = 3) -> str:
+        """Serialize seed rows like a time-series initial prefill."""
+        return " " + "\n".join(json.dumps(record) for record in df.head(rows).to_dict("records"))
+
     @staticmethod
     def _capture_sampling_params(
         backend,
@@ -537,3 +552,26 @@ class TestGenerationMaxTokensPlumbing:
         assert sp.max_tokens is not None
         assert sp.max_tokens == timeseries_model_metadata.max_seq_length - 1500
         assert sp.max_tokens < int(1500 * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)
+
+    def test_dataset_shaped_prefill_can_consume_entire_context(
+        self, fixture_pems_sf_sample_dataset, timeseries_elapsed_params, timeseries_model_metadata, mock_workdir
+    ):
+        """The wide PEMS-SF fixture can make three seed rows consume the full context."""
+        pems_df = fixture_pems_sf_sample_dataset.to_pandas()
+        timeseries_elapsed_params.data.group_training_examples_by = "e_id"
+        timeseries_elapsed_params.data.order_training_examples_by = "s_index"
+        timeseries_elapsed_params.time_series.timestamp_column = "s_index"
+        timeseries_elapsed_params.time_series.stop_timestamp = "4"
+        timeseries_model_metadata.max_tokens_per_example = None
+        timeseries_model_metadata.initial_prefill = {"0": self._jsonl_prefill_from_dataframe(pems_df)}
+        schema = {"properties": {column: {"type": "number"} for column in pems_df.columns}}
+        backend = create_timeseries_backend(timeseries_elapsed_params, timeseries_model_metadata, mock_workdir, schema)
+        backend.llm = MagicMock()
+        backend.llm.get_tokenizer.return_value = self._WhitespaceTokenizer()
+
+        prompt_len = backend._get_prompt_token_count()
+
+        assert prompt_len >= timeseries_model_metadata.max_seq_length
+        assert timeseries_model_metadata.generation_max_tokens_for(prompt_len) == 0
+        with pytest.raises(VLLMValidationError, match="max_tokens must be at least 1"):
+            backend.generate()

--- a/tests/generation/test_timeseries_backend.py
+++ b/tests/generation/test_timeseries_backend.py
@@ -26,8 +26,8 @@ from nemo_safe_synthesizer.defaults import DEFAULT_MAX_SEQ_LENGTH, PSEUDO_GROUP_
 from nemo_safe_synthesizer.generation.processors import TimeSeriesDataProcessor
 from nemo_safe_synthesizer.generation.results import GenerationBatches
 from nemo_safe_synthesizer.generation.timeseries_backend import (
-    GroupState,
     GroupProcessingResult,
+    GroupState,
     TimeseriesBackend,
 )
 from nemo_safe_synthesizer.llm.metadata import (
@@ -472,9 +472,7 @@ class TestBuildModifiedSamplingParamsStopPropagation:
 class TestGenerateParallelGroups:
     """Tests for processing vLLM completions during parallel time-series generation."""
 
-    def test_records_completion_finish_reasons(
-        self, timeseries_base_params, timeseries_model_metadata, mock_workdir
-    ):
+    def test_records_completion_finish_reasons(self, timeseries_base_params, timeseries_model_metadata, mock_workdir):
         """The generated batch should preserve vLLM finish reasons for stopping logic."""
         backend = create_timeseries_backend(timeseries_base_params, timeseries_model_metadata, mock_workdir)
         backend.llm = MagicMock()

--- a/tests/generation/test_timeseries_backend.py
+++ b/tests/generation/test_timeseries_backend.py
@@ -5,6 +5,7 @@
 
 import json
 import re
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -23,8 +24,10 @@ from nemo_safe_synthesizer.config import (
 )
 from nemo_safe_synthesizer.defaults import DEFAULT_MAX_SEQ_LENGTH, PSEUDO_GROUP_COLUMN
 from nemo_safe_synthesizer.generation.processors import TimeSeriesDataProcessor
+from nemo_safe_synthesizer.generation.results import GenerationBatches
 from nemo_safe_synthesizer.generation.timeseries_backend import (
     GroupState,
+    GroupProcessingResult,
     TimeseriesBackend,
 )
 from nemo_safe_synthesizer.llm.metadata import (
@@ -464,6 +467,49 @@ class TestBuildModifiedSamplingParamsStopPropagation:
         assert modified.ignore_eos is False
         assert modified.stop == []
         assert modified.stop_token_ids == []
+
+
+class TestGenerateParallelGroups:
+    """Tests for processing vLLM completions during parallel time-series generation."""
+
+    def test_records_completion_finish_reasons(
+        self, timeseries_base_params, timeseries_model_metadata, mock_workdir
+    ):
+        """The generated batch should preserve vLLM finish reasons for stopping logic."""
+        backend = create_timeseries_backend(timeseries_base_params, timeseries_model_metadata, mock_workdir)
+        backend.llm = MagicMock()
+        backend.llm.generate.return_value = [
+            SimpleNamespace(
+                outputs=[
+                    SimpleNamespace(
+                        finish_reason="length",
+                        text='{"timestamp": "2024-01-01 01:00:00", "value": 3}\n',
+                        token_ids=[1, 2, 3],
+                    )
+                ]
+            )
+        ]
+        backend._groups = ["group_A"]
+
+        captured = {}
+
+        def _capture_result(state, batch, invalid_fraction_threshold):  # noqa: ARG001
+            captured["batch"] = batch
+            return GroupProcessingResult.COMPLETED
+
+        backend._process_group_result = _capture_result
+
+        batches = GenerationBatches(target_num_records=100)
+        sampling_params = SamplingParams(max_tokens=10)
+
+        backend._generate_parallel_groups(
+            batches=batches,
+            sampling_params=sampling_params,
+            progress_snapshots=[],
+        )
+
+        assert captured["batch"].finish_reasons["length"] == 1
+        assert batches.num_length_truncated_completions == 1
 
 
 class TestGenerationMaxTokensPlumbing:

--- a/tests/observability/test_observability.py
+++ b/tests/observability/test_observability.py
@@ -272,6 +272,15 @@ class TestRenderRichTable:
         assert "0.72" in result
         assert "95.00%" in result
 
+    def test_renders_mapping_values_without_python_repr(self):
+        """Mapping values in flat tables are rendered as compact key-value lists."""
+        data = {"num_prompts": 10, "finish_reasons": {"length": 10, "stop": 2}}
+        result = _render_rich_table(data)
+
+        assert "Finish Reasons" in result
+        assert "length: 10, stop: 2" in result
+        assert "{'length': 10" not in result
+
     def test_renders_nested_dict(self):
         """Test rendering a nested statistics dictionary."""
         data = {


### PR DESCRIPTION
## Summary
- followup from #422.
- Preserve vLLM finish reasons in batch summaries and generation batch state.
- Keep length-truncated zero-valid probes conservative instead of treating them as model-underfitting probes.
- Add troubleshooting guidance for `finish_reason=length`.

## Test plan
- [x] `uv run pytest tests/generation/test_results.py tests/generation/test_generation.py`
- [x] `uv run pytest tests/generation/test_timeseries_backend.py::TestGenerationMaxTokensPlumbing`
