### PR TITLE
chore: Add workflow to add area labels to PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# ---------------------------------------------------------------------------
+# Rules for actions/labeler@v6. Consumed by .github/workflows/labeler.yml.
+#
+# Each top-level key is a label name (must exist in the repo). The rules
+# below apply the label when ANY changed file in the PR matches ANY of the
+# listed globs (any-glob-to-any-file semantics).
+#
+# The product-area mapping mirrors the module map in AGENTS.md. Infrastructure
+# areas cover repo-wide concerns (CI, tests, docs, dev-ex, build/dist).
+#
+# Adding a new area label:
+#   1. Add it to CONTRIBUTING.md (canonical list).
+#   2. Create it in the GitHub UI.
+#   3. Add an entry here with the file globs that should trigger it.
+# ---------------------------------------------------------------------------
+
+# -- Product areas (mirror src/nemo_safe_synthesizer/ module map) ------------
+
+"area:sdk-cli":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/nemo_safe_synthesizer/cli/**"
+          - "src/nemo_safe_synthesizer/sdk/**"
+          - "src/nemo_safe_synthesizer/__main__.py"
+
+"area:config":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/nemo_safe_synthesizer/config/**"
+          - "src/nemo_safe_synthesizer/configurator/**"
+          - "src/nemo_safe_synthesizer/defaults.py"
+
+"area:data-processing":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/nemo_safe_synthesizer/data_processing/**"
+          - "src/nemo_safe_synthesizer/holdout/**"
+          - "src/nemo_safe_synthesizer/artifacts/**"
+          - "src/nemo_safe_synthesizer/preflight/**"
+
+"area:evaluation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/nemo_safe_synthesizer/evaluation/**"
+          - "src/nemo_safe_synthesizer/results.py"
+          - "src/nemo_safe_synthesizer/tooling/**"
+
+"area:generation":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/nemo_safe_synthesizer/generation/**"
+
+"area:training":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/nemo_safe_synthesizer/training/**"
+
+"area:pii":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/nemo_safe_synthesizer/pii_replacer/**"
+
+"area:privacy":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/nemo_safe_synthesizer/privacy/**"
+
+"area:llm":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/nemo_safe_synthesizer/llm/**"
+
+"area:observability":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "src/nemo_safe_synthesizer/observability.py"
+          - "src/nemo_safe_synthesizer/telemetry.py"
+
+# -- Infrastructure areas ----------------------------------------------------
+
+"area:tests":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "tests/**"
+          - "pytest.ini"
+
+"area:docs":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "docs/**"
+          - "mkdocs.yml"
+          - "README.md"
+          - "CITATION.md"
+          - "CODE_OF_CONDUCT.md"
+          - "SECURITY.md"
+          - "THIRD_PARTY.md"
+          - "design.md"
+          - "src/nemo_safe_synthesizer/**/*.md"
+
+"area:ci":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".github/workflows/**"
+          - ".github/actions/**"
+          - ".github/dependabot.yml"
+          - ".github/copy-pr-bot.yaml"
+          - ".github/labeler.yml"
+          - ".github/CODEOWNERS"
+          - ".github/ISSUE_TEMPLATE/**"
+          - ".github/PULL_REQUEST_TEMPLATE.md"
+
+"area:dev-ex":
+  - changed-files:
+      - any-glob-to-any-file:
+          - ".agents/**"
+          - ".cursor/**"
+          - ".claude/**"
+          - "AGENTS.md"
+          - "AGENTS.local.md"
+          - "CLAUDE.md"
+          - "CONTRIBUTING.md"
+          - "STYLE_GUIDE.md"
+          - "Makefile"
+          - "tools/**"
+          - "ruff.toml"
+
+"area:build-dist":
+  - changed-files:
+      - any-glob-to-any-file:
+          - "pyproject.toml"
+          - "uv.lock"
+          - "constraints.txt"
+          - "mise.lock"
+          - "containers/**"
+          - "src/nemo_safe_synthesizer/package_info.py"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -86,6 +86,7 @@
       - any-glob-to-any-file:
           - "tests/**"
           - "pytest.ini"
+          - "script/slurm/**"
 
 "area:docs":
   - changed-files:
@@ -103,14 +104,7 @@
 "area:ci":
   - changed-files:
       - any-glob-to-any-file:
-          - ".github/workflows/**"
-          - ".github/actions/**"
-          - ".github/dependabot.yml"
-          - ".github/copy-pr-bot.yaml"
-          - ".github/labeler.yml"
-          - ".github/CODEOWNERS"
-          - ".github/ISSUE_TEMPLATE/**"
-          - ".github/PULL_REQUEST_TEMPLATE.md"
+          - ".github/**"
 
 "area:dev-ex":
   - changed-files:
@@ -126,6 +120,8 @@
           - "Makefile"
           - "tools/**"
           - "ruff.toml"
+          - ".mise.toml"
+          - "mise.lock"
 
 "area:build-dist":
   - changed-files:
@@ -133,6 +129,5 @@
           - "pyproject.toml"
           - "uv.lock"
           - "constraints.txt"
-          - "mise.lock"
           - "containers/**"
           - "src/nemo_safe_synthesizer/package_info.py"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,48 @@
+# Copyright (c) 2024-2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# ---------------------------------------------------------------------------
+# Auto-applies area:* labels to PRs based on the files changed, using the
+# rules in .github/labeler.yml. Runs on pull_request_target so it can write
+# labels on PRs opened from forks; it only reads PR metadata (no checkout of
+# untrusted PR code).
+#
+# sync-labels is false: labels are additive only. Maintainers can add,
+# remove, or override area:* labels manually without the action undoing
+# their changes on the next push.
+# ---------------------------------------------------------------------------
+
+name: PR labeler
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: labeler-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  label:
+    name: Apply area labels
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -375,7 +375,9 @@ Roughly aligned with our Conventional Commit types. Apply when it adds signal; m
 
 #### Area
 
-Where in the codebase the work lands. Apply one or more on PRs to help routing; optional on issues.
+Where in the codebase the work lands. Optional on issues.
+
+On PRs, `area:*` labels are auto-applied based on the files changed, using the rules in [`.github/labeler.yml`](.github/labeler.yml). Labels are additive only -- maintainers can add, remove, or override them manually, and the action will not undo manual changes on subsequent pushes. Update the labeler rules in the same PR that introduces new modules or area labels.
 
 Product areas mirror the `src/nemo_safe_synthesizer/` module map in [`AGENTS.md`](AGENTS.md):
 


### PR DESCRIPTION
# Summary

Follow up on #503 to automate adding area:* labels to PRs.

## Pre-Review Checklist

Github workflow only changes, python tests are not relevant.

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated PR labeling system that categorizes pull requests by product and infrastructure areas (e.g., SDK/CLI, config, data processing, evaluation, generation, training, PII, privacy, LLM, observability, tests, docs, CI, dev experience, build).  
* **Documentation**
  * Updated contributor guidance to clarify that area labels are auto-applied based on changed files and are additive (maintainers may adjust manually).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->