### PR TITLE
chore(ci): ungate checks for docs source changes

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -21,6 +21,21 @@ outputs:
   src:
     description: "'true' if any file under src/ changed"
     value: ${{ steps.filter.outputs.src }}
+  docs_src:
+    description: "'true' if docs source/config files changed"
+    value: ${{ steps.filter.outputs.docs_src }}
+  tests:
+    description: "'true' if any file under tests/ changed"
+    value: ${{ steps.filter.outputs.tests }}
+  pytest_ini:
+    description: "'true' if pytest.ini changed"
+    value: ${{ steps.filter.outputs.pytest_ini }}
+  pyproject:
+    description: "'true' if pyproject.toml changed"
+    value: ${{ steps.filter.outputs.pyproject }}
+  uv_lock:
+    description: "'true' if uv.lock changed"
+    value: ${{ steps.filter.outputs.uv_lock }}
   test:
     description: "'true' if any file under tests/ or pytest.ini changed"
     value: ${{ steps.filter.outputs.tests == 'true' || steps.filter.outputs.pytest_ini == 'true' }}
@@ -31,8 +46,8 @@ outputs:
     description: "'true' if any CI workflow or action files changed"
     value: ${{ steps.filter.outputs.ci }}
   any:
-    description: "'true' if any source, test, dependency, or CI file changed"
-    value: ${{ steps.filter.outputs.src == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.pytest_ini == 'true' || steps.filter.outputs.pyproject == 'true' || steps.filter.outputs.uv_lock == 'true' || steps.filter.outputs.ci == 'true' }}
+    description: "'true' if any source, docs source, test, dependency, or CI file changed"
+    value: ${{ steps.filter.outputs.src == 'true' || steps.filter.outputs.docs_src == 'true' || steps.filter.outputs.tests == 'true' || steps.filter.outputs.pytest_ini == 'true' || steps.filter.outputs.pyproject == 'true' || steps.filter.outputs.uv_lock == 'true' || steps.filter.outputs.ci == 'true' }}
 
 runs:
   using: "composite"
@@ -47,6 +62,10 @@ runs:
         filters: |
           src:
             - 'src/**'
+          docs_src:
+            - 'docs/*.py'
+            - 'docs/**/*.py'
+            - 'mkdocs.yml'
           tests:
             - 'tests/**'
           pyproject:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,14 +9,14 @@ This directory contains GitHub Actions workflows for CI/CD automation.
 
 All workflows that use `.github/actions/setup-python-env` now default to the version in `../../.python-version`. Set the action input `python-version` only when a job intentionally needs an override.
 
-| Workflow                                           | Trigger                                  | Description                                           |
-| -------------------------------------------------- | ---------------------------------------- | ----------------------------------------------------- |
-| [ci-checks.yml](ci-checks.yml)                     | Push to `main`, PRs, manual              | Format, typecheck, unit tests, and CPU smoke tests    |
-| [gpu-tests.yml](gpu-tests.yml)                     | Nightly , manual                         | GPU smoke tests (required) and E2E tests              |
-| [conventional-commit.yml](conventional-commit.yml) | PRs                                      | Validates PR titles follow conventional commit format |
-| [docs.yml](docs.yml)                               | Push to `main` (docs paths)              | Publishes `main` docs as the `latest` GitHub Pages version      |
-| [release.yml](release.yml)                         | Push tags to `v*`                        | Builds and publishes package to Test PyPI/PyPI, creates a GitHub release, and publishes versioned docs     |
-| [secrets-detector.yml](secrets-detector.yml)       | PRs                                      | Scans for accidentally committed secrets              |
+| Workflow                                           | Trigger                     | Description                                                                                                |
+| -------------------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| [ci-checks.yml](ci-checks.yml)                     | Push to `main`, PRs, manual | Format, typecheck, unit tests, and CPU smoke tests                                                         |
+| [gpu-tests.yml](gpu-tests.yml)                     | Nightly, manual             | GPU smoke tests (required) and E2E tests                                                                   |
+| [conventional-commit.yml](conventional-commit.yml) | PRs                         | Validates PR titles follow conventional commit format                                                      |
+| [docs.yml](docs.yml)                               | Push to `main` (docs paths) | Publishes `main` docs as the `latest` GitHub Pages version                                                 |
+| [release.yml](release.yml)                         | Push tags to `v*`           | Builds and publishes package to Test PyPI/PyPI, creates a GitHub release, and publishes versioned docs     |
+| [secrets-detector.yml](secrets-detector.yml)       | PRs                         | Scans for accidentally committed secrets                                                                   |
 
 ## Pull Request Testing (copy-pr-bot)
 
