### PR TITLE
fix: Show correct filename in log messages

### DIFF
--- a/src/nemo_safe_synthesizer/observability.py
+++ b/src/nemo_safe_synthesizer/observability.py
@@ -636,32 +636,26 @@ class CategoryLogger(logging.Logger):
         self.system = _CategoryLogAdapter(base_logger, LogCategory.SYSTEM)
         self.backend = _CategoryLogAdapter(base_logger, LogCategory.BACKEND)
         self.default = self.runtime
+        # Assign standard log methods as direct aliases to self.default rather than
+        # wrapping them in delegation methods. A delegation method in this class would
+        # add an observability.py frame to the call stack, which confuses both
+        # Python's stdlib findCaller() (used for pre-init foreign logs) and structlog's
+        # CallsiteParameterAdder. Using aliases means logger.info() calls
+        # LoggerAdapter.info() directly -- a logging-module frame that is already
+        # skipped by both mechanisms -- so the reported callsite is the real caller.
+        self.__dict__.update(
+            log=self.default.log,
+            debug=self.default.debug,
+            info=self.default.info,
+            warning=self.default.warning,
+            error=self.default.error,
+            exception=self.default.exception,
+            critical=self.default.critical,
+        )
 
     @property
     def name(self) -> str:
         return self._logger.name
-
-    # Delegate standard methods to runtime by default (backwards compatible)
-    def log(self, level: int, msg: object, *args: object, **kwargs: Any) -> None:
-        self.default.log(level, msg, *args, **kwargs)
-
-    def debug(self, msg: object, *args: object, **kwargs: Any) -> None:
-        self.default.debug(msg, *args, **kwargs)
-
-    def info(self, msg: object, *args: object, **kwargs: Any) -> None:
-        self.default.info(msg, *args, **kwargs)
-
-    def warning(self, msg: object, *args: object, **kwargs: Any) -> None:
-        self.default.warning(msg, *args, **kwargs)
-
-    def error(self, msg: object, *args: object, **kwargs: Any) -> None:
-        self.default.error(msg, *args, **kwargs)
-
-    def exception(self, msg: object, *args: object, **kwargs: Any) -> None:
-        self.default.exception(msg, *args, **kwargs)
-
-    def critical(self, msg: object, *args: object, **kwargs: Any) -> None:
-        self.default.critical(msg, *args, **kwargs)
 
     def isEnabledFor(self, level: int) -> bool:
         return self._logger.isEnabledFor(level)

--- a/tests/observability/test_observability.py
+++ b/tests/observability/test_observability.py
@@ -1,9 +1,11 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import inspect
 import json
 import logging
 import time
+from pathlib import Path
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -510,6 +512,65 @@ class TestInitializeObservability:
 class TestGetLogger:
     """Tests for get_logger function."""
 
+    @pytest.fixture
+    def callsite_test_logging(self, monkeypatch, caplog):
+        """Initialize observability while preserving caplog capture.
+
+        Leaves ``_INITIALIZED_OBSERVABILITY`` False and structlog reset on
+        teardown so the global state is internally consistent. Tests that need
+        an initialized observability stack (e.g. ``TestObservabilityIntegration``)
+        re-initialize via their own autouse fixture.
+        """
+        root_logger = logging.getLogger()
+        original_handlers = root_logger.handlers.copy()
+        original_level = root_logger.level
+
+        # Manage _INITIALIZED_OBSERVABILITY manually rather than through
+        # monkeypatch.setattr. monkeypatch restores the pre-test value AFTER
+        # this fixture's teardown runs, which would re-flip the flag back to
+        # True (set by earlier tests) while structlog has just been reset to
+        # defaults. That mismatch causes get_logger() to return a structlog
+        # BoundLoggerFilteringAtNotset wrapped in a stdlib LoggerAdapter, which
+        # blows up on isEnabledFor() in subsequent tests.
+        obs._INITIALIZED_OBSERVABILITY = False
+        monkeypatch.setenv("NSS_LOG_FORMAT", "plain")
+        monkeypatch.setenv("NSS_LOG_LEVEL", "INFO")
+        monkeypatch.setenv("NSS_LOG_COLOR", "false")
+        monkeypatch.delenv("NSS_LOG_FILE", raising=False)
+        monkeypatch.setattr(obs, "SETTINGS", NSSObservabilitySettings())
+        structlog.reset_defaults()
+        root_logger.handlers.clear()
+
+        yield
+
+        structlog.reset_defaults()
+        root_logger.handlers = original_handlers
+        root_logger.setLevel(original_level)
+        obs._INITIALIZED_OBSERVABILITY = False
+
+    @staticmethod
+    def _record_callsite(record: logging.LogRecord) -> tuple[str, int]:
+        match record.msg:
+            case {"filename": filename, "lineno": lineno}:
+                return str(filename), int(lineno)
+            case _:
+                return record.filename, record.lineno
+
+    @staticmethod
+    def _assert_log_record_callsite(
+        caplog,
+        *,
+        message: str,
+        expected_filename: str,
+        expected_lineno: int,
+    ) -> None:
+        records = [record for record in caplog.records if message in record.getMessage()]
+        assert len(records) == 1
+
+        filename, lineno = TestGetLogger._record_callsite(records[0])
+        assert filename == expected_filename
+        assert lineno == expected_lineno
+
     def test_returns_category_logger_by_default(self):
         """Test that get_logger returns CategoryLogger by default."""
         logger = get_logger("test_module")
