### PR TITLE
chore(slurm): patch slurm script to allow scheduled jobs

### DIFF
--- a/script/slurm/env_variables.sh
+++ b/script/slurm/env_variables.sh
@@ -19,7 +19,7 @@ CONFIGS=(
     mistral-nodp
     mistral-dp
 ) # the jobs will run all datasets with these configs
-export NSS_DIR="${LUSTRE_DIR}/Safe-Synthesizer" # where the nss repo is located
+export NSS_DIR="${NSS_DIR:-${LUSTRE_DIR}/Safe-Synthesizer}" # where the nss repo is located
 export NSS_SLURM_DIR="${NSS_DIR}/script/slurm" # slurm scripts location (inside repo)
 export CONFIG_DIR="${NSS_SLURM_DIR}/configs" # where the config files are located
 export BASE_LOG_DIR="${LUSTRE_DIR}/nss_results" # where you want the slurm logs to be saved, each job will have err and out files

--- a/script/slurm/slurm_nss_matrix.sh
+++ b/script/slurm/slurm_nss_matrix.sh
@@ -120,8 +120,8 @@ if [[ -n "${NSS_VERSION:-}" ]]; then
     NSS_RUN_CMD="${PYPI_VENV}/bin/safe-synthesizer"
     echo "[NSS SLURM] Using PyPI install: nemo-safe-synthesizer==${NSS_VERSION}"
 else
-    source "${NSS_DIR}/.venv/bin/activate"
     uv sync --frozen --extra cu129 --extra engine --group dev
+    source "${NSS_DIR}/.venv/bin/activate"
     NSS_RUN_CMD="uv run safe-synthesizer"
 fi
 echo "[NSS SLURM] nemo-safe-synthesizer version: $(python -c 'from nemo_safe_synthesizer.package_info import __version__; print(__version__)')"

--- a/script/slurm/submit_slurm_jobs.sh
+++ b/script/slurm/submit_slurm_jobs.sh
@@ -307,7 +307,7 @@ else
   if [[ -n "${end_to_end_array_id:-}" ]]; then
     printf '%s\n' "${end_to_end_array_id}"
   fi
-  if [[ -n "${JOB_ID_FILE:-}" && -z "${DRY_RUN:-}" ]]; then
+  if [[ -n "${JOB_ID_FILE:-}" && -n "${end_to_end_array_id:-}" && -z "${DRY_RUN:-}" ]]; then
     mkdir -p "$(dirname "${JOB_ID_FILE}")"
     printf '%s\n' "${end_to_end_array_id}" > "${JOB_ID_FILE}"
   fi

--- a/script/slurm/submit_slurm_jobs.sh
+++ b/script/slurm/submit_slurm_jobs.sh
@@ -22,8 +22,9 @@ ACCOUNT="${ACCOUNT:-nemotron_data_dev}"
 TIME_LIMIT="04:00:00"
 TRAIN_TIME_LIMIT=""
 GENERATE_TIME_LIMIT=""
-# Optional end-to-end-mode handoff for external orchestrators: record the
-# submitted array id so a separate wait/resume step can monitor the exact Slurm job.
+# Optional handoff for external orchestrators: record the array id to monitor.
+# In two_stage mode, this records only the generate array id so callers can use
+# the same one-id schema as end_to_end mode.
 JOB_ID_FILE=""
 
 # Parse flags (order-independent). Unknown flags are ignored.
@@ -70,7 +71,7 @@ while [ $# -gt 0 ]; do
       echo "    --nss-version VERSION  install nemo-safe-synthesizer==VERSION from PyPI instead of syncing the repo"
       echo "                           example: --nss-version 0.2.3"
       echo "                           if omitted, the repo at NSS_DIR is used (default behavior)"
-      echo "    --job-id-file PATH     write submitted Slurm array job id to PATH; only supported with --pipeline-mode end_to_end"
+      echo "    --job-id-file PATH     write submitted Slurm array job id to PATH; in two_stage mode this records the generate array id"
 
       exit 0;;
     --) shift; break;;
