### PR TITLE
chore: Skip versioned docs push for prerelease versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: linux-amd64-cpu4
     outputs:
       version: ${{ steps.build.outputs.version }}
+      is_prerelease: ${{ steps.build.outputs.is_prerelease }}
     steps:
       - name: Checkout at release ref
         uses: actions/checkout@v6
@@ -63,6 +64,11 @@ jobs:
           WHEEL=$(ls dist/*.whl)
           VERSION=$(echo "$WHEEL" | sed -n 's/.*-\([0-9][^-]*\)-.*/\1/p')
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          IS_PRERELEASE=false
+          if echo "$VERSION" | grep -qE '(rc|alpha|beta|\.dev)'; then
+            IS_PRERELEASE=true
+          fi
+          echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
           echo "Built: $WHEEL (version $VERSION)"
 
       - uses: actions/upload-artifact@v7
@@ -113,9 +119,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.publish-wheel.outputs.version }}
+          IS_PRERELEASE: ${{ needs.publish-wheel.outputs.is_prerelease }}
         run: |
           PRERELEASE_FLAG=""
-          if echo "$VERSION" | grep -qE '(rc|alpha|beta|\.dev)'; then
+          if [ "$IS_PRERELEASE" = "true" ]; then
             PRERELEASE_FLAG="--prerelease"
           fi
 
@@ -128,6 +135,7 @@ jobs:
   publish-release-docs:
     name: Publish release docs
     needs: publish-wheel
+    if: ${{ needs.publish-wheel.outputs.is_prerelease != 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout at release ref


### PR DESCRIPTION
# Summary

Don't include prerelease versions in the named versions available in gh-pages.

## Pre-Review Checklist

Not applicable as this PR modifies a release workflow. Will test on next release.

Ensure that the following pass:

- [ ] `make format && make check` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->

