### PR TITLE
fix: set default theta parameter

### DIFF
--- a/src/nemo_safe_synthesizer/training/huggingface_backend.py
+++ b/src/nemo_safe_synthesizer/training/huggingface_backend.py
@@ -270,6 +270,8 @@ class HuggingFaceBackend(TrainingBackend):
             theta = getattr(rope_scaling, "theta", None)
         if not isinstance(theta, (int, float)):
             theta = getattr(self.autoconfig, "rope_theta", DEFAULT_ROPE_THETA)
+        if not isinstance(theta, (int, float)):
+            theta = DEFAULT_ROPE_THETA
 
         rope_parameters["rope_theta"] = float(theta)
 

--- a/src/nemo_safe_synthesizer/training/huggingface_backend.py
+++ b/src/nemo_safe_synthesizer/training/huggingface_backend.py
@@ -270,8 +270,6 @@ class HuggingFaceBackend(TrainingBackend):
             theta = getattr(rope_scaling, "theta", None)
         if not isinstance(theta, (int, float)):
             theta = getattr(self.autoconfig, "rope_theta", DEFAULT_ROPE_THETA)
-        if not isinstance(theta, (int, float)):
-            theta = DEFAULT_ROPE_THETA
 
         rope_parameters["rope_theta"] = float(theta)
 

--- a/src/nemo_safe_synthesizer/training/huggingface_backend.py
+++ b/src/nemo_safe_synthesizer/training/huggingface_backend.py
@@ -82,6 +82,7 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
+DEFAULT_ROPE_THETA = 10000.0
 
 FIXED_RUNTIME_TRAINING_ARGS = {
     # the training time is set by the number of training records
@@ -132,6 +133,7 @@ class HuggingFaceBackend(TrainingBackend):
         self.autoconfig.max_position_embeddings = (
             model_args.pop("max_seq_length", None) or self.model_metadata.max_seq_length
         )
+        self._normalize_rope_parameters()
         self.model = self.model_loader_type.from_pretrained(**self.framework_load_params, config=self.autoconfig)
 
         self.tokenizer: PreTrainedTokenizer = add_bos_eos_tokens_to_tokenizer(
@@ -255,6 +257,23 @@ class HuggingFaceBackend(TrainingBackend):
         scheme = self._resolve_quantization_scheme()
         logger.info(f"Quantizing model with scheme={scheme.value}")
         return get_quantization_config(scheme)
+
+    def _normalize_rope_parameters(self) -> None:
+        """Ensure Transformers v5 ``rope_parameters`` includes ``rope_theta``."""
+        rope_parameters = getattr(self.autoconfig, "rope_parameters", None)
+        if not isinstance(rope_parameters, dict) or "rope_theta" in rope_parameters:
+            return
+
+        theta = rope_parameters.get("theta")
+        if not isinstance(theta, (int, float)):
+            rope_scaling = getattr(self.model_metadata, "rope_scaling", None)
+            theta = getattr(rope_scaling, "theta", None)
+        if not isinstance(theta, (int, float)):
+            theta = getattr(self.autoconfig, "rope_theta", DEFAULT_ROPE_THETA)
+        if not isinstance(theta, (int, float)):
+            theta = DEFAULT_ROPE_THETA
+
+        rope_parameters["rope_theta"] = float(theta)
 
     def _apply_rope_scaling(self, framework_params: dict, **kwargs: Any) -> None:
         """Apply rope scaling from model_metadata to the config.

--- a/tests/training/test_huggingface_backend.py
+++ b/tests/training/test_huggingface_backend.py
@@ -570,6 +570,8 @@ class TestApplyRopeScaling:
             "factor": 5.0,
         }
 
+
+class TestNormalizeRopeParameters:
     def test_normalizes_rope_parameters_theta_key(self, backend):
         """Test that legacy theta is copied to Transformers v5 rope_theta."""
         backend.model_metadata.rope_scaling = None

--- a/tests/training/test_huggingface_backend.py
+++ b/tests/training/test_huggingface_backend.py
@@ -570,6 +570,36 @@ class TestApplyRopeScaling:
             "factor": 5.0,
         }
 
+    def test_normalizes_rope_parameters_theta_key(self, backend):
+        """Test that legacy theta is copied to Transformers v5 rope_theta."""
+        backend.model_metadata.rope_scaling = None
+        backend.autoconfig.rope_scaling = None
+        backend.autoconfig.rope_parameters = {"rope_type": "default", "theta": 50000.0}
+
+        backend._normalize_rope_parameters()
+
+        assert backend.autoconfig.rope_parameters == {
+            "rope_type": "default",
+            "theta": 50000.0,
+            "rope_theta": 50000.0,
+        }
+
+    def test_normalizes_rope_parameters_from_metadata(self, backend):
+        """Test that model metadata supplies theta when rope_parameters lacks it."""
+        from nemo_safe_synthesizer.llm.metadata import RopeScaling
+
+        backend.model_metadata.rope_scaling = RopeScaling(rope_type="yarn", factor=4.0, theta=1500000.0)
+        backend.autoconfig.rope_scaling = {"rope_type": "yarn", "factor": 4.0}
+        backend.autoconfig.rope_parameters = {"rope_type": "yarn", "factor": 4.0}
+
+        backend._normalize_rope_parameters()
+
+        assert backend.autoconfig.rope_parameters == {
+            "rope_type": "yarn",
+            "factor": 4.0,
+            "rope_theta": 1500000.0,
+        }
+
 
 class TestBuildBaseTrainingArgs:
     def test_builds_correct_args_no_validation(self, backend):


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [x] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RoPE (Rotary Position Embedding) parameter handling during model loading to ensure a numeric rope_theta is populated from legacy and current configuration sources, with a sensible default fallback when absent.

* **Tests**
  * Added unit tests verifying RoPE parameter normalization across different model configuration formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Safe-Synthesizer/pull/509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->