@@ -98,12 +99,6 @@ fi
 
 if [[ "$PIPELINE_MODE" != "two_stage" && "$PIPELINE_MODE" != "end_to_end" ]]; then
   echo "ERROR: --pipeline-mode must be one of: two_stage, end_to_end: '$PIPELINE_MODE'" >&2
-  exit 1
-fi
-
-if [[ -n "${JOB_ID_FILE:-}" && "${PIPELINE_MODE}" != "end_to_end" ]]; then
-  echo "ERROR: --job-id-file is only supported with --pipeline-mode end_to_end." >&2
-  echo "Two-stage mode submits separate train and generate arrays, which are not represented by this file." >&2
   exit 1
 fi
 
@@ -283,6 +278,14 @@ if [ -n "${DRY_RUN:-}" ]; then
   common_args+=("--test-only")
 fi
 
+write_job_id_file() {
+  local array_id="$1"
+  if [[ -n "${JOB_ID_FILE:-}" && -n "${array_id:-}" && -z "${DRY_RUN:-}" ]]; then
+    mkdir -p "$(dirname "${JOB_ID_FILE}")"
+    printf '%s\n' "${array_id}" > "${JOB_ID_FILE}"
+  fi
+}
+
 if [[ "${PIPELINE_MODE}" == "two_stage" ]]; then
   # Submit two job arrays with sbatch, one for train and one for generate. Uses
   # --dependency=aftercorr to ensure generate jobs only run after train jobs
@@ -303,6 +306,10 @@ if [[ "${PIPELINE_MODE}" == "two_stage" ]]; then
       --export=ALL,NSS_PHASE=generate \
       ${NSS_SLURM_DIR}/slurm_srun.sh )
 
+  if [[ -n "${gen_array_id:-}" ]]; then
+    printf '%s\n' "${gen_array_id}"
+  fi
+  write_job_id_file "${gen_array_id}"
 else
   end_to_end_array_id=$( \
     sbatch "${common_args[@]}" \
@@ -313,10 +320,7 @@ else
   if [[ -n "${end_to_end_array_id:-}" ]]; then
     printf '%s\n' "${end_to_end_array_id}"
   fi
-  if [[ -n "${JOB_ID_FILE:-}" && -n "${end_to_end_array_id:-}" && -z "${DRY_RUN:-}" ]]; then
-    mkdir -p "$(dirname "${JOB_ID_FILE}")"
-    printf '%s\n' "${end_to_end_array_id}" > "${JOB_ID_FILE}"
-  fi
+  write_job_id_file "${end_to_end_array_id}"
 fi
 
 if [ -n "${DRY_RUN:-}" ]; then

--- a/script/slurm/submit_slurm_jobs.sh
+++ b/script/slurm/submit_slurm_jobs.sh
@@ -280,6 +280,9 @@ fi
 
 write_job_id_file() {
   local array_id="$1"
+  if [[ -n "${array_id:-}" ]]; then
+    printf '%s\n' "${array_id}"
+  fi
   if [[ -n "${JOB_ID_FILE:-}" && -n "${array_id:-}" && -z "${DRY_RUN:-}" ]]; then
     mkdir -p "$(dirname "${JOB_ID_FILE}")"
     printf '%s\n' "${array_id}" > "${JOB_ID_FILE}"
@@ -306,9 +309,6 @@ if [[ "${PIPELINE_MODE}" == "two_stage" ]]; then
       --export=ALL,NSS_PHASE=generate \
       ${NSS_SLURM_DIR}/slurm_srun.sh )
 
-  if [[ -n "${gen_array_id:-}" ]]; then
-    printf '%s\n' "${gen_array_id}"
-  fi
   write_job_id_file "${gen_array_id}"
 else
   end_to_end_array_id=$( \
@@ -317,9 +317,6 @@ else
     --job-name nss_end_to_end \
     --export=ALL,NSS_PHASE=end_to_end \
     ${NSS_SLURM_DIR}/slurm_srun.sh )
-  if [[ -n "${end_to_end_array_id:-}" ]]; then
-    printf '%s\n' "${end_to_end_array_id}"
-  fi
   write_job_id_file "${end_to_end_array_id}"
 fi
 

--- a/script/slurm/submit_slurm_jobs.sh
+++ b/script/slurm/submit_slurm_jobs.sh
@@ -22,6 +22,9 @@ ACCOUNT="${ACCOUNT:-nemotron_data_dev}"
 TIME_LIMIT="04:00:00"
 TRAIN_TIME_LIMIT=""
 GENERATE_TIME_LIMIT=""
+# Optional handoff for external orchestrators: record the submitted array id so
+# a separate wait/resume step can monitor the exact Slurm job.
+JOB_ID_FILE=""
 
 # Parse flags (order-independent). Unknown flags are ignored.
 while [ $# -gt 0 ]; do
@@ -52,10 +55,12 @@ while [ $# -gt 0 ]; do
       TRAIN_TIME_LIMIT="${2:-$TRAIN_TIME_LIMIT}"; shift 2;;
     --generate-time-limit)
       GENERATE_TIME_LIMIT="${2:-$GENERATE_TIME_LIMIT}"; shift 2;;
+    --job-id-file)
+      JOB_ID_FILE="${2:-}"; shift 2;;
     --dry-run)
       DRY_RUN="true"; shift;;
     --help|-h)