@@ -59,7 +59,7 @@ flowchart LR
         unit[Unit Tests]
         smoke_cpu[Smoke Tests]
         ci_status[CI Status]
-        changes_ci --> format & typecheck & unit & smoke_cpu
+        changes_ci --> unit & smoke_cpu
         format & typecheck & unit & smoke_cpu --> ci_status
     end
 
@@ -114,9 +114,9 @@ The `ci-checks.yml` workflow runs on every push to `main` and on pull requests. 
 | Unit Tests | `test-ci` | pytest with coverage (excludes slow, e2e, gpu, smoke) |
 | Smoke Tests | `test-smoke` | CPU smoke tests (training/generation hot paths, tiny models) |
 
-The `changes` detection job (using `dorny/paths-filter`) skips downstream jobs entirely when only non-source files are modified. Within each job, all tracked files are checked -- `ruff` and `ty` are fast enough for this to take seconds. The CI Status aggregation job is the single required check for branch protection.
+The `changes` detection job uses `dorny/paths-filter` to decide which test jobs run. Format and typecheck are ungated and run on every push, pull request, and manual dispatch. Unit tests run when any tracked source, docs source, test, dependency, or CI path changes. Smoke tests run only when `src/**`, `tests/**`, `pytest.ini`, `pyproject.toml`, or `uv.lock` changes.
 
-If a PR only touches workflow YAML, docs, or other non-source paths, format/typecheck/unit-test jobs are skipped. To verify new CI logic or satisfy reviewers: run `make check` and `make test` locally and note in the PR, or add a trivial Python change (e.g. docstring) to trigger the pipeline.
+Docs source paths include `docs/*.py`, `docs/**/*.py`, and `mkdocs.yml`. These paths trigger unit tests through the aggregate `any` output, but do not trigger CPU smoke tests. The CI Status aggregation job is the single required check for branch protection.
 
 To replicate CI locally:
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -114,7 +114,9 @@ The `ci-checks.yml` workflow runs on every push to `main` and on pull requests. 
 | Unit Tests | `test-ci` | pytest with coverage (excludes slow, e2e, gpu, smoke) |
 | Smoke Tests | `test-smoke` | CPU smoke tests (training/generation hot paths, tiny models) |
 
-The `changes` detection job uses `dorny/paths-filter` to decide which test jobs run. Format and typecheck are ungated and run on every push, pull request, and manual dispatch. Unit tests run when any tracked source, docs source, test, dependency, or CI path changes. Smoke tests run only when `src/**`, `tests/**`, `pytest.ini`, `pyproject.toml`, or `uv.lock` changes.
+The `changes` detection job uses `dorny/paths-filter` to decide which test jobs run on push and pull request events. Format and typecheck intentionally do not depend on `changes`; they are ungated and run on every push, pull request, and manual dispatch. Unit tests run when any tracked source, docs source, test, dependency, or CI path changes. Smoke tests run only when `src/**`, `tests/**`, `pytest.ini`, `pyproject.toml`, or `uv.lock` changes.
+
+On manual dispatch, `changes` is intentionally skipped and the test jobs explicitly bypass that skipped dependency. Manual dispatch runs unit tests and CPU smoke tests even when there is no changed-file signal to inspect.
 
 Docs source paths include `docs/*.py`, `docs/**/*.py`, and `mkdocs.yml`. These paths trigger unit tests through the aggregate `any` output, but do not trigger CPU smoke tests. The CI Status aggregation job is the single required check for branch protection.
 

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -61,6 +61,8 @@ jobs:
 
   format:
     name: Format
