### PR TITLE
chore: Mitigate vulnerability in diskcache

### DIFF
--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -92,13 +92,16 @@ def _secure_outlines_cache_dir() -> None:
         os.environ["OUTLINES_CACHE_DIR"] = str(cache_dir)
 
     try:
+        # Set the umask to 077 to prevent other principals from writing to the
+        # cache directory between the mkdir and chmod calls.
         old_umask = os.umask(0o077)
         try:
             cache_dir.mkdir(parents=True, exist_ok=True)
         finally:
             os.umask(old_umask)
+        # Also explicitly set permissions to 0700 for the situation where the
+        # directory already exists and is not 0700.
         cache_dir.chmod(0o700)
-    except OSError as exc:
     except OSError as exc:
         logger.warning(
             "Could not enforce 0700 permissions on outlines cache dir %s: %s. "

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -92,8 +92,13 @@ def _secure_outlines_cache_dir() -> None:
         os.environ["OUTLINES_CACHE_DIR"] = str(cache_dir)
 
     try:
-        cache_dir.mkdir(parents=True, exist_ok=True)
+        old_umask = os.umask(0o077)
+        try:
+            cache_dir.mkdir(parents=True, exist_ok=True)
+        finally:
+            os.umask(old_umask)
         cache_dir.chmod(0o700)
+    except OSError as exc:
     except OSError as exc:
         logger.warning(
             "Could not enforce 0700 permissions on outlines cache dir %s: %s. "

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -7,8 +7,10 @@ from __future__ import annotations
 
 import logging
 import os
+import tempfile
 import time
 from functools import partial
+from pathlib import Path
 from typing import Any, cast
 
 import torch
@@ -47,6 +49,62 @@ else:
 # for the supported NSS models, so default the warmup off; users can still opt
 # in by exporting VLLM_USE_DEEP_GEMM=1.
 os.environ.setdefault("VLLM_USE_DEEP_GEMM", "0")
+
+# CVE-2025-69872: diskcache (pulled in transitively by outlines and used by
+# vLLM's optional on-disk outlines cache) deserializes cached values with
+# pickle/cloudpickle and is therefore RCE-vulnerable if another principal can
+# write into the cache directory. Neither library exposes a way to swap the
+# serializer, so we mitigate at the boundary:
+#   1. Keep vLLM's opt-in diskcache off (its default is an in-memory LRUCache).
+#      Hard-set (not setdefault) so a user env can't silently flip on a
+#      pickle-deserializing code path.
+#   2. Pin OUTLINES_CACHE_DIR to a per-user path and chmod it to 0700, since
+#      outlines always uses diskcache for its FSM/index cache.
+os.environ["VLLM_V1_USE_OUTLINES_CACHE"] = "0"
+
+
+def _secure_outlines_cache_dir() -> None:
+    """Pin ``OUTLINES_CACHE_DIR`` to a per-user path and tighten permissions.
+
+    Respects an explicit ``OUTLINES_CACHE_DIR`` set by the operator (so CI and
+    multi-tenant deployments can choose their own private location), but always
+    creates the directory with 0700 permissions to prevent co-tenants from
+    poisoning the diskcache (CVE-2025-69872).
+
+    When unset, picks a per-user path under ``$XDG_CACHE_HOME`` or
+    ``$HOME/.cache`` and falls back to a UID-scoped subdir of the system temp
+    dir for distroless/rootless containers where ``$HOME`` is ``/``.
+    """
+    cache_dir_env = os.environ.get("OUTLINES_CACHE_DIR")
+    if cache_dir_env:
+        cache_dir = Path(cache_dir_env)
+    else:
+        xdg_cache_home = os.environ.get("XDG_CACHE_HOME")
+        home_dir = os.path.normpath(os.path.expanduser("~"))
+        if xdg_cache_home:
+            cache_root = Path(xdg_cache_home)
+        elif home_dir != "/" and Path(home_dir).is_dir():
+            cache_root = Path(home_dir) / ".cache"
+        else:
+            uid = getattr(os, "getuid", lambda: "default")()
+            cache_root = Path(tempfile.gettempdir()) / f".cache-{uid}"
+        cache_dir = cache_root / "nemo-safe-synthesizer" / "outlines"
+        os.environ["OUTLINES_CACHE_DIR"] = str(cache_dir)
+
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_dir.chmod(0o700)
+    except OSError as exc:
+        logger.warning(
+            "Could not enforce 0700 permissions on outlines cache dir %s: %s. "
+            "If this path is shared with other principals, set OUTLINES_CACHE_DIR "
+            "to a private location (CVE-2025-69872).",
+            cache_dir,
+            exc,
+        )
+
+
+_secure_outlines_cache_dir()
 
 
 def _is_redis_available() -> bool:

--- a/tests/generation/test_vllm_backend.py
+++ b/tests/generation/test_vllm_backend.py
@@ -581,7 +581,7 @@ class TestSecureOutlinesCacheDir:
 
     def test_vllm_outlines_diskcache_is_disabled(self):
         """Module import must hard-disable the vLLM opt-in diskcache."""
-        import nemo_safe_synthesizer.generation.vllm_backend  # noqa: F401  -- ensure module is imported
+        from nemo_safe_synthesizer.generation import vllm_backend  # noqa: F401  -- ensure module is imported
 
         assert os.environ.get("VLLM_V1_USE_OUTLINES_CACHE") == "0"
 

--- a/tests/generation/test_vllm_backend.py
+++ b/tests/generation/test_vllm_backend.py
@@ -3,6 +3,7 @@
 
 """Unit tests for the VllmBackend class private methods and module-level side effects."""
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -550,6 +551,39 @@ class TestNoopRemoteCacheBackend:
         fake_redis = MagicMock()
         with patch.dict("sys.modules", {"redis": fake_redis}):
             assert _is_redis_available() is True
+
+
+class TestSecureOutlinesCacheDir:
+    """Tests for the CVE-2025-69872 outlines diskcache hardening."""
+
+    def test_chmods_existing_cache_dir_to_0700(self, tmp_path, monkeypatch):
+        """``_secure_outlines_cache_dir`` tightens permissions on a permissive dir.
+
+        Exercises the explicit-OUTLINES_CACHE_DIR branch: simulates a co-tenant-
+        writable cache directory (mode 0777) and asserts the helper locks it down
+        to 0700, which is the precondition CVE-2025-69872 needs to fail.
+        """
+        import stat
+
+        from nemo_safe_synthesizer.generation.vllm_backend import _secure_outlines_cache_dir
+
+        cache_dir = tmp_path / "outlines-cache"
+        cache_dir.mkdir()
+        cache_dir.chmod(0o777)
+        assert stat.S_IMODE(cache_dir.stat().st_mode) == 0o777, "precondition: dir starts world-writable"
+
+        monkeypatch.setenv("OUTLINES_CACHE_DIR", str(cache_dir))
+
+        _secure_outlines_cache_dir()
+
+        assert stat.S_IMODE(cache_dir.stat().st_mode) == 0o700
+        assert os.environ["OUTLINES_CACHE_DIR"] == str(cache_dir)
+
+    def test_vllm_outlines_diskcache_is_disabled(self):
+        """Module import must hard-disable the vLLM opt-in diskcache."""
+        import nemo_safe_synthesizer.generation.vllm_backend  # noqa: F401  -- ensure module is imported
+
+        assert os.environ.get("VLLM_V1_USE_OUTLINES_CACHE") == "0"
 
 
 class TestGroupedGenerationStopKwargs:


### PR DESCRIPTION
# Summary

Mitigate CVE-2025-69872 in diskcache, a transitive dep for safe synthesizer. Since the consumers (vllm and outlines) do not provide ways to control the deserialization, we address the vulnerability via env vars for explicit cache location and file permissions.

If any of vllm, outlines, diskcache directly resolve the vulnerability in the future, we should revert this PR.

## Pre-Review Checklist


Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [x] `make test` passes locally
- [x] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

- Resolves https://github.com/NVIDIA-NeMo/Safe-Synthesizer/security/dependabot/2


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Hardened local cache handling to mitigate CVE-2025-69872 by disabling the unsafe global outlines cache at startup and enforcing per-user cache isolation.
  * Respects an explicitly configured cache location; otherwise selects a private per-user cache and attempts to set restrictive permissions.
  * Emits a startup warning if permission tightening cannot be enforced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Safe-Synthesizer/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->