### PR TITLE
fix: update fixture dataset for gpu smoke tests

### DIFF
--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -44,7 +44,8 @@ If the new file uses vLLM, also add it to the explicit file list in the `test-sm
 ## Things that will bite you
 
 - LoRA rank must be 8 (not 4). vLLM silently rejects rank 4. Use `lora_r=8`.
-- Iris only has 151 rows, but holdout needs >=200. Set `holdout=0, max_holdout=0` to skip it.
+- Preflight requires at least 200 training rows. GPU tests that train should use
+  `fixture_preflight_iris_df` or `fixture_preflight_timeseries_df`.
 - Attention implementation: HuggingFaceBackend defaults to `flashinfer`, which HF doesn't recognize. The `_patch_attn_eager` fixture overrides it to `"sdpa"`.
 - Stub tokenizer vocab is 32000. If you change the tiny model config, keep `vocab_size=32000` or you'll get shape mismatches.
 - CPU tests need `optim="adamw_torch"`. The production default (`paged_adamw_32bit`) requires bitsandbytes CUDA kernels.
@@ -58,7 +59,9 @@ Session-scoped (immutable / read-only):
 - `fixture_base_smoke_config` -- default `SafeSynthesizerParameters` pointing at the local tiny model (Pydantic frozen model)
 - `_patch_attn_eager` -- the attention implementation workaround mentioned above
 - `fixture_stub_tokenizer`, `fixture_tiny_llama_config`, `fixture_local_tinyllama_dir` -- tokenizer and tiny model on disk
-- `fixture_iris_df`, `fixture_timeseries_df` -- small DataFrames for training input
+- `fixture_iris_df`, `fixture_timeseries_df` -- small DataFrames for CPU smoke paths
+- `fixture_preflight_iris_df`, `fixture_preflight_timeseries_df` -- larger DataFrames for GPU paths
+  that run preflight
 
 Function-scoped (fresh per test):
 

--- a/tests/smoke/README.md
+++ b/tests/smoke/README.md
@@ -45,7 +45,7 @@ If the new file uses vLLM, also add it to the explicit file list in the `test-sm
 
 - LoRA rank must be 8 (not 4). vLLM silently rejects rank 4. Use `lora_r=8`.
 - Preflight requires at least 200 training rows. GPU tests that train should use
-  `fixture_preflight_iris_df` or `fixture_preflight_timeseries_df`.
+  `fixture_gpu_smoke_df` or `fixture_preflight_timeseries_df`.
 - Attention implementation: HuggingFaceBackend defaults to `flashinfer`, which HF doesn't recognize. The `_patch_attn_eager` fixture overrides it to `"sdpa"`.
 - Stub tokenizer vocab is 32000. If you change the tiny model config, keep `vocab_size=32000` or you'll get shape mismatches.
 - CPU tests need `optim="adamw_torch"`. The production default (`paged_adamw_32bit`) requires bitsandbytes CUDA kernels.
@@ -60,7 +60,7 @@ Session-scoped (immutable / read-only):
 - `_patch_attn_eager` -- the attention implementation workaround mentioned above
 - `fixture_stub_tokenizer`, `fixture_tiny_llama_config`, `fixture_local_tinyllama_dir` -- tokenizer and tiny model on disk
 - `fixture_iris_df`, `fixture_timeseries_df` -- small DataFrames for CPU smoke paths
-- `fixture_preflight_iris_df`, `fixture_preflight_timeseries_df` -- larger DataFrames for GPU paths
+- `fixture_gpu_smoke_df`, `fixture_preflight_timeseries_df` -- larger DataFrames for GPU paths
   that run preflight
 
 Function-scoped (fresh per test):

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from math import ceil
 from pathlib import Path
 
 import pandas as pd
@@ -99,10 +98,9 @@ def fixture_iris_df(stub_datasets_dir) -> pd.DataFrame:
 
 
 @pytest.fixture(scope="session")
-def fixture_preflight_iris_df(fixture_iris_df) -> pd.DataFrame:
-    """Iris rows repeated enough to satisfy preflight's training-size floor."""
-    repeat_count = ceil(200 / len(fixture_iris_df))
-    return pd.concat([fixture_iris_df] * repeat_count, ignore_index=True)
+def fixture_gpu_smoke_df(stub_datasets_dir) -> pd.DataFrame:
+    """Small tabular dataset sized for GPU smoke tests that run preflight."""
+    return pd.read_csv(stub_datasets_dir / "clinc_oos.csv", nrows=210)
 
 
 @pytest.fixture(scope="session")

