### PR TITLE
chore: bump to 1.7 telemetry version to allow for slurm-nvidia-internal

### DIFF
--- a/script/slurm/slurm_srun.sh
+++ b/script/slurm/slurm_srun.sh
@@ -13,8 +13,7 @@ ACCOUNT="${ACCOUNT:-nemotron_data_dev}"
 GPUS_PER_TASK="${GPUS_PER_TASK:-1}"
 CPUS_PER_TASK="${CPUS_PER_TASK:-16}"
 SRUN_EXTRA="${SRUN_EXTRA:-}"
-# TODO: Enable this once the schema is updated
-# export NEMO_DEPLOYMENT_TYPE="${NEMO_DEPLOYMENT_TYPE:-slurm-nvidia-internal}"
+export NEMO_DEPLOYMENT_TYPE="${NEMO_DEPLOYMENT_TYPE:-slurm-nvidia-internal}"
 
 # No --time flag used in srun since we have a single srun in each allocation so
 # the time limit is controleld by the --time flag on the sbatch calls in

--- a/script/slurm/slurm_srun.sh
+++ b/script/slurm/slurm_srun.sh
@@ -13,7 +13,8 @@ ACCOUNT="${ACCOUNT:-nemotron_data_dev}"
 GPUS_PER_TASK="${GPUS_PER_TASK:-1}"
 CPUS_PER_TASK="${CPUS_PER_TASK:-16}"
 SRUN_EXTRA="${SRUN_EXTRA:-}"
-export NEMO_DEPLOYMENT_TYPE="${NEMO_DEPLOYMENT_TYPE:-slurm-nvidia-internal}"
+# TODO: Enable this once the schema is updated
+# export NEMO_DEPLOYMENT_TYPE="${NEMO_DEPLOYMENT_TYPE:-slurm-nvidia-internal}"
 
 # No --time flag used in srun since we have a single srun in each allocation so
 # the time limit is controleld by the --time flag on the sbatch calls in

--- a/src/nemo_safe_synthesizer/telemetry.py
+++ b/src/nemo_safe_synthesizer/telemetry.py
@@ -158,7 +158,7 @@ def bucket_columns(n: int) -> str:
 
 class NSSTrainingAndGenerationEvent(BaseModel):
     _event_name: ClassVar[str] = "train_and_generation_event"
-    _schema_version: ClassVar[str] = "1.4"
+    _schema_version: ClassVar[str] = "1.7"
 
     nemo_source: NemoSourceEnum = Field(
         default=NemoSourceEnum.SAFE_SYNTHESIZER,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated telemetry schema version for training and generation events to a newer specification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Safe-Synthesizer/pull/493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->