-      echo "Usage: $0 [--configs c1,c2] [--dataset-urls name1,url1,path1] [--dataset-group short|long] [--runs N] [--exp-name NAME] [--pipeline-mode two_stage|end_to_end] [--partition P] [--wandb-project PROJECT] [--max-concurrent-slurm-jobs N] [--time-limit TIME] [--train-time-limit TIME] [--generate-time-limit TIME] [--nss-version VERSION] [--dry-run]"
+      echo "Usage: $0 [--configs c1,c2] [--dataset-urls name1,url1,path1] [--dataset-group short|long] [--runs N] [--exp-name NAME] [--pipeline-mode two_stage|end_to_end] [--partition P] [--wandb-project PROJECT] [--max-concurrent-slurm-jobs N] [--time-limit TIME] [--train-time-limit TIME] [--generate-time-limit TIME] [--nss-version VERSION] [--job-id-file PATH] [--dry-run]"
       echo ""
       echo "Provide either --dataset-urls to specify a list of datasets by name, url, or path, or --dataset-group to use a predefined set of datasets."
       echo "Time limits:"
@@ -65,6 +70,7 @@ while [ $# -gt 0 ]; do
       echo "    --nss-version VERSION  install nemo-safe-synthesizer==VERSION from PyPI instead of syncing the repo"
       echo "                           example: --nss-version 0.2.3"
       echo "                           if omitted, the repo at NSS_DIR is used (default behavior)"
+      echo "    --job-id-file PATH     write submitted end-to-end Slurm array job id to PATH"
 
       exit 0;;
     --) shift; break;;
@@ -292,11 +298,19 @@ if [[ "${PIPELINE_MODE}" == "two_stage" ]]; then
       ${NSS_SLURM_DIR}/slurm_srun.sh )
 
 else
-  sbatch "${common_args[@]}" \
+  end_to_end_array_id=$( \
+    sbatch "${common_args[@]}" \
     --time="${TIME_LIMIT}" \
     --job-name nss_end_to_end \
     --export=ALL,NSS_PHASE=end_to_end \
-    ${NSS_SLURM_DIR}/slurm_srun.sh
+    ${NSS_SLURM_DIR}/slurm_srun.sh )
+  if [[ -n "${end_to_end_array_id:-}" ]]; then
+    printf '%s\n' "${end_to_end_array_id}"
+  fi
+  if [[ -n "${JOB_ID_FILE:-}" && -z "${DRY_RUN:-}" ]]; then
+    mkdir -p "$(dirname "${JOB_ID_FILE}")"
+    printf '%s\n' "${end_to_end_array_id}" > "${JOB_ID_FILE}"
+  fi
 fi
 
 if [ -n "${DRY_RUN:-}" ]; then