+    # Intentionally does not depend on `changes`: format and lock checks run on
+    # every push, pull request, and workflow_dispatch.
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -86,6 +88,8 @@ jobs:
 
   typecheck:
     name: Typecheck
+    # Intentionally does not depend on `changes`: type checks run on every push,
+    # pull request, and workflow_dispatch.
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -109,7 +113,16 @@ jobs:
   unit-test:
     name: Unit Tests
     needs: changes
-    if: ${{ needs.changes.outputs.any == 'true' || github.event_name == 'workflow_dispatch' }}
+    # `changes` is intentionally skipped on workflow_dispatch. `always()` lets
+    # manual runs bypass that skipped dependency and run the full test job.
+    if: >-
+      ${{
+        always() &&
+        (
+          github.event_name == 'workflow_dispatch' ||
+          needs.changes.outputs.any == 'true'
+        )
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -155,7 +168,20 @@ jobs:
   smoke-test:
     name: Smoke Tests
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' || needs.changes.outputs.tests == 'true' || needs.changes.outputs.pytest_ini == 'true' || needs.changes.outputs.uv_lock == 'true' || needs.changes.outputs.pyproject == 'true' || github.event_name == 'workflow_dispatch' }}
+    # `changes` is intentionally skipped on workflow_dispatch. `always()` lets
+    # manual runs bypass that skipped dependency and run the full smoke job.
+    if: >-
+      ${{
+        always() &&
+        (
+          github.event_name == 'workflow_dispatch' ||
+          needs.changes.outputs.src == 'true' ||
+          needs.changes.outputs.tests == 'true' ||
+          needs.changes.outputs.pytest_ini == 'true' ||
+          needs.changes.outputs.uv_lock == 'true' ||
+          needs.changes.outputs.pyproject == 'true'
+        )
+      }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -46,6 +46,12 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
+      src: ${{ steps.changes.outputs.src }}
+      tests: ${{ steps.changes.outputs.tests }}
+      pytest_ini: ${{ steps.changes.outputs.pytest_ini }}
+      pyproject: ${{ steps.changes.outputs.pyproject }}
+      uv_lock: ${{ steps.changes.outputs.uv_lock }}
+      docs_src: ${{ steps.changes.outputs.docs_src }}
       any: ${{ steps.changes.outputs.any }}
     steps:
       - uses: actions/checkout@v6
@@ -80,8 +86,6 @@ jobs:
 
   typecheck:
     name: Typecheck
-    needs: changes
-    if: ${{ needs.changes.outputs.any == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout
@@ -151,7 +155,7 @@ jobs:
   smoke-test:
     name: Smoke Tests
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' || needs.changes.outputs.test == 'true' || needs.changes.outputs.deps == 'true' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ needs.changes.outputs.src == 'true' || needs.changes.outputs.tests == 'true' || needs.changes.outputs.pytest_ini == 'true' || needs.changes.outputs.uv_lock == 'true' || needs.changes.outputs.pyproject == 'true' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - name: checkout


### PR DESCRIPTION
## Summary
- Run format and typecheck on every CI invocation instead of path-gating them behind detect-changes.
- Add docs source detection for `docs/*.py`, `docs/**/*.py`, and `mkdocs.yml` so docs build support code triggers unit tests.
- Gate CPU smoke tests only on runtime/test/dependency inputs: `src/**`, `tests/**`, `pytest.ini`, `pyproject.toml`, and `uv.lock`.

## Test plan
- Read IDE diagnostics for changed workflow and README files.
- Did not run actionlint locally because it is not installed in this environment.


Made with [Cursor](https://cursor.com)