--- a/tests/smoke/conftest.py
+++ b/tests/smoke/conftest.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator
+from math import ceil
 from pathlib import Path
 
 import pandas as pd
@@ -98,6 +99,13 @@ def fixture_iris_df(stub_datasets_dir) -> pd.DataFrame:
 
 
 @pytest.fixture(scope="session")
+def fixture_preflight_iris_df(fixture_iris_df) -> pd.DataFrame:
+    """Iris rows repeated enough to satisfy preflight's training-size floor."""
+    repeat_count = ceil(200 / len(fixture_iris_df))
+    return pd.concat([fixture_iris_df] * repeat_count, ignore_index=True)
+
+
+@pytest.fixture(scope="session")
 def fixture_timeseries_df() -> pd.DataFrame:
     """Minimal timeseries stub: 2 groups, 5 rows each, 60s intervals."""
     return pd.DataFrame(
@@ -118,6 +126,23 @@ def fixture_timeseries_df() -> pd.DataFrame:
             "value": [10, 20, 30, 40, 50, 100, 110, 120, 130, 140],
         }
     )
+
+
+@pytest.fixture(scope="session")
+def fixture_preflight_timeseries_df() -> pd.DataFrame:
+    """Timeseries stub with 200 rows for GPU paths that run preflight."""
+    start = pd.Timestamp("2024-01-01 00:00:00")
+    rows = []
+    for group, offset in (("A", 0), ("B", 1000)):
+        for i in range(100):
+            rows.append(
+                {
+                    "group_id": group,
+                    "timestamp": start + pd.Timedelta(seconds=60 * i),
+                    "value": offset + i,
+                }
+            )
+    return pd.DataFrame(rows)
 
 
 @pytest.fixture(scope="session")

--- a/tests/smoke/test_full_pipeline_gpu.py
+++ b/tests/smoke/test_full_pipeline_gpu.py
@@ -25,7 +25,7 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_full_pipeline_smollm2(fixture_preflight_iris_df, fixture_smoke_save_path):
+def test_full_pipeline_smollm2(fixture_gpu_smoke_df, fixture_smoke_save_path):
     """Train SmolLM2-135M then generate with vLLM in a single end-to-end pass.
 
     SmolLM2-135M with only 50 sampled rows packs into ~1 training example,
@@ -42,7 +42,7 @@ def test_full_pipeline_smollm2(fixture_preflight_iris_df, fixture_smoke_save_pat
         max_holdout=0,
     )
     nss = SafeSynthesizer(config=config, save_path=fixture_smoke_save_path)
-    nss.with_data_source(fixture_preflight_iris_df).process_data().train()
+    nss.with_data_source(fixture_gpu_smoke_df).process_data().train()
 
     try:
         nss.generate()

--- a/tests/smoke/test_full_pipeline_gpu.py
+++ b/tests/smoke/test_full_pipeline_gpu.py
@@ -25,7 +25,7 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_full_pipeline_smollm2(fixture_iris_df, fixture_smoke_save_path):
+def test_full_pipeline_smollm2(fixture_preflight_iris_df, fixture_smoke_save_path):
     """Train SmolLM2-135M then generate with vLLM in a single end-to-end pass.
 
     SmolLM2-135M with only 50 sampled rows packs into ~1 training example,
@@ -42,7 +42,7 @@ def test_full_pipeline_smollm2(fixture_iris_df, fixture_smoke_save_path):
         max_holdout=0,
     )
     nss = SafeSynthesizer(config=config, save_path=fixture_smoke_save_path)
-    nss.with_data_source(fixture_iris_df).process_data().train()
+    nss.with_data_source(fixture_preflight_iris_df).process_data().train()
 
     try:
         nss.generate()