@@ -568,6 +629,59 @@ class TestGetLogger:
         # Root logger configuration should be unchanged
         assert root_logger.handlers == original_handlers
         assert root_logger.level == original_level
+
+    def test_logger_created_before_observability_configuration_reports_real_callsite(
+        self,
+        callsite_test_logging,
+        caplog,
+    ):
+        """Logger created before configuration still reports the caller filename."""
+        logger = get_logger("test_callsite_before_configuration")
+
+        initialize_observability()
+        root_logger = logging.getLogger()
+        if caplog.handler not in root_logger.handlers:
+            root_logger.addHandler(caplog.handler)
+        caplog.set_level(logging.INFO, logger=logger.name)
+
+        message = "logger before configuration callsite"
+        frame = inspect.currentframe()
+        assert frame is not None
+        expected_lineno = frame.f_lineno + 1
+        logger.info(message)
+
+        self._assert_log_record_callsite(
+            caplog,
+            message=message,
+            expected_filename=Path(__file__).name,
+            expected_lineno=expected_lineno,
+        )
+
+    def test_logger_created_after_observability_configuration_reports_real_callsite(
+        self,
+        callsite_test_logging,
+        caplog,
+    ):
+        """Logger created after configuration still reports the caller filename."""
+        initialize_observability()
+        root_logger = logging.getLogger()
+        if caplog.handler not in root_logger.handlers:
+            root_logger.addHandler(caplog.handler)
+        caplog.set_level(logging.INFO)
+
+        logger = get_logger("test_callsite_after_configuration")
+        message = "logger after configuration callsite"
+        frame = inspect.currentframe()
+        assert frame is not None
+        expected_lineno = frame.f_lineno + 1
+        logger.info(message)
+
+        self._assert_log_record_callsite(
+            caplog,
+            message=message,
+            expected_filename=Path(__file__).name,
+            expected_lineno=expected_lineno,
+        )
 
 
 class TestObservabilityIntegration:


### PR DESCRIPTION
# Summary

Fixes log messages to refer to the correct filenames, instead of sometimes using `observability.py:652` or other incorrect `observability.py` references.  Related to using the `.log()`, `.default.log()`, `.runtime.log()` methods on the logger object and the order of creating logger objects (at import time mostly) and initializing observability.

The added tests checking order of logger and observability initialization fails on main with the following, and passes with this PR:

```
FAILED tests/observability/test_observability.py::TestGetLogger::test_logger_created_before_observability_configuration_reports_real_callsite - AssertionError: assert 'observability.py' == 'test_observability.py'
  
  - test_observability.py
  ? -----
  + observability.py
```

So the test captures the bad behavior we're looking for and it's fixed with this PR.

## Pre-Review Checklist

Ensure that the following pass:

- [X] `make format && make check` or via prek validation.
- [X] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

I ran 4x with TinyLlama (and lower training time) comparing current main and this PR using json and plain log formats and had an agent compare the outputs looking for any differences. Diffs are as expected, with more bad filenames apparently happening in the json outputs, but all are fixed with this PR and no other major changes. See PR comment for details.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified and optimized the internal implementation of logging methods to improve code maintainability and reduce redundancy in method delegation patterns.

* **Tests**
  * Added comprehensive tests to verify logging correctly tracks source file location and line numbers across different observability initialization states, ensuring accurate callsite information is captured consistently in all scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Safe-Synthesizer/pull/497?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->