### PR TITLE
chore: Update default column classification model

### DIFF
--- a/docs/user-guide/environment.md
+++ b/docs/user-guide/environment.md
@@ -211,7 +211,7 @@ CLI and SDK (with the default or custom `NSS_INFERENCE_ENDPOINT`).
 ### `NIM_MODEL_ID`
 
 Model ID sent to the NIM endpoint for PII column classification. Defaults to
-`qwen/qwen2.5-coder-32b-instruct`.
+`qwen/qwen3-next-80b-a3b-instruct`.
 
 ### `SAFE_SYNTHESIZER_CPU_COUNT`
 

--- a/script/slurm/slurm_nss_matrix.sh
+++ b/script/slurm/slurm_nss_matrix.sh
@@ -129,7 +129,7 @@ echo "[NSS SLURM] nemo-safe-synthesizer version: $(python -c 'from nemo_safe_syn
 
 # for column classification
 export NSS_INFERENCE_ENDPOINT=https://integrate.api.nvidia.com/v1
-export NIM_MODEL_ID=qwen/qwen2.5-coder-32b-instruct
+export NIM_MODEL_ID=qwen/qwen3-next-80b-a3b-instruct
 
 # Extract dataset name for path construction (handles both full paths and simple names)
 # e.g., "/path/to/adult.csv" -> "adult", "/path/to/data.parquet" -> "data", "adult" -> "adult"

--- a/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
@@ -37,7 +37,7 @@ class DefaultLLMConfig:
 
     Attributes:
         CONFIG_ID: Model identifier for the LLM. From env ``NIM_MODEL_ID``, or
-            ``qwen/qwen2.5-coder-32b-instruct`` if unset.
+            ``qwen/qwen3-next-80b-a3b-instruct`` if unset.
         SYSTEM_PROMPT: System message describing the column-type annotation task
             sent to the LLM.
         MAX_OUTPUT_TOKENS: Maximum number of tokens allowed in the LLM response
@@ -46,7 +46,7 @@ class DefaultLLMConfig:
             Lower values give more deterministic output.
     """
 
-    CONFIG_ID = os.environ.get("NIM_MODEL_ID", "qwen/qwen2.5-coder-32b-instruct")
+    CONFIG_ID = os.environ.get("NIM_MODEL_ID", "qwen/qwen3-next-80b-a3b-instruct")
     SYSTEM_PROMPT = "You are a helpful AI that annotates columns in datasets with their respective types. "
     MAX_OUTPUT_TOKENS = 2048
     TEMPERATURE = 0.2

--- a/tests/nss_pii_replacer_test.py
+++ b/tests/nss_pii_replacer_test.py
@@ -11,11 +11,10 @@ import pandas as pd
 
 from nemo_safe_synthesizer.pii_replacer.nemo_pii import NemoPII
 
-# Currently use env variables to configure various pieces
-# Inferenc endpoint for classify:
+# Currently use env variables to configure the endpoint and model for column classification.
 # export NSS_INFERENCE_KEY=<...>
 # export NSS_INFERENCE_ENDPOINT=https://integrate.api.nvidia.com/v1
-# export NIM_MODEL_ID=qwen/qwen2.5-coder-32b-instruct
+# export NIM_MODEL_ID=qwen/qwen3-next-80b-a3b-instruct
 
 
 def main():


### PR DESCRIPTION
# Summary

The previous default model (qwen2.5) was deprecated and removed from build, so all requests return 404 now. After a quick search this afternoon, updating to `qwen/qwen3-next-80b-a3b-instruct` as the current prompt and setup continues to work well with the model.

May investigate using nemotron models later, but will require more changes as we're not getting well formed responses consistently from either nemotron 3 nano or super right now.

## Pre-Review Checklist
Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [x] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the default AI model used for PII column classification from Qwen 2.5 Coder 32B to Qwen 3 Next 80B. This change is reflected in documentation, environment configuration, and application defaults to ensure consistent model usage across all deployment scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Safe-Synthesizer/pull/498?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->