### PR TITLE
fix: make preflight hf cache check warn

### DIFF
--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -516,7 +516,7 @@ check of its own.
 | `inference_key_missing` | warning | `env.inference_key` | `NSS_INFERENCE_KEY` not set; PII classification degraded |
 | `hf_token_missing` | warning | `env.hf_model_availability` | Neither `HF_TOKEN` nor `HUGGING_FACE_HUB_TOKEN` set, and model loading may need online Hugging Face access |
 | `hf_model_not_cached` | warning/error | `env.hf_model_availability` | Hugging Face model is not present in the local cache; severity is error when HF offline mode is enabled |
-| `hf_model_cache_incomplete` | error | `env.hf_model_availability` | Cached Hugging Face model snapshot is missing required config, tokenizer, weights, or shards |
+| `hf_model_cache_incomplete` | warning/error | `env.hf_model_availability` | Cached Hugging Face model snapshot is missing required config, tokenizer, weights, or shards; severity is error when HF offline mode is enabled |
 | `hf_remote_code_not_cached` | warning/error | `env.hf_model_availability` | Trusted model references remote code that is not cached locally; severity is error when HF offline mode is enabled |
 | `preflight.check_crash` | error | (crashing check) | A check raised an unexpected exception; the issue's `check` field names the crashing check and other checks continued running |
 | `column_not_found` | error | `columns.groupby` / `columns.orderby` | Required column missing from dataset, or input DataFrame uses unsupported MultiIndex columns |

--- a/src/nemo_safe_synthesizer/preflight/checks/environment.py
+++ b/src/nemo_safe_synthesizer/preflight/checks/environment.py
@@ -407,14 +407,20 @@ class HFModelAvailabilityCheck(ConfigCheck):
 
         missing = ModelRef.missing_required_components(snapshot_path)
         if missing:
-            collector.error(
-                "hf_model_cache_incomplete",
-                (
-                    f"Cached Hugging Face model '{model_ref.repo_id}' at '{snapshot_path}' is missing "
-                    f"{', '.join(missing)}. Pre-download the full model snapshot before running offline "
-                    "or rate-limited jobs."
-                ),
+            message = (
+                f"Cached Hugging Face model '{model_ref.repo_id}' at '{snapshot_path}' is missing {', '.join(missing)}."
             )
+            if _hf_offline_enabled():
+                collector.error(
+                    "hf_model_cache_incomplete",
+                    f"{message} Offline Hugging Face mode is enabled, so model loading will fail.",
+                )
+                return
+            collector.warning(
+                "hf_model_cache_incomplete",
+                f"{message} Model loading will contact Hugging Face unless the full model snapshot is pre-downloaded.",
+            )
+            self._report_missing_hf_token(collector)
         self._report_missing_remote_code(model_ref, snapshot_path, collector)
 
     @staticmethod

--- a/tests/preflight/test_preflight.py
+++ b/tests/preflight/test_preflight.py
@@ -356,7 +356,7 @@ class TestHFModelAvailabilityCheck:
         assert any(i.code == "hf_model_not_cached" and i.severity == "warning" for i in issues)
         assert any(i.code == "hf_token_missing" and i.severity == "warning" for i in issues)
 
-    def test_partial_cached_snapshot_errors(
+    def test_partial_cached_snapshot_warns(
         self, hf_cached_snapshot_factory, pretrained_config, ctx_factory, monkeypatch
     ):
         """Partial HF snapshot validation intentionally tracks Transformers load needs."""
@@ -368,10 +368,10 @@ class TestHFModelAvailabilityCheck:
             ctx_factory(config=pretrained_config("nvidia/Nemotron-Mini-4B-Instruct"))
         )
 
-        assert any(i.code == "hf_model_cache_incomplete" and i.severity == "error" for i in issues)
+        assert any(i.code == "hf_model_cache_incomplete" and i.severity == "warning" for i in issues)
         assert "model weights" in _issue_by_code(issues, "hf_model_cache_incomplete").message
 
-    def test_incomplete_sharded_cached_snapshot_errors(
+    def test_incomplete_sharded_cached_snapshot_warns(
         self, hf_cached_snapshot_factory, hf_weight_index_factory, pretrained_config, ctx_factory, monkeypatch
     ):
         """Sharded snapshot validation intentionally tracks HF weight-index design."""
@@ -389,7 +389,23 @@ class TestHFModelAvailabilityCheck:
             ctx_factory(config=pretrained_config("nvidia/Nemotron-Mini-4B-Instruct"))
         )
 
+        assert any(i.code == "hf_model_cache_incomplete" and i.severity == "warning" for i in issues)
+
+    @pytest.mark.parametrize("offline_var", ["HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE"])
+    def test_partial_cached_snapshot_errors_when_offline(
+        self, hf_cached_snapshot_factory, offline_var, pretrained_config, ctx_factory, monkeypatch
+    ):
+        """Offline incomplete-cache severity intentionally tracks HF offline env-var semantics."""
+        cache_root, _ = hf_cached_snapshot_factory(files=("config.json", "tokenizer.json"))
+        self._use_cache_root(monkeypatch, cache_root)
+        monkeypatch.setenv(offline_var, "1")
+
+        issues = HFModelAvailabilityCheck().run(
+            ctx_factory(config=pretrained_config("nvidia/Nemotron-Mini-4B-Instruct"))
+        )
+
         assert any(i.code == "hf_model_cache_incomplete" and i.severity == "error" for i in issues)
+        assert not any(i.code == "hf_token_missing" for i in issues)
 
     @pytest.mark.parametrize("offline_var", ["HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE"])
     def test_missing_trusted_remote_code_errors_when_offline(


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `make format && make check` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Incomplete Hugging Face model cache now emits a warning instead of an error in normal mode; offline mode still produces an error. Users are informed that model loading may contact Hugging Face if components are missing.

* **Tests**
  * Preflight validation tests updated to expect warnings for incomplete cached model snapshots.

* **Documentation**
  * Troubleshooting guidance clarified to reflect the new warning/error behavior and offline-mode error condition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Safe-Synthesizer/pull/508?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->