### PR TITLE
docs: Fix broken links

### DIFF
--- a/docs/developer-guide/configuration_management.md
+++ b/docs/developer-guide/configuration_management.md
@@ -8,7 +8,7 @@ Click options, then maps Click's flat keyword arguments back to the nested
 structure Pydantic expects. It powers the CLI surfaces that expose
 `SafeSynthesizerParameters`.
 
-For general Pydantic style rules, see [STYLE_GUIDE.md](../../STYLE_GUIDE.md#data-modeling).
+For general Pydantic style rules, see [STYLE_GUIDE.md](https://github.com/NVIDIA-NeMo/Safe-Synthesizer/blob/main/STYLE_GUIDE.md#data-modeling).
 This page covers repository-specific mechanics.
 
 The type system is still growing. The long-term goal is that every setting
@@ -135,9 +135,8 @@ It is used only when the string literal side is exactly `"auto"`.
 
 ## Validators and Settings
 
-General Pydantic validator style lives in
-[STYLE_GUIDE.md](../../STYLE_GUIDE.md#data-modeling). Repository-specific
-validators live in `src/nemo_safe_synthesizer/configurator/validators.py`:
+General Pydantic validator style lives in [STYLE_GUIDE.md](https://github.com/NVIDIA-NeMo/Safe-Synthesizer/blob/main/STYLE_GUIDE.md#data-modeling). Repository-specific validators live in
+`src/nemo_safe_synthesizer/configurator/validators.py`:
 
 - `DependsOnValidator`: field is valid only when another field is set.
 - `ValueValidator`: validates the effective field value.

--- a/docs/developer-guide/observability.md
+++ b/docs/developer-guide/observability.md
@@ -5,8 +5,7 @@
 
 Safe Synthesizer centralizes structured logging and tracing in
 `src/nemo_safe_synthesizer/observability.py`. For normative code style, see
-[STYLE_GUIDE.md](../../STYLE_GUIDE.md#logging-and-observability). This page
-covers the high-level model.
+[STYLE_GUIDE.md](https://github.com/NVIDIA-NeMo/Safe-Synthesizer/blob/main/STYLE_GUIDE.md#logging-and-observability). This page covers the high-level model.
 
 ## Model
 

--- a/docs/product-overview/data_synthesis.md
+++ b/docs/product-overview/data_synthesis.md
@@ -36,7 +36,7 @@ Three models have been extensively tested:
 | TinyLlama | `TinyLlama/TinyLlama-1.1B-Chat-v1.0` |
 | Mistral | `mistralai/Mistral-7B-Instruct-v0.3` |
 
-For information on the trade-offs with model selection, see [Training](running.md#training).
+For information on the trade-offs with model selection, see [Training](../user-guide/running.md#training).
 
 ### Supported Data Types
 

--- a/docs/product-overview/evaluation.md
+++ b/docs/product-overview/evaluation.md
@@ -142,4 +142,4 @@ evaluation:
 
 ## Related Topics
 
-- [Synthetic Data Quality](evaluating-data.md): See recommendations for increasing quality and privacy scores
+- [Synthetic Data Quality](../user-guide/evaluating-data.md): See recommendations for increasing quality and privacy scores

--- a/docs/user-guide/running.md
+++ b/docs/user-guide/running.md
@@ -125,7 +125,7 @@ You can also run stages individually:
 Use `--validate` to check your dataset and configuration before committing to
 a full run. Pre-flight catches configuration mistakes, missing columns, token
 budget overflows, and GPU issues in seconds -- before the pipeline downloads
-models or starts training. See [`run --validate`](#run---validate) in CLI
+models or starts training. See [`run --validate`](#run-validate) in CLI
 Commands for the full reference.
 
 ---

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -59,7 +59,7 @@ You can also set the log level via environment variable:
 export NSS_LOG_LEVEL=DEBUG
 ```
 
-See [Running -- Logging](running.md#logging) for the full logging
+See [Running -- Logging](running.md#logging-and-experiment-tracking) for the full logging
 configuration reference.
 
 ---
@@ -453,7 +453,7 @@ Incompatible DP settings:
 When running with `--validate` (CLI) or `process_data(check_only=True)` (SDK),
 the following codes may appear. For an overview of what pre-flight validates,
 how to interpret the output, and how to use the resolved config, see
-[Running -- `run --validate`](running.md#run---validate).
+[Running -- `run --validate`](running.md#run-validate).
 
 The `Check` column lists the check name (as emitted in the report and
 accepted by `disabled_checks`). `preflight.check_crash` is synthesized

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -72,6 +72,11 @@ watch:
 
 strict: !ENV [MKDOCS_STRICT, false]
 
+validation:
+  links:
+    not_found: warn    # broken page links emit a warning
+    anchors: warn      # broken anchor links emit a warning (default is info)
+
 hooks:
   - docs/hooks.py
 


### PR DESCRIPTION
# Summary

Fix various broken links. And be explicit that broken links or anchors should produce a WARNING message in the mkdocs output.

We can't enable strict mode to fail on any broken link yet because we have a lot of them in the python docstrings that griffe is processing.

But bad relative links will now look like:

```
WARNING -  Doc file 'developer-guide/observability.md' contains a link '../../STYLE_GUIDE.md', but the target '../STYLE_GUIDE.md'
           is not found among documentation files.
```

in the build output. (Previously were INFO level.)

## Pre-Review Checklist

Ensure that the following pass:

- [X] `make format && make check` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

