### PR TITLE
chore: final code quality cleanup

### DIFF
--- a/src/nemo_safe_synthesizer/data_processing/actions/dates.py
+++ b/src/nemo_safe_synthesizer/data_processing/actions/dates.py
@@ -416,7 +416,7 @@ def fit_and_transform_dates(
         ``transform_dates`` for reversal.
     """
     date_min_dict = {}
-    object_cols = [col for col, col_type in df.dtypes.iteritems() if col_type == "object"]
+    object_cols = [col for col, col_type in df.dtypes.items() if col_type == "object"]
     result_df = df.copy() if not inplace else df
     for object_col in object_cols:
         no_nans = result_df[object_col].dropna(axis=0).reset_index(drop=True)
@@ -425,7 +425,7 @@ def fit_and_transform_dates(
             if inferred_format:
                 try:
                     inferred_format = inferred_format.replace("!", "")
-                    dates = pd.to_datetime(result_df.loc[:, object_col], format=inferred_format)
+                    dates = pd.to_datetime(result_df[object_col], format=inferred_format)
                     min_date = dates.min()
                     result_df[object_col] = (dates - min_date).dt.total_seconds()
                     date_min_dict[object_col] = {

--- a/src/nemo_safe_synthesizer/evaluation/components/text_semantic_similarity.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/text_semantic_similarity.py
@@ -250,7 +250,6 @@ class TextSemanticSimilarity(Component):
                     return SentenceTransformer("distiluse-base-multilingual-cased-v2")
         except RetryError:
             return None
-        return None
 
     @staticmethod
     def _get_embedding_vectors(

--- a/src/nemo_safe_synthesizer/pii_replacer/ner/labels.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/ner/labels.py
@@ -67,7 +67,7 @@ class LabelEvaluator:
     def _matches_any_regex(self, label: str):
         return any(regex.match(label) for regex in self._label_regexes)
 
-    def explicit_lables(self) -> set[str]:
+    def explicit_labels(self) -> set[str]:
         return self._explicit_labels
 
     @classmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -264,7 +264,6 @@ def load_test_dataframe(filename: str, datasets_dir: Path) -> pd.DataFrame:
 
         case _:
             raise ValueError(f"Unknown dataset format: {dataset_path.suffix}")
-    raise AssertionError("unreachable")
 
 
 @pytest.fixture(scope="session")

--- a/tools/codestyle/copyright_fixer.py
+++ b/tools/codestyle/copyright_fixer.py
@@ -283,7 +283,11 @@ def update_license_headers(
         return filepath
 
     if check:
-        missing = [f for f in files if _read_head(f) and not _has_header(_read_head(f))]
+        missing: list[str] = []
+        for f in files:
+            head = _read_head(f)
+            if head and not _has_header(head):
+                missing.append(f)
         if missing:
             typer.echo(f"Found {len(missing)} file(s) missing copyright headers:")
             for f in missing:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `make format && make check` or via prek validation.
- [x] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Corrected misspelled method name in label evaluation accessor.
  * Enhanced error handling to provide clearer feedback for unsupported dataset file formats.
  * Resolved deprecated library operations for improved compatibility.

* **Performance**
  * Optimized file header checking to reduce redundant file operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Safe-Synthesizer/pull/521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->