### PR TITLE
chore: Document repo labels and update templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -5,19 +5,6 @@ name: Bug Report
 description: Report a bug
 labels: ["bug"]
 body:
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Priority Level
-      description: How urgent is this issue?
-      default: 2
-      options:
-        - Critical (Total blocker)
-        - High (Major functionality broken)
-        - Medium (Annoying but has workaround)
-        - Low (Cosmetic / Minor)
-    validations:
-      required: true
   - type: textarea
     id: description
     attributes:

--- a/.github/ISSUE_TEMPLATE/development-task.yml
+++ b/.github/ISSUE_TEMPLATE/development-task.yml
@@ -3,19 +3,7 @@
 
 name: Development Task
 description: Track internal development work, refactoring, or infrastructure
-labels: ["task"]
 body:
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Priority Level
-      default: 1
-      options:
-        - High
-        - Medium
-        - Low
-    validations:
-      required: true
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -3,21 +3,8 @@
 
 name: Feature Request
 description: Request a new feature
-labels: ["enhancement"]
+labels: ["feature"]
 body:
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Priority Level
-      description: How important is this feature to your workflow?
-      default: 2
-      options:
-        - Critical (Essential for use)
-        - High (Major improvement)
-        - Medium (Nice to have)
-        - Low (Minor tweak)
-    validations:
-      required: true
   - type: textarea
     id: problem
     attributes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Please read our [Code of Conduct](CODE_OF_CONDUCT.md) before contributing.
   - [Branch Naming Convention](#branch-naming-convention)
   - [Conventional Commits](#conventional-commits)
   - [Branch Protection](#branch-protection)
+- [Classification and Project Tracking](#classification-and-project-tracking)
 - [Pull Request Process](#pull-request-process)
 - [Issues and Discussions](#issues-and-discussions)
 - [Developer Certificate of Origin](#developer-certificate-of-origin)
@@ -319,6 +320,94 @@ The `main` branch has the following protections:
 | Merge strategy                  | Squash only  |
 
 `GPU CI Status` is not currently a live branch-protection requirement because PR GPU runs are blocked by internal issues. We expect to re-enable it as soon as those blockers are resolved.
+
+## Classification and Project Tracking
+
+Three mechanisms classify and track work in this repo:
+
+1. GitHub issue Type field -- org-level, single value per issue.
+2. Labels -- repo-level, multiple per issue or PR; the canonical list lives below.
+3. Safe Synthesizer Development GitHub project fields -- `Priority` and `Size`.
+
+The split is intentional: the Type field handles coarse classification, labels handle granularity the Type field can't express, and the project handles backlog ordering and effort tracking.
+
+### Issue Type
+
+The GitHub Type field is set at the NVIDIA-NeMo org level (changing the value list requires an org owner). It applies to issues only -- PRs use the type labels described below.
+
+| Type | Use for |
+| --- | --- |
+| `Bug` | Defects in shipped behavior |
+| `Feature` | New user-facing capability |
+| `Question` | Questions or clarification requests; prefer [GitHub Discussions](https://github.com/NVIDIA-NeMo/safe-synthesizer/discussions) for general questions |
+| `Task` | Internal development work, refactors, infrastructure |
+
+Most internal issues will be `Task`.
+
+### Project fields: Priority and Size
+
+Issues are tracked in the Safe Synthesizer Development GitHub project. Priority and effort estimates live as project fields, not labels, so backlog and prioritization views can sort and group on them directly.
+
+- `Priority` -- relative urgency for backlog ordering. 
+- `Size` -- rough effort estimate.
+
+Set both in the [project view](https://github.com/orgs/NVIDIA-NeMo/projects/74) or expand the Projects drop-down on the right pane for PRs and issues.
+
+### Labels
+
+Labels are repo-scoped and apply to both issues and PRs. There is no required minimum set per issue or PR; apply labels that add useful signal.
+
+#### Type
+
+Roughly aligned with our Conventional Commit types. Apply when it adds signal; multiple are fine for cross-cutting work.
+
+| Label | Use for |
+| --- | --- |
+| `bug` | Defects in shipped behavior |
+| `feature` | New user-facing capability |
+| `refactor` | Internal restructuring with no behavior change |
+| `perf` | Performance improvement |
+| `security` | Security-relevant fix or hardening |
+| `docs` | Documentation-only change |
+| `test` | Test-only addition or change |
+| `chore` | Maintenance not tied to a user-visible change |
+| `breaking-change` | Backward-incompatible change (paired with another type) |
+
+#### Area
+
+Where in the codebase the work lands. Apply one or more on PRs to help routing; optional on issues.
+
+Product areas mirror the `src/nemo_safe_synthesizer/` module map in [`AGENTS.md`](AGENTS.md):
+
+`area:sdk-cli`, `area:config`, `area:data-processing`, `area:evaluation`, `area:generation`, `area:training`, `area:pii`, `area:privacy`, `area:llm`, `area:observability`.
+
+Infrastructure areas:
+
+`area:ci`, `area:tests`, `area:docs`, `area:dev-ex`, `area:build-dist`.
+
+#### Merge status
+
+| Label | Use for |
+| --- | --- |
+| `ready-to-merge` | All review and CI gates satisfied; ready for a maintainer to merge |
+| `blocked` | Cannot progress until an external dependency or upstream change is resolved |
+
+Other "who acts next" signaling on PRs is done via Assignees -- see the [Pull Request Process](#pull-request-process).
+
+#### Workflow
+
+| Label | Use for |
+| --- | --- |
+| `community-request` | Issue or PR from an external contributor or user |
+| `stale` | Auto-applied to inactive issues/PRs |
+
+#### Dependabot
+
+Dependabot manages `dependencies` and `github_actions` automatically on the PRs it opens; don't apply them manually.
+
+### Adding or changing labels
+
+This section is the canonical source. To add, rename, or remove a label, open a PR that updates this section and apply the change in the GitHub UI in the same PR. If drift becomes a problem we can switch to a `.github/labels.yml` driven by a sync action.
 
 ## Pull Request Process
 


### PR DESCRIPTION
# Summary

Document our usage of labels, project fields, and update templates.

This PR consolidates the discussion in #431 into a more focused and concrete proposal. We can expand and iterate in subsequent PRs.

Once approved, Kendrick will manually update the labels at the same time as merging this.

## Pre-Review Checklist

This PR is not relevant to any tests.

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

- Closes #431 