--- a/script/slurm/submit_slurm_jobs.sh
+++ b/script/slurm/submit_slurm_jobs.sh
@@ -22,8 +22,8 @@ ACCOUNT="${ACCOUNT:-nemotron_data_dev}"
 TIME_LIMIT="04:00:00"
 TRAIN_TIME_LIMIT=""
 GENERATE_TIME_LIMIT=""
-# Optional handoff for external orchestrators: record the submitted array id so
-# a separate wait/resume step can monitor the exact Slurm job.
+# Optional end-to-end-mode handoff for external orchestrators: record the
+# submitted array id so a separate wait/resume step can monitor the exact Slurm job.
 JOB_ID_FILE=""
 
 # Parse flags (order-independent). Unknown flags are ignored.
@@ -70,7 +70,7 @@ while [ $# -gt 0 ]; do
       echo "    --nss-version VERSION  install nemo-safe-synthesizer==VERSION from PyPI instead of syncing the repo"
       echo "                           example: --nss-version 0.2.3"
       echo "                           if omitted, the repo at NSS_DIR is used (default behavior)"
-      echo "    --job-id-file PATH     write submitted end-to-end Slurm array job id to PATH"
+      echo "    --job-id-file PATH     write submitted Slurm array job id to PATH; only supported with --pipeline-mode end_to_end"
 
       exit 0;;
     --) shift; break;;
@@ -98,6 +98,12 @@ fi
 
 if [[ "$PIPELINE_MODE" != "two_stage" && "$PIPELINE_MODE" != "end_to_end" ]]; then
   echo "ERROR: --pipeline-mode must be one of: two_stage, end_to_end: '$PIPELINE_MODE'" >&2
+  exit 1
+fi
+
+if [[ -n "${JOB_ID_FILE:-}" && "${PIPELINE_MODE}" != "end_to_end" ]]; then
+  echo "ERROR: --job-id-file is only supported with --pipeline-mode end_to_end." >&2
+  echo "Two-stage mode submits separate train and generate arrays, which are not represented by this file." >&2
   exit 1
 fi
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->
This PR executes TASK-05 of this [plan](https://gitlab-master.nvidia.com/sdg-research/nss-experimental-analysis/-/blob/81bf040a5ba6429e264335d460d53afcb17e74e3/plans/nss_weekly_pipeline_combined_cursor_plan.md), in order to allow us to schedule automatic slurm runs. 

- Goal: harden shared-clone and job-tracking behavior.
- Target files:
  - `Safe-Synthesizer/script/slurm/submit_slurm_jobs.sh`
  - `Safe-Synthesizer/script/slurm/env_variables.sh`
  - `Safe-Synthesizer/script/slurm/slurm_nss_matrix.sh`
- Required changes:
  - add `--job-id-file` (so we can monitor when the runs complete)
  - make `NSS_DIR` env-overridable (so we can point to a different canonical copy of the main branch)
  - make `.venv` activate best-effort before `uv sync` (because the .venv needs to be activated before a slurm instance can install the environment)
- Acceptance criteria:
  - limited validation run passes (`--runs 1`, short group)
  - job IDs are captured and consumed by wait logic
 

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `make format && make check` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture and optionally save Slurm array job IDs from batch submissions via a new command-line option.

* **Bug Fixes**
  * Run synchronization step before activating the virtual environment to ensure correct ordering.

* **Chores**
  * Environment variable handling updated to respect an existing override while preserving the same default path.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Safe-Synthesizer/pull/490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->