--- a/tests/smoke/test_nss_adapter_persistence_gpu.py
+++ b/tests/smoke/test_nss_adapter_persistence_gpu.py
@@ -22,11 +22,15 @@ pytestmark = [
 
 @pytest.fixture(scope="class")
 def fixture_adapter_train_artifacts(
-    _patch_attn_eager, fixture_base_smoke_config, fixture_iris_df, tmp_path_factory, fixture_local_tinyllama_dir
+    _patch_attn_eager,
+    fixture_base_smoke_config,
+    fixture_preflight_iris_df,
+    tmp_path_factory,
+    fixture_local_tinyllama_dir,
 ):
     """Train once per class, return (workdir, local_model_dir) for all adapter tests."""
     save_path = tmp_path_factory.mktemp("adapter-smoke")
-    nss = train_with_sdk(fixture_base_smoke_config, fixture_iris_df, save_path)
+    nss = train_with_sdk(fixture_base_smoke_config, fixture_preflight_iris_df, save_path)
     return nss._workdir, fixture_local_tinyllama_dir
 
 

--- a/tests/smoke/test_nss_adapter_persistence_gpu.py
+++ b/tests/smoke/test_nss_adapter_persistence_gpu.py
@@ -24,13 +24,13 @@ pytestmark = [
 def fixture_adapter_train_artifacts(
     _patch_attn_eager,
     fixture_base_smoke_config,
-    fixture_preflight_iris_df,
+    fixture_gpu_smoke_df,
     tmp_path_factory,
     fixture_local_tinyllama_dir,
 ):
     """Train once per class, return (workdir, local_model_dir) for all adapter tests."""
     save_path = tmp_path_factory.mktemp("adapter-smoke")
-    nss = train_with_sdk(fixture_base_smoke_config, fixture_preflight_iris_df, save_path)
+    nss = train_with_sdk(fixture_base_smoke_config, fixture_gpu_smoke_df, save_path)
     return nss._workdir, fixture_local_tinyllama_dir
 
 

--- a/tests/smoke/test_nss_generation_gpu.py
+++ b/tests/smoke/test_nss_generation_gpu.py
@@ -20,11 +20,11 @@ pytestmark = [
 
 
 @pytest.fixture(scope="class")
-def fixture_trained_nss(_patch_attn_eager, fixture_base_smoke_config, fixture_iris_df, tmp_path_factory):
+def fixture_trained_nss(_patch_attn_eager, fixture_base_smoke_config, fixture_preflight_iris_df, tmp_path_factory):
     """Train once per class; both SDK chain and manual VllmBackend tests consume this."""
     save_path = tmp_path_factory.mktemp("gen-smoke")
     nss = SafeSynthesizer(config=fixture_base_smoke_config, save_path=save_path)
-    nss.with_data_source(fixture_iris_df).process_data().train()
+    nss.with_data_source(fixture_preflight_iris_df).process_data().train()
     return nss
 
 

--- a/tests/smoke/test_nss_generation_gpu.py
+++ b/tests/smoke/test_nss_generation_gpu.py
@@ -20,11 +20,11 @@ pytestmark = [
 
 
 @pytest.fixture(scope="class")
-def fixture_trained_nss(_patch_attn_eager, fixture_base_smoke_config, fixture_preflight_iris_df, tmp_path_factory):
+def fixture_trained_nss(_patch_attn_eager, fixture_base_smoke_config, fixture_gpu_smoke_df, tmp_path_factory):
     """Train once per class; both SDK chain and manual VllmBackend tests consume this."""
     save_path = tmp_path_factory.mktemp("gen-smoke")
     nss = SafeSynthesizer(config=fixture_base_smoke_config, save_path=save_path)
-    nss.with_data_source(fixture_preflight_iris_df).process_data().train()
+    nss.with_data_source(fixture_gpu_smoke_df).process_data().train()
     return nss
 
 

--- a/tests/smoke/test_nss_resume_gpu.py
+++ b/tests/smoke/test_nss_resume_gpu.py
@@ -23,10 +23,10 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_resume_generate_after_train(fixture_local_tinyllama_dir, fixture_preflight_iris_df, tmp_path):
+def test_nss_resume_generate_after_train(fixture_local_tinyllama_dir, fixture_gpu_smoke_df, tmp_path):
     """Train, then create a new SafeSynthesizer instance and generate from saved state.
 
-    Uses preflight-sized iris rows with holdout=0.05 so load_from_save_path()
+    Uses a preflight-sized tabular fixture with holdout=0.05 so load_from_save_path()
     has a non-empty test.csv to read. The base holdout=0 config produces an empty
     test split which causes EmptyDataError on resume.
     """
@@ -41,7 +41,7 @@ def test_nss_resume_generate_after_train(fixture_local_tinyllama_dir, fixture_pr
     )
 
     # Step 1: Train
-    nss1 = train_with_sdk(config, fixture_preflight_iris_df, tmp_path)
+    nss1 = train_with_sdk(config, fixture_gpu_smoke_df, tmp_path)
     workdir = nss1._workdir
 
     # Step 2: New instance (simulates a new process / CLI invocation)

--- a/tests/smoke/test_nss_resume_gpu.py
+++ b/tests/smoke/test_nss_resume_gpu.py
@@ -5,7 +5,6 @@
 
 import sys
 
-import pandas as pd
 import pytest
 import torch
 
@@ -24,16 +23,13 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_resume_generate_after_train(fixture_local_tinyllama_dir, fixture_iris_df, tmp_path):
+def test_nss_resume_generate_after_train(fixture_local_tinyllama_dir, fixture_preflight_iris_df, tmp_path):
     """Train, then create a new SafeSynthesizer instance and generate from saved state.
 
-    Uses doubled fixture_iris_df (302 rows) with holdout=0.05 so load_from_save_path()
+    Uses preflight-sized iris rows with holdout=0.05 so load_from_save_path()
     has a non-empty test.csv to read. The base holdout=0 config produces an empty
     test split which causes EmptyDataError on resume.
     """
-    # Double the dataset to exceed the 200-row holdout minimum
-    large_df = pd.concat([fixture_iris_df, fixture_iris_df], ignore_index=True)
-
     config = SafeSynthesizerParameters.from_params(
         replace_pii=None,
         pretrained_model=str(fixture_local_tinyllama_dir),
@@ -45,7 +41,7 @@ def test_nss_resume_generate_after_train(fixture_local_tinyllama_dir, fixture_ir
     )
 
     # Step 1: Train
-    nss1 = train_with_sdk(config, large_df, tmp_path)
+    nss1 = train_with_sdk(config, fixture_preflight_iris_df, tmp_path)
     workdir = nss1._workdir
 
     # Step 2: New instance (simulates a new process / CLI invocation)

--- a/tests/smoke/test_nss_structured_gen_gpu.py
+++ b/tests/smoke/test_nss_structured_gen_gpu.py
@@ -21,7 +21,7 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_structured_generation(fixture_local_tinyllama_dir, fixture_preflight_iris_df, tmp_path):
+def test_nss_structured_generation(fixture_local_tinyllama_dir, fixture_gpu_smoke_df, tmp_path):
     """Train and generate with outlines structured generation backend.
 
     The tiny random model produces garbage, so GenerationError (no valid records)
@@ -40,7 +40,7 @@ def test_nss_structured_generation(fixture_local_tinyllama_dir, fixture_prefligh
         structured_generation_schema_method="json_schema",
     )
     nss = SafeSynthesizer(config=config, save_path=tmp_path)
-    nss.with_data_source(fixture_preflight_iris_df).process_data().train()
+    nss.with_data_source(fixture_gpu_smoke_df).process_data().train()
     try:
         nss.generate()
     except GenerationError as exc:

--- a/tests/smoke/test_nss_structured_gen_gpu.py
+++ b/tests/smoke/test_nss_structured_gen_gpu.py
@@ -21,7 +21,7 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_structured_generation(fixture_local_tinyllama_dir, fixture_iris_df, tmp_path):
+def test_nss_structured_generation(fixture_local_tinyllama_dir, fixture_preflight_iris_df, tmp_path):
     """Train and generate with outlines structured generation backend.
 
     The tiny random model produces garbage, so GenerationError (no valid records)
@@ -40,7 +40,7 @@ def test_nss_structured_generation(fixture_local_tinyllama_dir, fixture_iris_df,
         structured_generation_schema_method="json_schema",
     )
     nss = SafeSynthesizer(config=config, save_path=tmp_path)
-    nss.with_data_source(fixture_iris_df).process_data().train()
+    nss.with_data_source(fixture_preflight_iris_df).process_data().train()
     try:
         nss.generate()
     except GenerationError as exc:

--- a/tests/smoke/test_nss_timeseries_gpu.py
+++ b/tests/smoke/test_nss_timeseries_gpu.py
@@ -21,7 +21,7 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_timeseries_train_and_generate(fixture_local_tinyllama_dir, fixture_timeseries_df, tmp_path):
+def test_nss_timeseries_train_and_generate(fixture_local_tinyllama_dir, fixture_preflight_timeseries_df, tmp_path):
     """Train and generate through the TimeseriesBackend with inline stub data."""
     config = SafeSynthesizerParameters.from_params(
         replace_pii=None,
@@ -38,7 +38,7 @@ def test_nss_timeseries_train_and_generate(fixture_local_tinyllama_dir, fixture_
         order_training_examples_by="timestamp",
     )
     nss = SafeSynthesizer(config=config, save_path=tmp_path)
-    nss.with_data_source(fixture_timeseries_df).process_data().train()
+    nss.with_data_source(fixture_preflight_timeseries_df).process_data().train()
     try:
         nss.generate()
     except GenerationError as exc:

--- a/tests/smoke/test_nss_training_gpu.py
+++ b/tests/smoke/test_nss_training_gpu.py
@@ -20,15 +20,15 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_train_one_batch(fixture_base_smoke_config, fixture_preflight_iris_df, tmp_path):
+def test_nss_train_one_batch(fixture_base_smoke_config, fixture_gpu_smoke_df, tmp_path):
     """Train one batch through the SafeSynthesizer SDK with local tiny model."""
-    nss = train_with_sdk(fixture_base_smoke_config, fixture_preflight_iris_df, tmp_path)
+    nss = train_with_sdk(fixture_base_smoke_config, fixture_gpu_smoke_df, tmp_path)
     assert nss._workdir is not None
     assert_adapter_saved(nss._workdir)
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_train_dp_one_batch(fixture_local_tinyllama_dir, fixture_preflight_iris_df, tmp_path):
+def test_nss_train_dp_one_batch(fixture_local_tinyllama_dir, fixture_gpu_smoke_df, tmp_path):
     """Train one batch with DP enabled through the SafeSynthesizer SDK.
 
     Uses num_input_records_to_sample=100 (vs 10 for non-DP) to keep the epoch
@@ -45,6 +45,6 @@ def test_nss_train_dp_one_batch(fixture_local_tinyllama_dir, fixture_preflight_i
         dp_enabled=True,
         epsilon=100.0,
     )
-    nss = train_with_sdk(config, fixture_preflight_iris_df, tmp_path)
+    nss = train_with_sdk(config, fixture_gpu_smoke_df, tmp_path)
     assert nss._workdir is not None
     assert_adapter_saved(nss._workdir)

--- a/tests/smoke/test_nss_training_gpu.py
+++ b/tests/smoke/test_nss_training_gpu.py
@@ -20,15 +20,15 @@ pytestmark = [
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_train_one_batch(fixture_base_smoke_config, fixture_iris_df, tmp_path):
+def test_nss_train_one_batch(fixture_base_smoke_config, fixture_preflight_iris_df, tmp_path):
     """Train one batch through the SafeSynthesizer SDK with local tiny model."""
-    nss = train_with_sdk(fixture_base_smoke_config, fixture_iris_df, tmp_path)
+    nss = train_with_sdk(fixture_base_smoke_config, fixture_preflight_iris_df, tmp_path)
     assert nss._workdir is not None
     assert_adapter_saved(nss._workdir)
 
 
 @pytest.mark.usefixtures("_patch_attn_eager")
-def test_nss_train_dp_one_batch(fixture_local_tinyllama_dir, fixture_iris_df, tmp_path):
+def test_nss_train_dp_one_batch(fixture_local_tinyllama_dir, fixture_preflight_iris_df, tmp_path):
     """Train one batch with DP enabled through the SafeSynthesizer SDK.
 
     Uses num_input_records_to_sample=100 (vs 10 for non-DP) to keep the epoch
@@ -45,6 +45,6 @@ def test_nss_train_dp_one_batch(fixture_local_tinyllama_dir, fixture_iris_df, tm
         dp_enabled=True,
         epsilon=100.0,
     )
-    nss = train_with_sdk(config, fixture_iris_df, tmp_path)
+    nss = train_with_sdk(config, fixture_preflight_iris_df, tmp_path)
     assert nss._workdir is not None
     assert_adapter_saved(nss._workdir)


### PR DESCRIPTION
didn't fix this in #406. 

# Summary

Swaps GPU smoke tests off the 150-row Iris fixture and onto a dedicated `fixture_gpu_smoke_df` backed by `clinc_oos.csv`. The new fixture uses 210 rows so preflight still sees 200 training rows after the resume test’s 5% holdout. Iris stays unchanged for CPU/unit paths.