### PR TITLE
feat: expand vLLM observability/telemetry

### DIFF
--- a/src/nemo_safe_synthesizer/cli/wandb_setup.py
+++ b/src/nemo_safe_synthesizer/cli/wandb_setup.py
@@ -22,7 +22,7 @@ from ..observability import get_logger
 from .artifact_structure import Workdir
 
 if TYPE_CHECKING:
-    from ..generation.vllm_observability import CellObservability
+    from ..generation.vllm_observability import GenerationObservability
 
 logger = get_logger(__name__)
 
@@ -268,15 +268,15 @@ def initialize_wandb_run(
         logger.info(f"Wandb run url: {wandb.run.url if wandb.run else 'None'}")
 
 
-def log_cell_observability(event: CellObservability, prefix: str = "vllm_cell") -> None:
-    """Log a ``CellObservability`` event to the currently active wandb run.
+def log_generation_observability(event: GenerationObservability, prefix: str = "vllm_gen") -> None:
+    """Log a ``GenerationObservability`` event to the currently active wandb run.
 
     No-op when no wandb run is active (``WANDB_MODE=disabled`` or the
     pipeline hasn't called :func:`initialize_wandb_run`). Errors during
     ``wandb.log`` are swallowed at warning level — observability is
     best-effort, and a wandb failure must not break generation.
 
-    ``CellObservability`` is imported under ``TYPE_CHECKING`` only; with
+    ``GenerationObservability`` is imported under ``TYPE_CHECKING`` only; with
     ``from __future__ import annotations`` the annotation stays a string,
     so this CLI module keeps importing without eagerly pulling in the
     generation subpackage.
@@ -286,4 +286,4 @@ def log_cell_observability(event: CellObservability, prefix: str = "vllm_cell") 
     try:
         wandb.log(event.to_wandb_payload(prefix=prefix))
     except Exception as exc:  # noqa: BLE001 — degraded mode
-        logger.warning(f"failed to log cell observability to wandb: {exc}")
+        logger.warning(f"failed to log generation observability to wandb: {exc}")

--- a/src/nemo_safe_synthesizer/cli/wandb_setup.py
+++ b/src/nemo_safe_synthesizer/cli/wandb_setup.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 import wandb
 from pydantic import AliasChoices, Field, field_validator
@@ -20,9 +20,6 @@ from pydantic_settings import BaseSettings
 from ..config import SafeSynthesizerParameters
 from ..observability import get_logger
 from .artifact_structure import Workdir
-
-if TYPE_CHECKING:
-    from ..generation.vllm_observability import GenerationObservability
 
 logger = get_logger(__name__)
 
@@ -268,22 +265,37 @@ def initialize_wandb_run(
         logger.info(f"Wandb run url: {wandb.run.url if wandb.run else 'None'}")
 
 
-def log_generation_observability(event: GenerationObservability, prefix: str = "vllm_gen") -> None:
-    """Log a ``GenerationObservability`` event to the currently active wandb run.
+class WandbLoggable(Protocol):
+    """Structural type for observability events that can be logged to wandb.
 
-    No-op when no wandb run is active (``WANDB_MODE=disabled`` or the
-    pipeline hasn't called :func:`initialize_wandb_run`). Errors during
-    ``wandb.log`` are swallowed at warning level — observability is
-    best-effort, and a wandb failure must not break generation.
+    Any event exposing ``to_wandb_payload(prefix) -> dict`` satisfies this --
+    e.g. ``TrainingObservability`` and the generation-side
+    ``GenerationObservability``. Using a Protocol keeps :func:`log_observability_event`
+    decoupled from the concrete event types (no import of the training/generation
+    subpackages from this CLI module).
+    """
 
-    ``GenerationObservability`` is imported under ``TYPE_CHECKING`` only; with
-    ``from __future__ import annotations`` the annotation stays a string,
-    so this CLI module keeps importing without eagerly pulling in the
-    generation subpackage.
+    def to_wandb_payload(self, prefix: str = ...) -> dict[str, Any]: ...
+
+
+def log_observability_event(event: WandbLoggable, prefix: str) -> None:
+    """Log an observability event to the currently active wandb run.
+
+    Generic sink shared by the training and generation observability paths.
+    No-op when no wandb run is active (``WANDB_MODE=disabled`` or the pipeline
+    hasn't called :func:`initialize_wandb_run`). Errors during ``wandb.log`` are
+    swallowed at warning level -- observability is best-effort and a wandb
+    failure must not break the run.
+
+    Args:
+        event: Any object exposing ``to_wandb_payload(prefix) -> dict`` (see
+            :class:`WandbLoggable`).
+        prefix: wandb key namespace for this event's metrics (e.g. ``"training"``
+            or ``"vllm_gen"``).
     """
     if wandb.run is None:
         return
     try:
         wandb.log(event.to_wandb_payload(prefix=prefix))
-    except Exception as exc:  # noqa: BLE001 — degraded mode
-        logger.warning(f"failed to log generation observability to wandb: {exc}")
+    except Exception as exc:  # noqa: BLE001 -- degraded mode
+        logger.warning(f"failed to log observability event ({prefix!r}) to wandb: {exc}")

--- a/src/nemo_safe_synthesizer/cli/wandb_setup.py
+++ b/src/nemo_safe_synthesizer/cli/wandb_setup.py
@@ -275,7 +275,7 @@ class WandbLoggable(Protocol):
     subpackages from this CLI module).
     """
 
-    def to_wandb_payload(self, prefix: str = ...) -> dict[str, Any]: ...
+    def to_wandb_payload(self, prefix: str = "") -> dict[str, Any]: ...
 
 
 def log_observability_event(event: WandbLoggable, prefix: str) -> None:

--- a/src/nemo_safe_synthesizer/cli/wandb_setup.py
+++ b/src/nemo_safe_synthesizer/cli/wandb_setup.py
@@ -21,6 +21,9 @@ from ..config import SafeSynthesizerParameters
 from ..observability import get_logger
 from .artifact_structure import Workdir
 
+if TYPE_CHECKING:
+    from ..generation.vllm_observability import CellObservability
+
 logger = get_logger(__name__)
 
 
@@ -265,7 +268,7 @@ def initialize_wandb_run(
         logger.info(f"Wandb run url: {wandb.run.url if wandb.run else 'None'}")
 
 
-def log_cell_observability(event: Any, prefix: str = "vllm_cell") -> None:
+def log_cell_observability(event: CellObservability, prefix: str = "vllm_cell") -> None:
     """Log a ``CellObservability`` event to the currently active wandb run.
 
     No-op when no wandb run is active (``WANDB_MODE=disabled`` or the
@@ -273,20 +276,14 @@ def log_cell_observability(event: Any, prefix: str = "vllm_cell") -> None:
     ``wandb.log`` are swallowed at warning level — observability is
     best-effort, and a wandb failure must not break generation.
 
-    Accepts ``Any`` typing for ``event`` to avoid a hard import of
-    ``CellObservability`` at module load time (keeps this CLI module
-    importable without the generation subpackage). Callers must pass a
-    ``CellObservability`` instance (anything with a
-    ``to_wandb_payload(prefix)`` method works at runtime).
+    ``CellObservability`` is imported under ``TYPE_CHECKING`` only; with
+    ``from __future__ import annotations`` the annotation stays a string,
+    so this CLI module keeps importing without eagerly pulling in the
+    generation subpackage.
     """
     if wandb.run is None:
         return
     try:
-        payload = event.to_wandb_payload(prefix=prefix)
-    except Exception as exc:  # noqa: BLE001 — degraded mode
-        logger.warning(f"observability event has no to_wandb_payload: {exc}")
-        return
-    try:
-        wandb.log(payload)
+        wandb.log(event.to_wandb_payload(prefix=prefix))
     except Exception as exc:  # noqa: BLE001 — degraded mode
         logger.warning(f"failed to log cell observability to wandb: {exc}")

--- a/src/nemo_safe_synthesizer/cli/wandb_setup.py
+++ b/src/nemo_safe_synthesizer/cli/wandb_setup.py
@@ -275,7 +275,8 @@ class WandbLoggable(Protocol):
     subpackages from this CLI module).
     """
 
-    def to_wandb_payload(self, prefix: str = "") -> dict[str, Any]: ...
+    def to_wandb_payload(self, prefix: str = "") -> dict[str, Any]:
+        """Return wandb metrics for this event, namespaced under ``prefix``."""
 
 
 def log_observability_event(event: WandbLoggable, prefix: str) -> None:

--- a/src/nemo_safe_synthesizer/cli/wandb_setup.py
+++ b/src/nemo_safe_synthesizer/cli/wandb_setup.py
@@ -263,3 +263,30 @@ def initialize_wandb_run(
     logger.info(f"Wandb run id: {wandb.run.id if wandb.run else 'None'}")
     if settings.wandb_mode != WandbMode.DISABLED:
         logger.info(f"Wandb run url: {wandb.run.url if wandb.run else 'None'}")
+
+
+def log_cell_observability(event: Any, prefix: str = "vllm_cell") -> None:
+    """Log a ``CellObservability`` event to the currently active wandb run.
+
+    No-op when no wandb run is active (``WANDB_MODE=disabled`` or the
+    pipeline hasn't called :func:`initialize_wandb_run`). Errors during
+    ``wandb.log`` are swallowed at warning level — observability is
+    best-effort, and a wandb failure must not break generation.
+
+    Accepts ``Any`` typing for ``event`` to avoid a hard import of
+    ``CellObservability`` at module load time (keeps this CLI module
+    importable without the generation subpackage). Callers must pass a
+    ``CellObservability`` instance (anything with a
+    ``to_wandb_payload(prefix)`` method works at runtime).
+    """
+    if wandb.run is None:
+        return
+    try:
+        payload = event.to_wandb_payload(prefix=prefix)
+    except Exception as exc:  # noqa: BLE001 — degraded mode
+        logger.warning(f"observability event has no to_wandb_payload: {exc}")
+        return
+    try:
+        wandb.log(payload)
+    except Exception as exc:  # noqa: BLE001 — degraded mode
+        logger.warning(f"failed to log cell observability to wandb: {exc}")

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -25,7 +25,7 @@ from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 
 from .. import utils
 from ..cli.artifact_structure import Workdir
-from ..cli.wandb_setup import log_generation_observability
+from ..cli.wandb_setup import log_observability_event
 from ..config import SafeSynthesizerParameters
 from ..config.generate import (
     resolve_structured_generation_schema_method,
@@ -795,12 +795,13 @@ class VllmBackend(GeneratorBackend):
             # Mirror to the active wandb run when one exists (no-op when
             # ``WANDB_MODE=disabled`` or ``initialize_wandb_run`` was never
             # called). Best-effort; wandb failures are swallowed downstream.
-            log_generation_observability(gen_event)
+            log_observability_event(gen_event, prefix="vllm_gen")
         except Exception as exc:  # noqa: BLE001 — observability must never break generation
             # Guard the warning itself: a faulty logger handler must not turn a
             # swallowed observability failure into a generation failure.
             with contextlib.suppress(Exception):
-                logger.runtime.warning(
+                logger.runtime.debug(
                     "vllm.generation.observability.emit_failed",
-                    extra={"ctx": {"error": str(exc)}},
+                    extra={"ctx": {"error": f"{exc!r}"}},
+                    exc_info=True,
                 )

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -306,7 +306,7 @@ class VllmBackend(GeneratorBackend):
             )
 
         # Cache the engine's *effective* runtime config once at init. Read by
-        # ``generate()`` to populate the ``vllm.generation.complete`` observability
+        # ``generate()`` to populate the generation-complete observability
         # event; used by the benchmark harness (and any other intent-comparing
         # caller) to detect "flag didn't engage" mismatches against what was
         # asked for.
@@ -653,7 +653,7 @@ class VllmBackend(GeneratorBackend):
         through ``ignore_eos=False``.
 
         Wrapped in an :class:`NvmlPeakSampler` context so a
-        ``vllm.generation.complete`` observability event is emitted at end of
+        generation-complete observability event is emitted at end of
         the call carrying peak device VRAM, host loadavg pre/post, vLLM's
         kv_cache_usage_perc / prefix_cache_hit_rate / spec_accept_rate
         (read at end-of-generation), and the engine's effective runtime
@@ -766,7 +766,7 @@ class VllmBackend(GeneratorBackend):
     def _emit_generation_observability(
         self, sampler: NvmlPeakSampler, loadavg_pre: tuple[float, float, float] | None
     ) -> None:
-        """Assemble and route the ``vllm.generation.complete`` observability event.
+        """Assemble and route the generation-complete observability event.
 
         Reads end-of-generation vLLM metrics plus the NVML peak captured by
         ``sampler``, builds a :class:`GenerationObservability`, and routes it to
@@ -791,7 +791,7 @@ class VllmBackend(GeneratorBackend):
                 # sets the bit when a knob silently fails to engage.
                 flag_did_not_engage=False,
             )
-            logger.runtime.info("vllm.generation.complete", extra={"ctx": gen_event.model_dump()})
+            logger.runtime.info("vLLM generation complete", extra={"ctx": gen_event.model_dump()})
             # Mirror to the active wandb run when one exists (no-op when
             # ``WANDB_MODE=disabled`` or ``initialize_wandb_run`` was never
             # called). Best-effort; wandb failures are swallowed downstream.
@@ -801,7 +801,7 @@ class VllmBackend(GeneratorBackend):
             # swallowed observability failure into a generation failure.
             with contextlib.suppress(Exception):
                 logger.runtime.debug(
-                    "vllm.generation.observability.emit_failed",
+                    "vLLM generation observability emit failed",
                     extra={"ctx": {"error": f"{exc!r}"}},
                     exc_info=True,
                 )

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -36,6 +36,13 @@ from ..generation.batch import Batch
 from ..generation.processors import Processor, TabularDataProcessor, create_processor
 from ..generation.regex_manager import build_json_based_regex, build_json_structural_tag
 from ..generation.results import GenerateJobResults, GenerationBatches, GenerationStatus
+from ..generation.vllm_observability import (
+    CellObservability,
+    NvmlPeakSampler,
+    probe_engine_runtime_config,
+    read_loadavg,
+    read_vllm_runtime_metrics,
+)
 from ..llm.metadata import ModelMetadata
 from ..llm.utils import ModelRef, cleanup_memory, get_max_vram
 from ..observability import get_logger, heartbeat
@@ -291,6 +298,13 @@ class VllmBackend(GeneratorBackend):
                 attention_config=attention_config,
                 trust_remote_code=model_ref.trust_remote_code,
             )
+
+        # Cache the engine's *effective* runtime config once at init. Read by
+        # ``generate()`` to populate the ``vllm.cell.complete`` observability
+        # event; used by the benchmark harness (and any other intent-comparing
+        # caller) to detect "flag didn't engage" mismatches against what was
+        # asked for.
+        self._engine_runtime_config = probe_engine_runtime_config(self.llm)
 
         # vLLM's get_tokenizer() returns a wider union than HF's PreTrainedTokenizerBase;
         # in practice it's always a HF tokenizer subclass, so cast for the processor.
@@ -632,6 +646,14 @@ class VllmBackend(GeneratorBackend):
         only for ``TabularDataProcessor``. Native EOS stopping remains enabled
         through ``ignore_eos=False``.
 
+        Wrapped in an :class:`NvmlPeakSampler` context so a
+        ``vllm.cell.complete`` observability event is emitted at end of
+        the call carrying peak device VRAM, host loadavg pre/post, vLLM's
+        kv_cache_usage_perc / prefix_cache_hit_rate / spec_accept_rate
+        (read at end-of-generation), and the engine's effective runtime
+        config probed at engine-init time. Sampler is degraded-mode when
+        NVML is unavailable; the event still emits with ``peak_vram_gb=None``.
+
         Args:
             data_actions_fn: Optional post-processing / validation function
                 applied to each batch of generated records.
@@ -639,81 +661,118 @@ class VllmBackend(GeneratorBackend):
         Returns:
             Results containing the generated DataFrame and statistics.
         """
+        loadavg_pre = read_loadavg()
+        vram_sampler = NvmlPeakSampler()
+        vram_sampler.__enter__()
         generation_start = time.monotonic()
+        try:
+            need_special_token_outputs = not isinstance(self.processor, TabularDataProcessor)
+            sampling_kwargs = dict(
+                temperature=self.config.generation.temperature,
+                repetition_penalty=self.config.generation.repetition_penalty,
+                top_p=self.config.generation.top_p,
+                top_k=FIXED_RUNTIME_GENERATE_ARGS["top_k"],
+                min_p=FIXED_RUNTIME_GENERATE_ARGS["min_p"],
+                max_tokens=self.model_metadata.generation_max_tokens_for(self._get_prompt_token_count()),
+                skip_special_tokens=not need_special_token_outputs,
+                include_stop_str_in_output=need_special_token_outputs,
+                ignore_eos=False,
+            )
 
-        need_special_token_outputs = not isinstance(self.processor, TabularDataProcessor)
-        sampling_kwargs = dict(
-            temperature=self.config.generation.temperature,
-            repetition_penalty=self.config.generation.repetition_penalty,
-            top_p=self.config.generation.top_p,
-            top_k=FIXED_RUNTIME_GENERATE_ARGS["top_k"],
-            min_p=FIXED_RUNTIME_GENERATE_ARGS["min_p"],
-            max_tokens=self.model_metadata.generation_max_tokens_for(self._get_prompt_token_count()),
-            skip_special_tokens=not need_special_token_outputs,
-            include_stop_str_in_output=need_special_token_outputs,
-            ignore_eos=False,
-        )
+            self.prepare_params(**sampling_kwargs)
 
-        self.prepare_params(**sampling_kwargs)
+            # The batches object collects batches and keeps track of the stopping condition.
+            batches = GenerationBatches(
+                target_num_records=self.config.generation.num_records,
+                invalid_fraction_threshold=self.config.generation.invalid_fraction_threshold,
+                patience=self.config.generation.patience,
+                data_actions_fn=data_actions_fn,
+            )
 
-        # The batches object collects batches and keeps track of the stopping condition.
-        batches = GenerationBatches(
-            target_num_records=self.config.generation.num_records,
-            invalid_fraction_threshold=self.config.generation.invalid_fraction_threshold,
-            patience=self.config.generation.patience,
-            data_actions_fn=data_actions_fn,
-        )
+            with heartbeat(
+                "Generation",
+                logger_name=__name__,
+                target_records=self.config.generation.num_records,
+                progress_note=("Long stretches with no new records are normal."),
+            ):
+                while batches.num_valid_records < self.config.generation.num_records:
+                    # Generate a batch from prompts and process the responses.
+                    num_prompts = batches.get_next_num_prompts()
+                    start_time = time.perf_counter()
+                    batch: Batch = self._generate_batch(
+                        num_prompts_per_batch=num_prompts,
+                        batch=Batch(processor=self.processor),
+                        **sampling_kwargs,
+                    )
+                    duration = time.perf_counter() - start_time
+                    batches.add_batch(batch)
 
-        with heartbeat(
-            "Generation",
-            logger_name=__name__,
-            target_records=self.config.generation.num_records,
-            progress_note=("Long stretches with no new records are normal."),
-        ):
-            while batches.num_valid_records < self.config.generation.num_records:
-                # Generate a batch from prompts and process the responses.
-                num_prompts = batches.get_next_num_prompts()
-                start_time = time.perf_counter()
-                batch: Batch = self._generate_batch(
-                    num_prompts_per_batch=num_prompts,
-                    batch=Batch(processor=self.processor),
-                    **sampling_kwargs,
+                    # Log generation summary and progress.
+                    batch.log_summary(detailed_errors=self.use_detailed_logs)
+                    self._log_batch_timing_and_progress(
+                        batch=batch,
+                        duration=duration,
+                        num_records=self.config.generation.num_records,
+                        num_valid_records=batches.num_valid_records,
+                        batches=batches,
+                    )
+                    # Check if the generation job should stop.
+                    if batches.status in [
+                        GenerationStatus.STOP_NO_RECORDS,
+                        GenerationStatus.STOP_METRIC_REACHED,
+                    ]:
+                        break
+
+            batches.job_complete()
+            batches.log_status()
+
+            max_num_records = (
+                self.config.generation.num_records
+                if self.config.data.group_training_examples_by is None and batches.status == GenerationStatus.COMPLETE
+                else None
+            )
+
+            generation_time_sec = time.monotonic() - generation_start
+            self.elapsed_time = generation_time_sec
+            self.gen_results = GenerateJobResults.from_batches(
+                batches=batches,
+                columns=self.columns,
+                max_num_records=max_num_records,
+                elapsed_time=self.elapsed_time,
+            )
+        finally:
+            # Cleanup + observability emission run regardless of whether
+            # the body raised — sampler thread always shuts down, event
+            # always emits (with whatever measurements were captured up
+            # to the failure point).
+            vram_sampler.__exit__(None, None, None)
+            try:
+                vllm_metrics = read_vllm_runtime_metrics(self.llm)
+            except Exception as exc:  # noqa: BLE001 — degraded mode
+                logger.runtime.warning(
+                    "vllm.cell.observability.metrics_read_failed",
+                    extra={"ctx": {"error": str(exc)}},
                 )
-                duration = time.perf_counter() - start_time
-                batches.add_batch(batch)
-
-                # Log generation summary and progress.
-                batch.log_summary(detailed_errors=self.use_detailed_logs)
-                self._log_batch_timing_and_progress(
-                    batch=batch,
-                    duration=duration,
-                    num_records=self.config.generation.num_records,
-                    num_valid_records=batches.num_valid_records,
-                    batches=batches,
-                )
-                # Check if the generation job should stop.
-                if batches.status in [
-                    GenerationStatus.STOP_NO_RECORDS,
-                    GenerationStatus.STOP_METRIC_REACHED,
-                ]:
-                    break
-
-        batches.job_complete()
-        batches.log_status()
-
-        max_num_records = (
-            self.config.generation.num_records
-            if self.config.data.group_training_examples_by is None and batches.status == GenerationStatus.COMPLETE
-            else None
-        )
-
-        generation_time_sec = time.monotonic() - generation_start
-        self.elapsed_time = generation_time_sec
-        self.gen_results = GenerateJobResults.from_batches(
-            batches=batches,
-            columns=self.columns,
-            max_num_records=max_num_records,
-            elapsed_time=self.elapsed_time,
-        )
+                vllm_metrics = {
+                    "kv_cache_usage_perc": None,
+                    "prefix_cache_hit_rate": None,
+                    "spec_accept_rate": None,
+                }
+            cell_event = CellObservability(
+                peak_vram_gb=vram_sampler.peak_gb,
+                kv_cache_usage_perc=vllm_metrics["kv_cache_usage_perc"],
+                prefix_cache_hit_rate=vllm_metrics["prefix_cache_hit_rate"],
+                spec_accept_rate=vllm_metrics["spec_accept_rate"],
+                loadavg_pre=loadavg_pre,
+                loadavg_post=read_loadavg(),
+                engine_runtime_config=self._engine_runtime_config,
+                # ``flag_did_not_engage`` is the caller's job to compute.
+                # Production has no intended-overrides dict to compare
+                # against; benchmark callers compute the mismatch
+                # against their candidate's ``VllmEngineParameters`` /
+                # equivalent and set the bit if any check fires.
+                flag_did_not_engage=False,
+            )
+            logger.runtime.info("vllm.cell.complete", extra={"ctx": cell_event.model_dump()})
 
         return self.gen_results

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -224,6 +224,10 @@ class VllmBackend(GeneratorBackend):
         )
         self.llm: vLLM | None = None
         self._prompt_token_count: int | None = None
+        # Populated in ``initialize()`` after engine build; pre-declared
+        # here so ``generate()`` can always read it (tests that mock the
+        # backend without calling ``initialize()`` see the empty dict).
+        self._engine_runtime_config: dict[str, Any] = {}
 
         # Do not generate detailed error messages in production to avoid leaking sensitive data.
         self.use_detailed_logs = kwargs.pop("use_detailed_logs", False)

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -24,6 +24,7 @@ from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 
 from .. import utils
 from ..cli.artifact_structure import Workdir
+from ..cli.wandb_setup import log_cell_observability
 from ..config import SafeSynthesizerParameters
 from ..config.generate import (
     resolve_structured_generation_schema_method,
@@ -35,7 +36,6 @@ from ..generation.backend import GeneratorBackend
 from ..generation.batch import Batch
 from ..generation.processors import Processor, TabularDataProcessor, create_processor
 from ..generation.regex_manager import build_json_based_regex, build_json_structural_tag
-from ..cli.wandb_setup import log_cell_observability
 from ..generation.results import GenerateJobResults, GenerationBatches, GenerationStatus
 from ..generation.vllm_observability import (
     CellObservability,

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import tempfile
@@ -24,7 +25,7 @@ from vllm.sampling_params import SamplingParams, StructuredOutputsParams
 
 from .. import utils
 from ..cli.artifact_structure import Workdir
-from ..cli.wandb_setup import log_cell_observability
+from ..cli.wandb_setup import log_generation_observability
 from ..config import SafeSynthesizerParameters
 from ..config.generate import (
     resolve_structured_generation_schema_method,
@@ -38,7 +39,7 @@ from ..generation.processors import Processor, TabularDataProcessor, create_proc
 from ..generation.regex_manager import build_json_based_regex, build_json_structural_tag
 from ..generation.results import GenerateJobResults, GenerationBatches, GenerationStatus
 from ..generation.vllm_observability import (
-    CellObservability,
+    GenerationObservability,
     NvmlPeakSampler,
     probe_engine_runtime_config,
     read_loadavg,
@@ -305,7 +306,7 @@ class VllmBackend(GeneratorBackend):
             )
 
         # Cache the engine's *effective* runtime config once at init. Read by
-        # ``generate()`` to populate the ``vllm.cell.complete`` observability
+        # ``generate()`` to populate the ``vllm.generation.complete`` observability
         # event; used by the benchmark harness (and any other intent-comparing
         # caller) to detect "flag didn't engage" mismatches against what was
         # asked for.
@@ -652,7 +653,7 @@ class VllmBackend(GeneratorBackend):
         through ``ignore_eos=False``.
 
         Wrapped in an :class:`NvmlPeakSampler` context so a
-        ``vllm.cell.complete`` observability event is emitted at end of
+        ``vllm.generation.complete`` observability event is emitted at end of
         the call carrying peak device VRAM, host loadavg pre/post, vLLM's
         kv_cache_usage_perc / prefix_cache_hit_rate / spec_accept_rate
         (read at end-of-generation), and the engine's effective runtime
@@ -676,7 +677,7 @@ class VllmBackend(GeneratorBackend):
             # by ``with`` exit, so ``sampler.peak_gb`` is the final peak, and
             # the event carries whatever measurements were captured up to a
             # failure point.
-            self._emit_cell_observability(sampler, loadavg_pre)
+            self._emit_generation_observability(sampler, loadavg_pre)
 
         return self.gen_results
 
@@ -762,20 +763,20 @@ class VllmBackend(GeneratorBackend):
             elapsed_time=self.elapsed_time,
         )
 
-    def _emit_cell_observability(
+    def _emit_generation_observability(
         self, sampler: NvmlPeakSampler, loadavg_pre: tuple[float, float, float] | None
     ) -> None:
-        """Assemble and route the ``vllm.cell.complete`` observability event.
+        """Assemble and route the ``vllm.generation.complete`` observability event.
 
         Reads end-of-generation vLLM metrics plus the NVML peak captured by
-        ``sampler``, builds a :class:`CellObservability`, and routes it to
+        ``sampler``, builds a :class:`GenerationObservability`, and routes it to
         structured logs and (when a run is active) wandb. Best-effort: any
         failure here is logged and swallowed so observability never masks a
         generation error propagating through :meth:`generate`'s ``finally``.
         """
         try:
             vllm_metrics = read_vllm_runtime_metrics(self.llm)
-            cell_event = CellObservability(
+            gen_event = GenerationObservability(
                 peak_vram_gb=sampler.peak_gb,
                 kv_cache_usage_perc=vllm_metrics["kv_cache_usage_perc"],
                 prefix_cache_hit_rate=vllm_metrics["prefix_cache_hit_rate"],
@@ -790,13 +791,16 @@ class VllmBackend(GeneratorBackend):
                 # sets the bit when a knob silently fails to engage.
                 flag_did_not_engage=False,
             )
-            logger.runtime.info("vllm.cell.complete", extra={"ctx": cell_event.model_dump()})
+            logger.runtime.info("vllm.generation.complete", extra={"ctx": gen_event.model_dump()})
             # Mirror to the active wandb run when one exists (no-op when
             # ``WANDB_MODE=disabled`` or ``initialize_wandb_run`` was never
             # called). Best-effort; wandb failures are swallowed downstream.
-            log_cell_observability(cell_event)
+            log_generation_observability(gen_event)
         except Exception as exc:  # noqa: BLE001 — observability must never break generation
-            logger.runtime.warning(
-                "vllm.cell.observability.emit_failed",
-                extra={"ctx": {"error": str(exc)}},
-            )
+            # Guard the warning itself: a faulty logger handler must not turn a
+            # swallowed observability failure into a generation failure.
+            with contextlib.suppress(Exception):
+                logger.runtime.warning(
+                    "vllm.generation.observability.emit_failed",
+                    extra={"ctx": {"error": str(exc)}},
+                )

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -35,6 +35,7 @@ from ..generation.backend import GeneratorBackend
 from ..generation.batch import Batch
 from ..generation.processors import Processor, TabularDataProcessor, create_processor
 from ..generation.regex_manager import build_json_based_regex, build_json_structural_tag
+from ..cli.wandb_setup import log_cell_observability
 from ..generation.results import GenerateJobResults, GenerationBatches, GenerationStatus
 from ..generation.vllm_observability import (
     CellObservability,
@@ -774,5 +775,10 @@ class VllmBackend(GeneratorBackend):
                 flag_did_not_engage=False,
             )
             logger.runtime.info("vllm.cell.complete", extra={"ctx": cell_event.model_dump()})
+            # Also log to the active wandb run when one exists (no-op
+            # when ``WANDB_MODE=disabled`` or ``initialize_wandb_run``
+            # hasn't been called). Best-effort; wandb failures don't
+            # propagate.
+            log_cell_observability(cell_event)
 
         return self.gen_results

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -667,122 +667,136 @@ class VllmBackend(GeneratorBackend):
             Results containing the generated DataFrame and statistics.
         """
         loadavg_pre = read_loadavg()
-        vram_sampler = NvmlPeakSampler()
-        vram_sampler.__enter__()
-        generation_start = time.monotonic()
+        sampler = NvmlPeakSampler()
         try:
-            need_special_token_outputs = not isinstance(self.processor, TabularDataProcessor)
-            sampling_kwargs = dict(
-                temperature=self.config.generation.temperature,
-                repetition_penalty=self.config.generation.repetition_penalty,
-                top_p=self.config.generation.top_p,
-                top_k=FIXED_RUNTIME_GENERATE_ARGS["top_k"],
-                min_p=FIXED_RUNTIME_GENERATE_ARGS["min_p"],
-                max_tokens=self.model_metadata.generation_max_tokens_for(self._get_prompt_token_count()),
-                skip_special_tokens=not need_special_token_outputs,
-                include_stop_str_in_output=need_special_token_outputs,
-                ignore_eos=False,
-            )
-
-            self.prepare_params(**sampling_kwargs)
-
-            # The batches object collects batches and keeps track of the stopping condition.
-            batches = GenerationBatches(
-                target_num_records=self.config.generation.num_records,
-                invalid_fraction_threshold=self.config.generation.invalid_fraction_threshold,
-                patience=self.config.generation.patience,
-                data_actions_fn=data_actions_fn,
-            )
-
-            with heartbeat(
-                "Generation",
-                logger_name=__name__,
-                target_records=self.config.generation.num_records,
-                progress_note=("Long stretches with no new records are normal."),
-            ):
-                while batches.num_valid_records < self.config.generation.num_records:
-                    # Generate a batch from prompts and process the responses.
-                    num_prompts = batches.get_next_num_prompts()
-                    start_time = time.perf_counter()
-                    batch: Batch = self._generate_batch(
-                        num_prompts_per_batch=num_prompts,
-                        batch=Batch(processor=self.processor),
-                        **sampling_kwargs,
-                    )
-                    duration = time.perf_counter() - start_time
-                    batches.add_batch(batch)
-
-                    # Log generation summary and progress.
-                    batch.log_summary(detailed_errors=self.use_detailed_logs)
-                    self._log_batch_timing_and_progress(
-                        batch=batch,
-                        duration=duration,
-                        num_records=self.config.generation.num_records,
-                        num_valid_records=batches.num_valid_records,
-                        batches=batches,
-                    )
-                    # Check if the generation job should stop.
-                    if batches.status in [
-                        GenerationStatus.STOP_NO_RECORDS,
-                        GenerationStatus.STOP_METRIC_REACHED,
-                    ]:
-                        break
-
-            batches.job_complete()
-            batches.log_status()
-
-            max_num_records = (
-                self.config.generation.num_records
-                if self.config.data.group_training_examples_by is None and batches.status == GenerationStatus.COMPLETE
-                else None
-            )
-
-            generation_time_sec = time.monotonic() - generation_start
-            self.elapsed_time = generation_time_sec
-            self.gen_results = GenerateJobResults.from_batches(
-                batches=batches,
-                columns=self.columns,
-                max_num_records=max_num_records,
-                elapsed_time=self.elapsed_time,
-            )
+            with sampler:
+                self._run_generation(data_actions_fn)
         finally:
-            # Cleanup + observability emission run regardless of whether
-            # the body raised — sampler thread always shuts down, event
-            # always emits (with whatever measurements were captured up
-            # to the failure point).
-            vram_sampler.__exit__(None, None, None)
-            try:
-                vllm_metrics = read_vllm_runtime_metrics(self.llm)
-            except Exception as exc:  # noqa: BLE001 — degraded mode
-                logger.runtime.warning(
-                    "vllm.cell.observability.metrics_read_failed",
-                    extra={"ctx": {"error": str(exc)}},
+            # Emit regardless of success: the sampler thread has been joined
+            # by ``with`` exit, so ``sampler.peak_gb`` is the final peak, and
+            # the event carries whatever measurements were captured up to a
+            # failure point.
+            self._emit_cell_observability(sampler, loadavg_pre)
+
+        return self.gen_results
+
+    def _run_generation(self, data_actions_fn: utils.DataActionsFn | None) -> None:
+        """Run the batch-generation loop until the target or a stop condition fires.
+
+        Populates ``self.gen_results`` and ``self.elapsed_time``. Extracted
+        from :meth:`generate` so that method stays a thin observability
+        bracket around the loop.
+        """
+        generation_start = time.monotonic()
+        need_special_token_outputs = not isinstance(self.processor, TabularDataProcessor)
+        sampling_kwargs = dict(
+            temperature=self.config.generation.temperature,
+            repetition_penalty=self.config.generation.repetition_penalty,
+            top_p=self.config.generation.top_p,
+            top_k=FIXED_RUNTIME_GENERATE_ARGS["top_k"],
+            min_p=FIXED_RUNTIME_GENERATE_ARGS["min_p"],
+            max_tokens=self.model_metadata.generation_max_tokens_for(self._get_prompt_token_count()),
+            skip_special_tokens=not need_special_token_outputs,
+            include_stop_str_in_output=need_special_token_outputs,
+            ignore_eos=False,
+        )
+
+        self.prepare_params(**sampling_kwargs)
+
+        # The batches object collects batches and keeps track of the stopping condition.
+        batches = GenerationBatches(
+            target_num_records=self.config.generation.num_records,
+            invalid_fraction_threshold=self.config.generation.invalid_fraction_threshold,
+            patience=self.config.generation.patience,
+            data_actions_fn=data_actions_fn,
+        )
+
+        with heartbeat(
+            "Generation",
+            logger_name=__name__,
+            target_records=self.config.generation.num_records,
+            progress_note=("Long stretches with no new records are normal."),
+        ):
+            while batches.num_valid_records < self.config.generation.num_records:
+                # Generate a batch from prompts and process the responses.
+                num_prompts = batches.get_next_num_prompts()
+                start_time = time.perf_counter()
+                batch: Batch = self._generate_batch(
+                    num_prompts_per_batch=num_prompts,
+                    batch=Batch(processor=self.processor),
+                    **sampling_kwargs,
                 )
-                vllm_metrics = {
-                    "kv_cache_usage_perc": None,
-                    "prefix_cache_hit_rate": None,
-                    "spec_accept_rate": None,
-                }
+                duration = time.perf_counter() - start_time
+                batches.add_batch(batch)
+
+                # Log generation summary and progress.
+                batch.log_summary(detailed_errors=self.use_detailed_logs)
+                self._log_batch_timing_and_progress(
+                    batch=batch,
+                    duration=duration,
+                    num_records=self.config.generation.num_records,
+                    num_valid_records=batches.num_valid_records,
+                    batches=batches,
+                )
+                # Check if the generation job should stop.
+                if batches.status in [
+                    GenerationStatus.STOP_NO_RECORDS,
+                    GenerationStatus.STOP_METRIC_REACHED,
+                ]:
+                    break
+
+        batches.job_complete()
+        batches.log_status()
+
+        max_num_records = (
+            self.config.generation.num_records
+            if self.config.data.group_training_examples_by is None and batches.status == GenerationStatus.COMPLETE
+            else None
+        )
+
+        self.elapsed_time = time.monotonic() - generation_start
+        self.gen_results = GenerateJobResults.from_batches(
+            batches=batches,
+            columns=self.columns,
+            max_num_records=max_num_records,
+            elapsed_time=self.elapsed_time,
+        )
+
+    def _emit_cell_observability(
+        self, sampler: NvmlPeakSampler, loadavg_pre: tuple[float, float, float] | None
+    ) -> None:
+        """Assemble and route the ``vllm.cell.complete`` observability event.
+
+        Reads end-of-generation vLLM metrics plus the NVML peak captured by
+        ``sampler``, builds a :class:`CellObservability`, and routes it to
+        structured logs and (when a run is active) wandb. Best-effort: any
+        failure here is logged and swallowed so observability never masks a
+        generation error propagating through :meth:`generate`'s ``finally``.
+        """
+        try:
+            vllm_metrics = read_vllm_runtime_metrics(self.llm)
             cell_event = CellObservability(
-                peak_vram_gb=vram_sampler.peak_gb,
+                peak_vram_gb=sampler.peak_gb,
                 kv_cache_usage_perc=vllm_metrics["kv_cache_usage_perc"],
                 prefix_cache_hit_rate=vllm_metrics["prefix_cache_hit_rate"],
                 spec_accept_rate=vllm_metrics["spec_accept_rate"],
                 loadavg_pre=loadavg_pre,
                 loadavg_post=read_loadavg(),
                 engine_runtime_config=self._engine_runtime_config,
-                # ``flag_did_not_engage`` is the caller's job to compute.
-                # Production has no intended-overrides dict to compare
-                # against; benchmark callers compute the mismatch
-                # against their candidate's ``VllmEngineParameters`` /
-                # equivalent and set the bit if any check fires.
+                # ``flag_did_not_engage`` is the consuming caller's job to
+                # compute. Production generation has no intended-overrides
+                # dict to compare against; the benchmark harness probes the
+                # engine config against its candidate's intended settings and
+                # sets the bit when a knob silently fails to engage.
                 flag_did_not_engage=False,
             )
             logger.runtime.info("vllm.cell.complete", extra={"ctx": cell_event.model_dump()})
-            # Also log to the active wandb run when one exists (no-op
-            # when ``WANDB_MODE=disabled`` or ``initialize_wandb_run``
-            # hasn't been called). Best-effort; wandb failures don't
-            # propagate.
+            # Mirror to the active wandb run when one exists (no-op when
+            # ``WANDB_MODE=disabled`` or ``initialize_wandb_run`` was never
+            # called). Best-effort; wandb failures are swallowed downstream.
             log_cell_observability(cell_event)
-
-        return self.gen_results
+        except Exception as exc:  # noqa: BLE001 — observability must never break generation
+            logger.runtime.warning(
+                "vllm.cell.observability.emit_failed",
+                extra={"ctx": {"error": str(exc)}},
+            )

--- a/src/nemo_safe_synthesizer/generation/vllm_observability.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_observability.py
@@ -1,0 +1,433 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""vLLM observability primitives for production + benchmark.
+
+Schema-frozen cell-observability events emitted by ``VllmBackend.generate()``
+and consumed by downstream observability surfaces (structured logs, wandb,
+the benchmark harness's per-cell aggregator).
+
+Four primitives, all degraded-mode by design:
+
+- :class:`NvmlPeakSampler` — daemon-thread peak device-VRAM tracker via
+  ``pynvml``. Reads at the driver layer so it sees vLLM worker-subprocess
+  allocations regardless of which process holds the torch handle —
+  sidesteps the ``VLLM_ENABLE_V1_MULTIPROCESSING=1`` blind spot where
+  ``torch.cuda.max_memory_allocated()`` in the harness reads 0.
+- :func:`read_loadavg` — ``/proc/loadavg`` snapshot as a (1m, 5m, 15m)
+  triple. ``None`` on non-Linux or read failure.
+- :func:`probe_engine_runtime_config` — best-effort introspection of the
+  engine's effective scheduler/cache/speculative settings via
+  ``llm.llm_engine.vllm_config``. Empty dict on any failure.
+- :func:`read_vllm_runtime_metrics` — one-shot snapshot of
+  ``llm.get_metrics()`` for KV-cache usage, prefix-cache hit rate, and
+  speculative-decoding acceptance rate. Returns a dict with stable keys
+  regardless of which metrics the engine actually exposed.
+
+Plus the :class:`CellObservability` pydantic model — the schema for the
+``vllm.cell.complete`` structured event emitted at the end of each
+generation invocation. Forward-compatible: new optional fields can be
+added without breaking existing consumers because the model uses
+``extra="forbid"`` (so producers are forced to update when they add new
+fields) but every existing field has a default of ``None`` or empty.
+
+References (design):
+- HuggingFace train_memory blog covers in-process torch profiling, which
+  is the gap NVML fills here (out-of-process VRAM visibility).
+- spark-dashboard (Rust) demonstrates the NVML + ``/metrics`` pattern at
+  ~1s polling cadence — the precedent for combining NVML's driver-level
+  reading with vLLM's Prometheus surface.
+- vLLM's metrics design doc enumerates the gauges/counters
+  :func:`read_vllm_runtime_metrics` reads.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ..observability import get_logger
+
+if TYPE_CHECKING:
+    from vllm import LLM
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Schema for the cell-observability event
+# ---------------------------------------------------------------------------
+
+
+class CellObservability(BaseModel):
+    """One ``vllm.cell.complete`` event payload.
+
+    Emitted by ``VllmBackend.generate()`` at end of each generation
+    invocation. Consumed by:
+
+    - Structured log routing (default — flows through
+      ``logger.runtime.info(...)`` like the rest of PR-1's trace
+      telemetry).
+    - Wandb (when a run is active) — logged to the current wandb run.
+    - The benchmark harness's per-cell aggregator (composes this into
+      its richer ``CandidateMetrics`` schema).
+
+    Every measurement field is optional; producers should populate what
+    they can capture and leave the rest at the default. Wandb drops
+    ``None`` values silently which is the right behavior for "this
+    metric wasn't reachable on this cell".
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    # GPU memory — NVML-sampled peak across the whole cell.
+    peak_vram_gb: float | None = Field(
+        default=None,
+        description=(
+            "Peak device-wide VRAM usage in GiB, sampled by NVML "
+            "(``pynvml.nvmlDeviceGetMemoryInfo``) across the whole cell. "
+            "``None`` when NVML is unavailable. Device-wide reading; on a "
+            "shared GPU it includes other processes."
+        ),
+    )
+
+    # KV cache + prefix cache — vLLM's Prometheus surface, end-of-generate.
+    kv_cache_usage_perc: float | None = Field(
+        default=None,
+        description=(
+            "vLLM's ``vllm:kv_cache_usage_perc`` gauge (fraction 0..1 of "
+            "KV cache blocks in use) at end of generation. ``None`` when "
+            "the engine doesn't expose the gauge or the call failed. "
+            "Approximates peak; vLLM only publishes the instantaneous "
+            "value, not a max-over-time."
+        ),
+    )
+    prefix_cache_hit_rate: float | None = Field(
+        default=None,
+        description=(
+            "Derived from ``vllm:prefix_cache_hits / vllm:prefix_cache_queries`` "
+            "at end of generation. ``None`` when either counter is absent or "
+            "queries==0. Surfaces whether shared schema prefixes actually "
+            "amortized across the batch."
+        ),
+    )
+
+    # Speculative decoding — vLLM's Prometheus surface, end-of-generate.
+    spec_accept_rate: float | None = Field(
+        default=None,
+        description=(
+            "Derived from ``vllm:spec_decode_num_accepted_tokens / "
+            "num_draft_tokens`` at end of generation. ``None`` when "
+            "speculative decoding wasn't enabled on this cell (counters "
+            "absent) or no drafts were proposed (denominator==0)."
+        ),
+    )
+
+    # Host load — /proc/loadavg pre/post.
+    loadavg_pre: tuple[float, float, float] | None = Field(
+        default=None,
+        description=(
+            "Host ``/proc/loadavg`` snapshot captured at the start of "
+            "this cell (1-min, 5-min, 15-min averages). ``None`` when "
+            "``/proc/loadavg`` is unavailable (non-Linux)."
+        ),
+    )
+    loadavg_post: tuple[float, float, float] | None = Field(
+        default=None,
+        description=(
+            "Host ``/proc/loadavg`` snapshot captured at the end of this "
+            "cell. Drift from ``loadavg_pre`` signals load change during "
+            "the cell."
+        ),
+    )
+
+    # Engine config introspection — what the engine actually does, not what was asked.
+    engine_runtime_config: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Best-effort probe of the engine's effective runtime config "
+            "(``enable_prefix_caching``, ``enable_chunked_prefill``, "
+            "``max_num_seqs``, ``max_num_batched_tokens``, "
+            "``kv_cache_dtype``, ``speculative_method`` when populated). "
+            "Empty dict on probe failure."
+        ),
+    )
+    flag_did_not_engage: bool = Field(
+        default=False,
+        description=(
+            "``True`` when ``engine_runtime_config`` disagrees with the "
+            "candidate/caller's intended setting on any checked field — "
+            "an unsupported knob silently ignored, a default-on flag "
+            "overriding an explicit-off intent, etc."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# NVML peak sampler
+# ---------------------------------------------------------------------------
+
+
+class NvmlPeakSampler:
+    """Daemon-thread sampler tracking peak device VRAM via NVML.
+
+    Use as a context manager wrapping the engine-build + generation
+    block::
+
+        with NvmlPeakSampler() as vram:
+            ...  # build engine, run generate
+        peak_gb = vram.peak_gb  # float | None
+
+    Returns ``None`` from :attr:`peak_gb` when NVML isn't available
+    (driver missing, pynvml import failed, device index invalid).
+    Reports device-wide VRAM — on a dedicated host that's the same as
+    the vLLM worker's allocation; on a shared GPU it would include
+    other process allocations (filter via PID externally if needed).
+    """
+
+    def __init__(self, device_index: int = 0, interval_seconds: float = 0.25) -> None:
+        self._device_index = device_index
+        self._interval = interval_seconds
+        self._stop = threading.Event()
+        self._peak_bytes = 0
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._handle: Any = None
+        self._pynvml: Any = None
+
+    def __enter__(self) -> NvmlPeakSampler:
+        try:
+            import pynvml  # noqa: PLC0415 — soft dep, no top-level cost
+        except ImportError:
+            logger.debug("nvml-sampler: pynvml unavailable; peak VRAM will be None")
+            return self
+        try:
+            pynvml.nvmlInit()
+            self._pynvml = pynvml
+            self._handle = pynvml.nvmlDeviceGetHandleByIndex(self._device_index)
+        except Exception as exc:  # noqa: BLE001 — degraded mode
+            logger.warning("nvml-sampler: init failed; peak VRAM will be None: %s", exc)
+            self._pynvml = None
+            return self
+        self._thread = threading.Thread(
+            target=self._run, daemon=True, name=f"nvml-sampler[{self._device_index}]"
+        )
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        if self._pynvml is not None:
+            try:
+                self._pynvml.nvmlShutdown()
+            except Exception:  # noqa: BLE001
+                pass
+
+    @property
+    def peak_gb(self) -> float | None:
+        """Peak device-wide VRAM (GiB) observed during sampling; ``None`` if NVML unavailable."""
+        if self._pynvml is None:
+            return None
+        with self._lock:
+            return self._peak_bytes / (1024**3)
+
+    def _run(self) -> None:
+        """Poll loop. Tolerates transient NVML errors without dying."""
+        assert self._pynvml is not None
+        while not self._stop.is_set():
+            try:
+                info = self._pynvml.nvmlDeviceGetMemoryInfo(self._handle)
+                used = int(info.used)
+                with self._lock:
+                    if used > self._peak_bytes:
+                        self._peak_bytes = used
+            except Exception:  # noqa: BLE001 — degraded mode
+                pass
+            self._stop.wait(self._interval)
+
+
+# ---------------------------------------------------------------------------
+# Host load
+# ---------------------------------------------------------------------------
+
+
+def read_loadavg() -> tuple[float, float, float] | None:
+    """Return ``/proc/loadavg`` as a (1m, 5m, 15m) triple; ``None`` when unavailable.
+
+    Linux-only. Cheap (one syscall). Safe to call from any process —
+    the read is host-scoped, not process-scoped. Designed to bracket a
+    generation call: caller reads pre + post, the pair is informative
+    about whether host load drifted during the cell.
+    """
+    try:
+        with open("/proc/loadavg", encoding="utf-8") as f:
+            parts = f.read().split()
+        return (float(parts[0]), float(parts[1]), float(parts[2]))
+    except (OSError, ValueError, IndexError):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Engine config introspection
+# ---------------------------------------------------------------------------
+
+
+# Engine-config fields the flag-engagement check looks at. Kept module-level
+# so callers can subset or extend it without touching probe internals.
+ENGINE_CONFIG_CHECKED_FIELDS: tuple[str, ...] = (
+    "enable_prefix_caching",
+    "enable_chunked_prefill",
+    "max_num_seqs",
+    "max_num_batched_tokens",
+    "kv_cache_dtype",
+)
+
+
+def probe_engine_runtime_config(llm: Any) -> dict[str, Any]:
+    """Best-effort introspection of the engine's effective runtime config.
+
+    Returns a flat dict of the load-bearing scheduler/cache/speculative
+    settings. Empty dict on any failure — this is observability, not a
+    correctness gate. Tries ``llm.llm_engine.vllm_config`` first, then
+    ``llm.engine.vllm_config`` to span vLLM v0/v1 attribute naming.
+    """
+    try:
+        engine = getattr(llm, "llm_engine", None) or getattr(llm, "engine", None)
+        vcfg = getattr(engine, "vllm_config", None) if engine is not None else None
+        if vcfg is None:
+            return {}
+        out: dict[str, Any] = {}
+        scheduler = getattr(vcfg, "scheduler_config", None)
+        if scheduler is not None:
+            for attr in ("max_num_seqs", "max_num_batched_tokens"):
+                value = getattr(scheduler, attr, None)
+                if value is not None:
+                    out[attr] = value
+            chunked = getattr(scheduler, "chunked_prefill_enabled", None)
+            if chunked is None:
+                chunked = getattr(scheduler, "enable_chunked_prefill", None)
+            if chunked is not None:
+                out["enable_chunked_prefill"] = bool(chunked)
+        cache = getattr(vcfg, "cache_config", None)
+        if cache is not None:
+            for attr in ("enable_prefix_caching", "cache_dtype", "kv_cache_dtype"):
+                value = getattr(cache, attr, None)
+                if value is not None:
+                    out[attr if attr != "cache_dtype" else "kv_cache_dtype"] = value
+        spec = getattr(vcfg, "speculative_config", None)
+        if spec is not None:
+            method = getattr(spec, "method", None)
+            if method is not None:
+                out["speculative_method"] = method
+        return out
+    except Exception:  # noqa: BLE001 — degraded mode by design
+        return {}
+
+
+def flag_engagement_mismatches(
+    intended: dict[str, Any],
+    actual: dict[str, Any],
+    checked_fields: tuple[str, ...] = ENGINE_CONFIG_CHECKED_FIELDS,
+) -> list[str]:
+    """Return human-readable mismatch descriptions; empty list means clean engagement.
+
+    Only checks fields the caller explicitly set in ``intended`` (i.e.,
+    fields whose value is not ``None``); a ``None`` on the intended side
+    means "use engine default" so there's no reference value to compare
+    against. Fields missing from ``actual`` are skipped — the probe is
+    best-effort and may not expose every flag.
+
+    The dict-vs-dict shape (rather than a typed pydantic model) is
+    deliberate so this helper works regardless of whether the caller
+    has a ``VllmEngineParameters`` instance or just raw vLLM kwargs.
+    """
+    mismatches: list[str] = []
+    for field in checked_fields:
+        intended_val = intended.get(field)
+        if intended_val is None:
+            continue
+        actual_val = actual.get(field)
+        if actual_val is None:
+            continue
+        if intended_val != actual_val:
+            mismatches.append(f"{field}: intended={intended_val!r} actual={actual_val!r}")
+    return mismatches
+
+
+# ---------------------------------------------------------------------------
+# vLLM runtime metrics
+# ---------------------------------------------------------------------------
+
+
+# vLLM metric names this module knows about. Kept module-level so a future
+# renaming in vLLM only needs one update site.
+METRIC_KV_CACHE_USAGE_PERC = "vllm:kv_cache_usage_perc"
+METRIC_PREFIX_CACHE_QUERIES = "vllm:prefix_cache_queries"
+METRIC_PREFIX_CACHE_HITS = "vllm:prefix_cache_hits"
+METRIC_SPEC_NUM_DRAFT_TOKENS = "vllm:spec_decode_num_draft_tokens"
+METRIC_SPEC_NUM_ACCEPTED_TOKENS = "vllm:spec_decode_num_accepted_tokens"
+
+
+def read_vllm_runtime_metrics(llm: LLM) -> dict[str, float | None]:
+    """Snapshot ``llm.get_metrics()`` for known metrics; degraded-mode on failure.
+
+    Returns a dict with stable keys regardless of which metrics were
+    actually exposed by the engine — missing metrics map to ``None``.
+    Callers should treat ``None`` as "engine didn't surface this counter"
+    and not crash on missing data.
+
+    Currently captures:
+
+    - ``kv_cache_usage_perc`` — vLLM gauge, fraction (0..1) of used KV
+      cache blocks at the moment of read.
+    - ``prefix_cache_hit_rate`` — derived from
+      ``vllm:prefix_cache_hits / vllm:prefix_cache_queries``.
+    - ``spec_accept_rate`` — derived from
+      ``vllm:spec_decode_num_accepted_tokens / num_draft_tokens``.
+      ``None`` when speculative decoding wasn't enabled (counters
+      registered at runtime by the spec-decode subsystem; absent
+      otherwise) — distinguishes "not measured" from "measured zero".
+    """
+    out: dict[str, float | None] = {
+        "kv_cache_usage_perc": None,
+        "prefix_cache_hit_rate": None,
+        "spec_accept_rate": None,
+    }
+    try:
+        metrics = llm.get_metrics()
+    except Exception as exc:  # noqa: BLE001 — degraded mode
+        logger.debug("read_vllm_runtime_metrics: get_metrics failed: %s", exc)
+        return out
+
+    kv_usage: float | None = None
+    prefix_hits: float | None = None
+    prefix_queries: float | None = None
+    spec_accepted: float | None = None
+    spec_drafted: float | None = None
+    for m in metrics:
+        name = getattr(m, "name", "")
+        value = getattr(m, "value", None)
+        if value is None:
+            continue
+        if name == METRIC_KV_CACHE_USAGE_PERC:
+            kv_usage = float(value)
+        elif name == METRIC_PREFIX_CACHE_HITS:
+            prefix_hits = float(value)
+        elif name == METRIC_PREFIX_CACHE_QUERIES:
+            prefix_queries = float(value)
+        elif name == METRIC_SPEC_NUM_ACCEPTED_TOKENS:
+            spec_accepted = float(value)
+        elif name == METRIC_SPEC_NUM_DRAFT_TOKENS:
+            spec_drafted = float(value)
+
+    if kv_usage is not None:
+        out["kv_cache_usage_perc"] = kv_usage
+    if prefix_hits is not None and prefix_queries is not None and prefix_queries > 0:
+        out["prefix_cache_hit_rate"] = prefix_hits / prefix_queries
+    if spec_accepted is not None and spec_drafted is not None and spec_drafted > 0:
+        out["spec_accept_rate"] = spec_accepted / spec_drafted
+    return out

--- a/src/nemo_safe_synthesizer/generation/vllm_observability.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_observability.py
@@ -415,7 +415,7 @@ METRIC_SPEC_NUM_DRAFT_TOKENS = "vllm:spec_decode_num_draft_tokens"
 METRIC_SPEC_NUM_ACCEPTED_TOKENS = "vllm:spec_decode_num_accepted_tokens"
 
 
-def read_vllm_runtime_metrics(llm: LLM) -> dict[str, float | None]:
+def read_vllm_runtime_metrics(llm: LLM | None) -> dict[str, float | None]:
     """Snapshot ``llm.get_metrics()`` for known metrics; degraded-mode on failure.
 
     Returns a dict with stable keys regardless of which metrics were
@@ -440,6 +440,8 @@ def read_vllm_runtime_metrics(llm: LLM) -> dict[str, float | None]:
         "prefix_cache_hit_rate": None,
         "spec_accept_rate": None,
     }
+    if llm is None:
+        return out
     try:
         metrics = llm.get_metrics()
     except Exception as exc:  # noqa: BLE001 — degraded mode

--- a/src/nemo_safe_synthesizer/generation/vllm_observability.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_observability.py
@@ -477,8 +477,8 @@ def read_vllm_runtime_metrics(llm: LLM | None) -> VllmRuntimeMetrics:
     # derivation below is pure dict arithmetic and cannot raise.
     try:
         raw = _collect_raw_metrics(llm)
-    except Exception as exc:  # noqa: BLE001 — degraded mode by design
-        logger.debug("read_vllm_runtime_metrics failed: %s", exc)
+    except Exception:  # noqa: BLE001 — degraded mode by design
+        logger.debug("read_vllm_runtime_metrics failed", exc_info=True)
         return _empty_runtime_metrics()
 
     return VllmRuntimeMetrics(

--- a/src/nemo_safe_synthesizer/generation/vllm_observability.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_observability.py
@@ -47,18 +47,38 @@ References (design):
 
 from __future__ import annotations
 
-import os
-import threading
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from ..observability import get_logger
+from ..observability import (
+    NvmlPeakSampler,
+    _default_nvml_device_index,
+    get_logger,
+    read_loadavg,
+)
 
 if TYPE_CHECKING:
     from vllm import LLM
+
+__all__ = [
+    "ENGINE_CONFIG_CHECKED_FIELDS",
+    "METRIC_KV_CACHE_USAGE_PERC",
+    "METRIC_PREFIX_CACHE_HITS",
+    "METRIC_PREFIX_CACHE_QUERIES",
+    "METRIC_SPEC_NUM_ACCEPTED_TOKENS",
+    "METRIC_SPEC_NUM_DRAFT_TOKENS",
+    "GenerationObservability",
+    "NvmlPeakSampler",
+    "VllmRuntimeMetrics",
+    "_default_nvml_device_index",
+    "flag_engagement_mismatches",
+    "probe_engine_runtime_config",
+    "read_loadavg",
+    "read_vllm_runtime_metrics",
+]
 
 logger = get_logger(__name__)
 
@@ -216,138 +236,6 @@ class GenerationObservability(BaseModel):
             if value is not None:
                 payload[f"{prefix}/engine_runtime/{key}"] = value
         return payload
-
-
-# ---------------------------------------------------------------------------
-# NVML peak sampler
-# ---------------------------------------------------------------------------
-
-
-def _default_nvml_device_index() -> int:
-    """Physical NVML index of the first CUDA-visible device.
-
-    NVML's :func:`nvmlDeviceGetHandleByIndex` enumerates *physical* GPUs and
-    ignores ``CUDA_VISIBLE_DEVICES``, whereas vLLM (single-GPU here) runs on
-    CUDA logical device 0 — which the env var may remap to a different
-    physical GPU. Returns the physical index of the first visible device so
-    the sampler tracks the GPU vLLM actually uses.
-
-    Falls back to ``0`` when ``CUDA_VISIBLE_DEVICES`` is unset, empty, or not
-    a plain integer list (e.g. ``GPU-<uuid>`` / ``MIG-...`` specs this does
-    not decode) — degraded mode, consistent with the rest of this module.
-    """
-    raw = os.environ.get("CUDA_VISIBLE_DEVICES")
-    if not raw:
-        return 0
-    first = raw.split(",")[0].strip()
-    try:
-        return int(first)
-    except ValueError:
-        return 0
-
-
-class NvmlPeakSampler:
-    """Daemon-thread sampler tracking peak device VRAM via NVML.
-
-    Use as a context manager wrapping the engine-build + generation
-    block::
-
-        with NvmlPeakSampler() as vram:
-            ...  # build engine, run generate
-        peak_gb = vram.peak_gb  # float | None
-
-    Returns ``None`` from :attr:`peak_gb` when NVML isn't available
-    (driver missing, pynvml import failed, device index invalid).
-    Reports device-wide VRAM — on a dedicated host that's the same as
-    the vLLM worker's allocation; on a shared GPU it would include
-    other process allocations (filter via PID externally if needed).
-
-    ``device_index`` defaults to the first ``CUDA_VISIBLE_DEVICES`` entry
-    (see :func:`_default_nvml_device_index`) so the sampler follows vLLM's
-    GPU on multi-GPU hosts instead of always reading physical GPU 0. Pass an
-    explicit index to override.
-    """
-
-    def __init__(self, device_index: int | None = None, interval_seconds: float = 0.25) -> None:
-        self._device_index = _default_nvml_device_index() if device_index is None else device_index
-        self._interval = interval_seconds
-        self._stop = threading.Event()
-        self._peak_bytes = 0
-        self._lock = threading.Lock()
-        self._thread: threading.Thread | None = None
-        self._handle: Any = None
-        self._pynvml: Any = None
-
-    def __enter__(self) -> NvmlPeakSampler:
-        try:
-            import pynvml  # noqa: PLC0415 — soft dep, no top-level cost
-        except ImportError:
-            logger.debug("nvml-sampler: pynvml unavailable; peak VRAM will be None")
-            return self
-        try:
-            pynvml.nvmlInit()
-            self._pynvml = pynvml
-            self._handle = pynvml.nvmlDeviceGetHandleByIndex(self._device_index)
-        except pynvml.NVMLError as exc:  # driver missing, bad index, etc. — degraded mode
-            logger.warning("nvml-sampler: init failed; peak VRAM will be None: %s", exc)
-            self._pynvml = None
-            return self
-        self._thread = threading.Thread(target=self._run, daemon=True, name=f"nvml-sampler[{self._device_index}]")
-        self._thread.start()
-        return self
-
-    def __exit__(self, *exc: Any) -> None:
-        self._stop.set()
-        if self._thread is not None:
-            self._thread.join(timeout=2.0)
-        if self._pynvml is not None:
-            try:
-                self._pynvml.nvmlShutdown()
-            except self._pynvml.NVMLError:  # shutdown is best-effort; init already succeeded
-                logger.debug("nvml-sampler: nvmlShutdown failed", exc_info=True)
-
-    @property
-    def peak_gb(self) -> float | None:
-        """Peak device-wide VRAM (GiB) observed during sampling; ``None`` if NVML unavailable."""
-        if self._pynvml is None:
-            return None
-        with self._lock:
-            return self._peak_bytes / (1024**3)
-
-    def _run(self) -> None:
-        """Poll loop. Tolerates transient NVML errors without dying."""
-        assert self._pynvml is not None
-        while not self._stop.is_set():
-            try:
-                info = self._pynvml.nvmlDeviceGetMemoryInfo(self._handle)
-                used = int(info.used)
-                with self._lock:
-                    if used > self._peak_bytes:
-                        self._peak_bytes = used
-            except self._pynvml.NVMLError:  # transient driver hiccup — keep sampling
-                pass
-            self._stop.wait(self._interval)
-
-
-# ---------------------------------------------------------------------------
-# Host load
-# ---------------------------------------------------------------------------
-
-
-def read_loadavg() -> tuple[float, float, float] | None:
-    """Return ``/proc/loadavg`` as a (1m, 5m, 15m) triple; ``None`` when unavailable.
-
-    Linux-only. Cheap (one syscall). Safe to call from any process —
-    the read is host-scoped, not process-scoped. Designed to bracket a
-    generation call: caller reads pre + post, the pair is informative
-    about whether host load drifted during the generation.
-    """
-    try:
-        with open("/proc/loadavg", encoding="utf-8") as f:
-            parts = f.read().split()
-        return (float(parts[0]), float(parts[1]), float(parts[2]))
-    except (OSError, ValueError, IndexError):
-        return None
 
 
 # ---------------------------------------------------------------------------

--- a/src/nemo_safe_synthesizer/generation/vllm_observability.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_observability.py
@@ -256,9 +256,7 @@ class NvmlPeakSampler:
             logger.warning("nvml-sampler: init failed; peak VRAM will be None: %s", exc)
             self._pynvml = None
             return self
-        self._thread = threading.Thread(
-            target=self._run, daemon=True, name=f"nvml-sampler[{self._device_index}]"
-        )
+        self._thread = threading.Thread(target=self._run, daemon=True, name=f"nvml-sampler[{self._device_index}]")
         self._thread.start()
         return self
 

--- a/src/nemo_safe_synthesizer/generation/vllm_observability.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_observability.py
@@ -468,6 +468,18 @@ METRIC_PREFIX_CACHE_HITS = "vllm:prefix_cache_hits"
 METRIC_SPEC_NUM_DRAFT_TOKENS = "vllm:spec_decode_num_draft_tokens"
 METRIC_SPEC_NUM_ACCEPTED_TOKENS = "vllm:spec_decode_num_accepted_tokens"
 
+# Raw counters pulled from ``llm.get_metrics()``. The output fields below are
+# either passed through (kv-cache usage) or derived as ratios of these.
+_COLLECTED_METRICS: frozenset[str] = frozenset(
+    {
+        METRIC_KV_CACHE_USAGE_PERC,
+        METRIC_PREFIX_CACHE_QUERIES,
+        METRIC_PREFIX_CACHE_HITS,
+        METRIC_SPEC_NUM_DRAFT_TOKENS,
+        METRIC_SPEC_NUM_ACCEPTED_TOKENS,
+    }
+)
+
 
 class VllmRuntimeMetrics(TypedDict):
     """End-of-generation vLLM metric snapshot with a fixed key set.
@@ -484,6 +496,33 @@ class VllmRuntimeMetrics(TypedDict):
     kv_cache_usage_perc: float | None
     prefix_cache_hit_rate: float | None
     spec_accept_rate: float | None
+
+
+def _empty_runtime_metrics() -> VllmRuntimeMetrics:
+    """The degraded-mode snapshot: every field ``None`` (nothing measured)."""
+    return VllmRuntimeMetrics(kv_cache_usage_perc=None, prefix_cache_hit_rate=None, spec_accept_rate=None)
+
+
+def _safe_ratio(numerator: float | None, denominator: float | None) -> float | None:
+    """``numerator / denominator``, or ``None`` when either is absent or the denominator is non-positive."""
+    if numerator is None or denominator is None or denominator <= 0:
+        return None
+    return numerator / denominator
+
+
+def _collect_raw_metrics(llm: LLM) -> dict[str, float]:
+    """Read ``llm.get_metrics()`` into ``{name: value}`` for the counters in :data:`_COLLECTED_METRICS`.
+
+    Isolates the only failure-prone work (the engine call plus numeric
+    coercion) so the caller's degraded-mode guard can wrap exactly this.
+    """
+    raw: dict[str, float] = {}
+    for m in llm.get_metrics():
+        name = getattr(m, "name", "")
+        value = getattr(m, "value", None)
+        if value is not None and name in _COLLECTED_METRICS:
+            raw[name] = float(value)
+    return raw
 
 
 def read_vllm_runtime_metrics(llm: LLM | None) -> VllmRuntimeMetrics:
@@ -506,46 +545,20 @@ def read_vllm_runtime_metrics(llm: LLM | None) -> VllmRuntimeMetrics:
       registered at runtime by the spec-decode subsystem; absent
       otherwise) — distinguishes "not measured" from "measured zero".
     """
-    out: VllmRuntimeMetrics = {
-        "kv_cache_usage_perc": None,
-        "prefix_cache_hit_rate": None,
-        "spec_accept_rate": None,
-    }
     if llm is None:
-        return out
+        return _empty_runtime_metrics()
 
-    # Whole-body guard: this is a best-effort probe, so any failure (the
-    # engine call, an unexpected metric shape, a non-numeric value) degrades
-    # to the stable all-``None`` dict rather than propagating. Callers can
-    # therefore trust the return contract without re-wrapping the call.
+    # Best-effort probe: the engine call or a non-numeric metric value is the
+    # only thing that can fail, so the guard wraps exactly that. The ratio
+    # derivation below is pure dict arithmetic and cannot raise.
     try:
-        kv_usage: float | None = None
-        prefix_hits: float | None = None
-        prefix_queries: float | None = None
-        spec_accepted: float | None = None
-        spec_drafted: float | None = None
-        for m in llm.get_metrics():
-            name = getattr(m, "name", "")
-            value = getattr(m, "value", None)
-            if value is None:
-                continue
-            if name == METRIC_KV_CACHE_USAGE_PERC:
-                kv_usage = float(value)
-            elif name == METRIC_PREFIX_CACHE_HITS:
-                prefix_hits = float(value)
-            elif name == METRIC_PREFIX_CACHE_QUERIES:
-                prefix_queries = float(value)
-            elif name == METRIC_SPEC_NUM_ACCEPTED_TOKENS:
-                spec_accepted = float(value)
-            elif name == METRIC_SPEC_NUM_DRAFT_TOKENS:
-                spec_drafted = float(value)
-
-        if kv_usage is not None:
-            out["kv_cache_usage_perc"] = kv_usage
-        if prefix_hits is not None and prefix_queries is not None and prefix_queries > 0:
-            out["prefix_cache_hit_rate"] = prefix_hits / prefix_queries
-        if spec_accepted is not None and spec_drafted is not None and spec_drafted > 0:
-            out["spec_accept_rate"] = spec_accepted / spec_drafted
+        raw = _collect_raw_metrics(llm)
     except Exception as exc:  # noqa: BLE001 — degraded mode by design
         logger.debug("read_vllm_runtime_metrics failed: %s", exc)
-    return out
+        return _empty_runtime_metrics()
+
+    return VllmRuntimeMetrics(
+        kv_cache_usage_perc=raw.get(METRIC_KV_CACHE_USAGE_PERC),
+        prefix_cache_hit_rate=_safe_ratio(raw.get(METRIC_PREFIX_CACHE_HITS), raw.get(METRIC_PREFIX_CACHE_QUERIES)),
+        spec_accept_rate=_safe_ratio(raw.get(METRIC_SPEC_NUM_ACCEPTED_TOKENS), raw.get(METRIC_SPEC_NUM_DRAFT_TOKENS)),
+    )

--- a/src/nemo_safe_synthesizer/generation/vllm_observability.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_observability.py
@@ -3,7 +3,7 @@
 
 """vLLM observability primitives for production + benchmark.
 
-Schema-frozen cell-observability events emitted by ``VllmBackend.generate()``
+Schema-frozen generation-observability events emitted by ``VllmBackend.generate()``
 and consumed by downstream observability surfaces (structured logs, wandb,
 the benchmark harness's per-cell aggregator).
 
@@ -24,25 +24,30 @@ Four primitives, all degraded-mode by design:
   speculative-decoding acceptance rate. Returns a dict with stable keys
   regardless of which metrics the engine actually exposed.
 
-Plus the :class:`CellObservability` pydantic model — the schema for the
-``vllm.cell.complete`` structured event emitted at the end of each
+Plus the :class:`GenerationObservability` pydantic model — the schema for the
+``vllm.generation.complete`` structured event emitted at the end of each
 generation invocation. Forward-compatible: new optional fields can be
 added without breaking existing consumers because the model uses
 ``extra="forbid"`` (so producers are forced to update when they add new
 fields) but every existing field has a default of ``None`` or empty.
 
 References (design):
-- HuggingFace train_memory blog covers in-process torch profiling, which
-  is the gap NVML fills here (out-of-process VRAM visibility).
+- HuggingFace ``train_memory`` blog ("Visualize and understand GPU memory
+  in PyTorch") covers in-process torch profiling, which is the gap NVML
+  fills here (out-of-process VRAM visibility):
+  https://huggingface.co/blog/train_memory
 - spark-dashboard (Rust) demonstrates the NVML + ``/metrics`` pattern at
   ~1s polling cadence — the precedent for combining NVML's driver-level
-  reading with vLLM's Prometheus surface.
+  reading with vLLM's Prometheus surface:
+  https://github.com/niklasfrick/spark-dashboard
 - vLLM's metrics design doc enumerates the gauges/counters
-  :func:`read_vllm_runtime_metrics` reads.
+  :func:`read_vllm_runtime_metrics` reads:
+  https://github.com/vllm-project/vllm/blob/main/docs/design/metrics.md
 """
 
 from __future__ import annotations
 
+import os
 import threading
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -58,13 +63,20 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 
+_LOADAVG_HORIZON_LABELS: tuple[str, str, str] = ("1m", "5m", "15m")
+"""Labels for unpacked ``/proc/loadavg`` triples on the wandb side.
+
+Used by :meth:`GenerationObservability.to_wandb_payload`.
+"""
+
+
 # ---------------------------------------------------------------------------
-# Schema for the cell-observability event
+# Schema for the generation-observability event
 # ---------------------------------------------------------------------------
 
 
-class CellObservability(BaseModel):
-    """One ``vllm.cell.complete`` event payload.
+class GenerationObservability(BaseModel):
+    """One ``vllm.generation.complete`` event payload.
 
     Emitted by ``VllmBackend.generate()`` at end of each generation
     invocation. Consumed by:
@@ -79,17 +91,17 @@ class CellObservability(BaseModel):
     Every measurement field is optional; producers should populate what
     they can capture and leave the rest at the default. Wandb drops
     ``None`` values silently which is the right behavior for "this
-    metric wasn't reachable on this cell".
+    metric wasn't reachable on this generation".
     """
 
     model_config = ConfigDict(extra="forbid")
 
-    # GPU memory — NVML-sampled peak across the whole cell.
+    # GPU memory — NVML-sampled peak across the whole generation.
     peak_vram_gb: float | None = Field(
         default=None,
         description=(
             "Peak device-wide VRAM usage in GiB, sampled by NVML "
-            "(``pynvml.nvmlDeviceGetMemoryInfo``) across the whole cell. "
+            "(``pynvml.nvmlDeviceGetMemoryInfo``) across the whole generation. "
             "``None`` when NVML is unavailable. Device-wide reading; on a "
             "shared GPU it includes other processes."
         ),
@@ -122,7 +134,7 @@ class CellObservability(BaseModel):
         description=(
             "Derived from ``vllm:spec_decode_num_accepted_tokens / "
             "num_draft_tokens`` at end of generation. ``None`` when "
-            "speculative decoding wasn't enabled on this cell (counters "
+            "speculative decoding wasn't enabled on this generation (counters "
             "absent) or no drafts were proposed (denominator==0)."
         ),
     )
@@ -132,7 +144,7 @@ class CellObservability(BaseModel):
         default=None,
         description=(
             "Host ``/proc/loadavg`` snapshot captured at the start of "
-            "this cell (1-min, 5-min, 15-min averages). ``None`` when "
+            "this generation (1-min, 5-min, 15-min averages). ``None`` when "
             "``/proc/loadavg`` is unavailable (non-Linux)."
         ),
     )
@@ -140,8 +152,8 @@ class CellObservability(BaseModel):
         default=None,
         description=(
             "Host ``/proc/loadavg`` snapshot captured at the end of this "
-            "cell. Drift from ``loadavg_pre`` signals load change during "
-            "the cell."
+            "generation. Drift from ``loadavg_pre`` signals load change during "
+            "the generation."
         ),
     )
 
@@ -166,7 +178,7 @@ class CellObservability(BaseModel):
         ),
     )
 
-    def to_wandb_payload(self, prefix: str = "vllm_cell") -> dict[str, Any]:
+    def to_wandb_payload(self, prefix: str = "vllm_gen") -> dict[str, Any]:
         """Flatten this event into a wandb-friendly ``wandb.log(...)`` dict.
 
         Wandb plots scalars cleanly but renders tuples/dicts as opaque
@@ -180,7 +192,7 @@ class CellObservability(BaseModel):
           scalars (mirrors the existing flattening pattern in the
           benchmark harness).
 
-        All keys are namespaced under ``prefix`` so production cell
+        All keys are namespaced under ``prefix`` so production generation
         events don't collide with other wandb metrics in the same run.
         """
         payload: dict[str, Any] = {}
@@ -201,20 +213,37 @@ class CellObservability(BaseModel):
             for label, value in zip(_LOADAVG_HORIZON_LABELS, tup, strict=False):
                 payload[f"{prefix}/loadavg_{side}_{label}"] = value
         for key, value in self.engine_runtime_config.items():
-            payload[f"{prefix}/engine_runtime/{key}"] = value
+            if value is not None:
+                payload[f"{prefix}/engine_runtime/{key}"] = value
         return payload
-
-
-_LOADAVG_HORIZON_LABELS: tuple[str, str, str] = ("1m", "5m", "15m")
-"""Labels for unpacked ``/proc/loadavg`` triples on the wandb side.
-
-Used by :meth:`CellObservability.to_wandb_payload`.
-"""
 
 
 # ---------------------------------------------------------------------------
 # NVML peak sampler
 # ---------------------------------------------------------------------------
+
+
+def _default_nvml_device_index() -> int:
+    """Physical NVML index of the first CUDA-visible device.
+
+    NVML's :func:`nvmlDeviceGetHandleByIndex` enumerates *physical* GPUs and
+    ignores ``CUDA_VISIBLE_DEVICES``, whereas vLLM (single-GPU here) runs on
+    CUDA logical device 0 — which the env var may remap to a different
+    physical GPU. Returns the physical index of the first visible device so
+    the sampler tracks the GPU vLLM actually uses.
+
+    Falls back to ``0`` when ``CUDA_VISIBLE_DEVICES`` is unset, empty, or not
+    a plain integer list (e.g. ``GPU-<uuid>`` / ``MIG-...`` specs this does
+    not decode) — degraded mode, consistent with the rest of this module.
+    """
+    raw = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if not raw:
+        return 0
+    first = raw.split(",")[0].strip()
+    try:
+        return int(first)
+    except ValueError:
+        return 0
 
 
 class NvmlPeakSampler:
@@ -232,10 +261,15 @@ class NvmlPeakSampler:
     Reports device-wide VRAM — on a dedicated host that's the same as
     the vLLM worker's allocation; on a shared GPU it would include
     other process allocations (filter via PID externally if needed).
+
+    ``device_index`` defaults to the first ``CUDA_VISIBLE_DEVICES`` entry
+    (see :func:`_default_nvml_device_index`) so the sampler follows vLLM's
+    GPU on multi-GPU hosts instead of always reading physical GPU 0. Pass an
+    explicit index to override.
     """
 
-    def __init__(self, device_index: int = 0, interval_seconds: float = 0.25) -> None:
-        self._device_index = device_index
+    def __init__(self, device_index: int | None = None, interval_seconds: float = 0.25) -> None:
+        self._device_index = _default_nvml_device_index() if device_index is None else device_index
         self._interval = interval_seconds
         self._stop = threading.Event()
         self._peak_bytes = 0
@@ -269,8 +303,8 @@ class NvmlPeakSampler:
         if self._pynvml is not None:
             try:
                 self._pynvml.nvmlShutdown()
-            except self._pynvml.NVMLError:
-                pass
+            except self._pynvml.NVMLError:  # shutdown is best-effort; init already succeeded
+                logger.debug("nvml-sampler: nvmlShutdown failed", exc_info=True)
 
     @property
     def peak_gb(self) -> float | None:
@@ -306,7 +340,7 @@ def read_loadavg() -> tuple[float, float, float] | None:
     Linux-only. Cheap (one syscall). Safe to call from any process —
     the read is host-scoped, not process-scoped. Designed to bracket a
     generation call: caller reads pre + post, the pair is informative
-    about whether host load drifted during the cell.
+    about whether host load drifted during the generation.
     """
     try:
         with open("/proc/loadavg", encoding="utf-8") as f:
@@ -408,6 +442,7 @@ def probe_engine_runtime_config(llm: object) -> dict[str, Any]:
     try:
         vcfg = _engine_vllm_config(llm)
     except Exception:  # noqa: BLE001 — degraded mode by design
+        logger.debug("engine-probe: vllm_config unreachable; returning empty probe", exc_info=True)
         return {}
     if vcfg is None:
         return {}
@@ -421,6 +456,7 @@ def probe_engine_runtime_config(llm: object) -> dict[str, Any]:
             if value is not None:
                 out[spec.out_key] = spec.transform(value)
         except Exception:  # noqa: BLE001 — degrade one field, not the whole probe
+            logger.debug("engine-probe: field %r failed; skipping", spec.out_key, exc_info=True)
             continue
     return out
 
@@ -485,7 +521,7 @@ class VllmRuntimeMetrics(TypedDict):
     """End-of-generation vLLM metric snapshot with a fixed key set.
 
     Every value is ``float | None``; ``None`` means the engine did not
-    surface that counter on this cell (distinct from a measured zero).
+    surface that counter on this generation (distinct from a measured zero).
 
     A ``TypedDict`` rather than a dataclass on purpose: the value stays a
     plain ``dict`` at runtime, so dict-style consumers (e.g. the benchmark

--- a/src/nemo_safe_synthesizer/generation/vllm_observability.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_observability.py
@@ -44,7 +44,9 @@ References (design):
 from __future__ import annotations
 
 import threading
-from typing import TYPE_CHECKING, Any
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -252,7 +254,7 @@ class NvmlPeakSampler:
             pynvml.nvmlInit()
             self._pynvml = pynvml
             self._handle = pynvml.nvmlDeviceGetHandleByIndex(self._device_index)
-        except Exception as exc:  # noqa: BLE001 — degraded mode
+        except pynvml.NVMLError as exc:  # driver missing, bad index, etc. — degraded mode
             logger.warning("nvml-sampler: init failed; peak VRAM will be None: %s", exc)
             self._pynvml = None
             return self
@@ -267,7 +269,7 @@ class NvmlPeakSampler:
         if self._pynvml is not None:
             try:
                 self._pynvml.nvmlShutdown()
-            except Exception:  # noqa: BLE001
+            except self._pynvml.NVMLError:
                 pass
 
     @property
@@ -288,7 +290,7 @@ class NvmlPeakSampler:
                 with self._lock:
                     if used > self._peak_bytes:
                         self._peak_bytes = used
-            except Exception:  # noqa: BLE001 — degraded mode
+            except self._pynvml.NVMLError:  # transient driver hiccup — keep sampling
                 pass
             self._stop.wait(self._interval)
 
@@ -319,56 +321,108 @@ def read_loadavg() -> tuple[float, float, float] | None:
 # ---------------------------------------------------------------------------
 
 
-# Engine-config fields the flag-engagement check looks at. Kept module-level
-# so callers can subset or extend it without touching probe internals.
-ENGINE_CONFIG_CHECKED_FIELDS: tuple[str, ...] = (
-    "enable_prefix_caching",
-    "enable_chunked_prefill",
-    "max_num_seqs",
-    "max_num_batched_tokens",
-    "kv_cache_dtype",
+def _identity(value: Any) -> Any:
+    """Default field transform — return the probed value unchanged."""
+    return value
+
+
+@dataclass(frozen=True)
+class _ProbeField:
+    """One extraction rule for :func:`probe_engine_runtime_config`.
+
+    Declarative replacement for per-field control flow: each row says where
+    to read (``section`` + precedence-ordered ``sources``), what to call the
+    result (``out_key``), how to normalize it (``transform``), and whether
+    the flag-engagement check compares it (``checked``).
+    """
+
+    section: str
+    """``vllm_config`` sub-object attribute, e.g. ``"scheduler_config"``."""
+    sources: tuple[str, ...]
+    """Candidate source attribute names, modern-name-first precedence."""
+    out_key: str
+    """Key under which the value is surfaced in the probe result."""
+    transform: Callable[[Any], Any] = _identity
+    """Normalizer applied to the first present source value."""
+    checked: bool = True
+    """Whether :data:`ENGINE_CONFIG_CHECKED_FIELDS` includes this field."""
+
+
+# The single source of truth for what the probe extracts. Adding a probed
+# field is one row here — no new control flow. ``sources`` ordering encodes
+# vLLM's cross-version attribute renames (modern name first, legacy fallback).
+_PROBE_FIELDS: tuple[_ProbeField, ...] = (
+    _ProbeField("scheduler_config", ("max_num_seqs",), "max_num_seqs"),
+    _ProbeField("scheduler_config", ("max_num_batched_tokens",), "max_num_batched_tokens"),
+    _ProbeField(
+        "scheduler_config",
+        ("chunked_prefill_enabled", "enable_chunked_prefill"),
+        "enable_chunked_prefill",
+        transform=bool,
+    ),
+    _ProbeField("cache_config", ("enable_prefix_caching",), "enable_prefix_caching"),
+    _ProbeField("cache_config", ("kv_cache_dtype", "cache_dtype"), "kv_cache_dtype"),
+    # Probed for observability but excluded from the flag-engagement check.
+    _ProbeField("speculative_config", ("method",), "speculative_method", checked=False),
 )
 
 
-def probe_engine_runtime_config(llm: Any) -> dict[str, Any]:
+# Engine-config fields the flag-engagement check compares intended-vs-actual.
+# Derived from the probe table so the two cannot drift: a field is checked iff
+# the probe can surface it and the row opts in via ``checked=True``.
+ENGINE_CONFIG_CHECKED_FIELDS: tuple[str, ...] = tuple(f.out_key for f in _PROBE_FIELDS if f.checked)
+
+
+def _engine_vllm_config(llm: object) -> Any | None:
+    """Resolve ``llm.llm_engine.vllm_config`` (or the v0 ``llm.engine`` name).
+
+    Pure ``getattr`` traversal; returns ``None`` when any link is absent.
+    """
+    engine = getattr(llm, "llm_engine", None) or getattr(llm, "engine", None)
+    return getattr(engine, "vllm_config", None) if engine is not None else None
+
+
+def _first_present(obj: object, names: tuple[str, ...]) -> Any | None:
+    """Return the first non-``None`` attribute among ``names``, else ``None``."""
+    for name in names:
+        value = getattr(obj, name, None)
+        if value is not None:
+            return value
+    return None
+
+
+def probe_engine_runtime_config(llm: object) -> dict[str, Any]:
     """Best-effort introspection of the engine's effective runtime config.
 
     Returns a flat dict of the load-bearing scheduler/cache/speculative
-    settings. Empty dict on any failure — this is observability, not a
-    correctness gate. Tries ``llm.llm_engine.vllm_config`` first, then
-    ``llm.engine.vllm_config`` to span vLLM v0/v1 attribute naming.
+    settings drawn from :data:`_PROBE_FIELDS`. Empty dict when the engine
+    config can't be reached — this is observability, not a correctness gate.
+
+    Degrades at field granularity: a malformed individual attribute skips
+    that one field rather than emptying the whole result.
+
+    Typed ``object`` (not ``LLM``) on purpose: the probe is pure defensive
+    ``getattr`` introspection and degrades on any shape, so it does not
+    require — and must not claim to require — the concrete engine type.
     """
     try:
-        engine = getattr(llm, "llm_engine", None) or getattr(llm, "engine", None)
-        vcfg = getattr(engine, "vllm_config", None) if engine is not None else None
-        if vcfg is None:
-            return {}
-        out: dict[str, Any] = {}
-        scheduler = getattr(vcfg, "scheduler_config", None)
-        if scheduler is not None:
-            for attr in ("max_num_seqs", "max_num_batched_tokens"):
-                value = getattr(scheduler, attr, None)
-                if value is not None:
-                    out[attr] = value
-            chunked = getattr(scheduler, "chunked_prefill_enabled", None)
-            if chunked is None:
-                chunked = getattr(scheduler, "enable_chunked_prefill", None)
-            if chunked is not None:
-                out["enable_chunked_prefill"] = bool(chunked)
-        cache = getattr(vcfg, "cache_config", None)
-        if cache is not None:
-            for attr in ("enable_prefix_caching", "cache_dtype", "kv_cache_dtype"):
-                value = getattr(cache, attr, None)
-                if value is not None:
-                    out[attr if attr != "cache_dtype" else "kv_cache_dtype"] = value
-        spec = getattr(vcfg, "speculative_config", None)
-        if spec is not None:
-            method = getattr(spec, "method", None)
-            if method is not None:
-                out["speculative_method"] = method
-        return out
+        vcfg = _engine_vllm_config(llm)
     except Exception:  # noqa: BLE001 — degraded mode by design
         return {}
+    if vcfg is None:
+        return {}
+    out: dict[str, Any] = {}
+    for spec in _PROBE_FIELDS:
+        try:
+            section = getattr(vcfg, spec.section, None)
+            if section is None:
+                continue
+            value = _first_present(section, spec.sources)
+            if value is not None:
+                out[spec.out_key] = spec.transform(value)
+        except Exception:  # noqa: BLE001 — degrade one field, not the whole probe
+            continue
+    return out
 
 
 def flag_engagement_mismatches(
@@ -415,13 +469,30 @@ METRIC_SPEC_NUM_DRAFT_TOKENS = "vllm:spec_decode_num_draft_tokens"
 METRIC_SPEC_NUM_ACCEPTED_TOKENS = "vllm:spec_decode_num_accepted_tokens"
 
 
-def read_vllm_runtime_metrics(llm: LLM | None) -> dict[str, float | None]:
+class VllmRuntimeMetrics(TypedDict):
+    """End-of-generation vLLM metric snapshot with a fixed key set.
+
+    Every value is ``float | None``; ``None`` means the engine did not
+    surface that counter on this cell (distinct from a measured zero).
+
+    A ``TypedDict`` rather than a dataclass on purpose: the value stays a
+    plain ``dict`` at runtime, so dict-style consumers (e.g. the benchmark
+    harness) are unaffected, while callers gain static key checking and
+    ``float | None`` value typing instead of ``dict[str, float | None]``.
+    """
+
+    kv_cache_usage_perc: float | None
+    prefix_cache_hit_rate: float | None
+    spec_accept_rate: float | None
+
+
+def read_vllm_runtime_metrics(llm: LLM | None) -> VllmRuntimeMetrics:
     """Snapshot ``llm.get_metrics()`` for known metrics; degraded-mode on failure.
 
-    Returns a dict with stable keys regardless of which metrics were
-    actually exposed by the engine — missing metrics map to ``None``.
-    Callers should treat ``None`` as "engine didn't surface this counter"
-    and not crash on missing data.
+    Returns a :class:`VllmRuntimeMetrics` with stable keys regardless of
+    which metrics the engine actually exposed — missing metrics map to
+    ``None``. Callers should treat ``None`` as "engine didn't surface this
+    counter" and not crash on missing data.
 
     Currently captures:
 
@@ -435,44 +506,46 @@ def read_vllm_runtime_metrics(llm: LLM | None) -> dict[str, float | None]:
       registered at runtime by the spec-decode subsystem; absent
       otherwise) — distinguishes "not measured" from "measured zero".
     """
-    out: dict[str, float | None] = {
+    out: VllmRuntimeMetrics = {
         "kv_cache_usage_perc": None,
         "prefix_cache_hit_rate": None,
         "spec_accept_rate": None,
     }
     if llm is None:
         return out
+
+    # Whole-body guard: this is a best-effort probe, so any failure (the
+    # engine call, an unexpected metric shape, a non-numeric value) degrades
+    # to the stable all-``None`` dict rather than propagating. Callers can
+    # therefore trust the return contract without re-wrapping the call.
     try:
-        metrics = llm.get_metrics()
-    except Exception as exc:  # noqa: BLE001 — degraded mode
-        logger.debug("read_vllm_runtime_metrics: get_metrics failed: %s", exc)
-        return out
+        kv_usage: float | None = None
+        prefix_hits: float | None = None
+        prefix_queries: float | None = None
+        spec_accepted: float | None = None
+        spec_drafted: float | None = None
+        for m in llm.get_metrics():
+            name = getattr(m, "name", "")
+            value = getattr(m, "value", None)
+            if value is None:
+                continue
+            if name == METRIC_KV_CACHE_USAGE_PERC:
+                kv_usage = float(value)
+            elif name == METRIC_PREFIX_CACHE_HITS:
+                prefix_hits = float(value)
+            elif name == METRIC_PREFIX_CACHE_QUERIES:
+                prefix_queries = float(value)
+            elif name == METRIC_SPEC_NUM_ACCEPTED_TOKENS:
+                spec_accepted = float(value)
+            elif name == METRIC_SPEC_NUM_DRAFT_TOKENS:
+                spec_drafted = float(value)
 
-    kv_usage: float | None = None
-    prefix_hits: float | None = None
-    prefix_queries: float | None = None
-    spec_accepted: float | None = None
-    spec_drafted: float | None = None
-    for m in metrics:
-        name = getattr(m, "name", "")
-        value = getattr(m, "value", None)
-        if value is None:
-            continue
-        if name == METRIC_KV_CACHE_USAGE_PERC:
-            kv_usage = float(value)
-        elif name == METRIC_PREFIX_CACHE_HITS:
-            prefix_hits = float(value)
-        elif name == METRIC_PREFIX_CACHE_QUERIES:
-            prefix_queries = float(value)
-        elif name == METRIC_SPEC_NUM_ACCEPTED_TOKENS:
-            spec_accepted = float(value)
-        elif name == METRIC_SPEC_NUM_DRAFT_TOKENS:
-            spec_drafted = float(value)
-
-    if kv_usage is not None:
-        out["kv_cache_usage_perc"] = kv_usage
-    if prefix_hits is not None and prefix_queries is not None and prefix_queries > 0:
-        out["prefix_cache_hit_rate"] = prefix_hits / prefix_queries
-    if spec_accepted is not None and spec_drafted is not None and spec_drafted > 0:
-        out["spec_accept_rate"] = spec_accepted / spec_drafted
+        if kv_usage is not None:
+            out["kv_cache_usage_perc"] = kv_usage
+        if prefix_hits is not None and prefix_queries is not None and prefix_queries > 0:
+            out["prefix_cache_hit_rate"] = prefix_hits / prefix_queries
+        if spec_accepted is not None and spec_drafted is not None and spec_drafted > 0:
+            out["spec_accept_rate"] = spec_accepted / spec_drafted
+    except Exception as exc:  # noqa: BLE001 — degraded mode by design
+        logger.debug("read_vllm_runtime_metrics failed: %s", exc)
     return out

--- a/src/nemo_safe_synthesizer/generation/vllm_observability.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_observability.py
@@ -25,7 +25,7 @@ Four primitives, all degraded-mode by design:
   regardless of which metrics the engine actually exposed.
 
 Plus the :class:`GenerationObservability` pydantic model — the schema for the
-``vllm.generation.complete`` structured event emitted at the end of each
+generation-complete structured event emitted at the end of each
 generation invocation. Forward-compatible: new optional fields can be
 added without breaking existing consumers because the model uses
 ``extra="forbid"`` (so producers are forced to update when they add new
@@ -96,7 +96,7 @@ Used by :meth:`GenerationObservability.to_wandb_payload`.
 
 
 class GenerationObservability(BaseModel):
-    """One ``vllm.generation.complete`` event payload.
+    """One generation-complete event payload.
 
     Emitted by ``VllmBackend.generate()`` at end of each generation
     invocation. Consumed by:

--- a/src/nemo_safe_synthesizer/generation/vllm_observability.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_observability.py
@@ -164,6 +164,51 @@ class CellObservability(BaseModel):
         ),
     )
 
+    def to_wandb_payload(self, prefix: str = "vllm_cell") -> dict[str, Any]:
+        """Flatten this event into a wandb-friendly ``wandb.log(...)`` dict.
+
+        Wandb plots scalars cleanly but renders tuples/dicts as opaque
+        blobs, so this method:
+
+        - Drops ``None`` values (wandb would drop them anyway; explicit
+          here for documentation).
+        - Unpacks ``loadavg_pre`` / ``loadavg_post`` 3-tuples to per-
+          duration scalars (``loadavg_pre_1m`` / ``_5m`` / ``_15m``).
+        - Flattens ``engine_runtime_config`` to ``engine_runtime/<key>``
+          scalars (mirrors the existing flattening pattern in the
+          benchmark harness).
+
+        All keys are namespaced under ``prefix`` so production cell
+        events don't collide with other wandb metrics in the same run.
+        """
+        payload: dict[str, Any] = {}
+        for scalar_field in (
+            "peak_vram_gb",
+            "kv_cache_usage_perc",
+            "prefix_cache_hit_rate",
+            "spec_accept_rate",
+            "flag_did_not_engage",
+        ):
+            value = getattr(self, scalar_field)
+            if value is not None:
+                payload[f"{prefix}/{scalar_field}"] = value
+        for side in ("pre", "post"):
+            tup = getattr(self, f"loadavg_{side}")
+            if tup is None:
+                continue
+            for label, value in zip(_LOADAVG_HORIZON_LABELS, tup, strict=False):
+                payload[f"{prefix}/loadavg_{side}_{label}"] = value
+        for key, value in self.engine_runtime_config.items():
+            payload[f"{prefix}/engine_runtime/{key}"] = value
+        return payload
+
+
+_LOADAVG_HORIZON_LABELS: tuple[str, str, str] = ("1m", "5m", "15m")
+"""Labels for unpacked ``/proc/loadavg`` triples on the wandb side.
+
+Used by :meth:`CellObservability.to_wandb_payload`.
+"""
+
 
 # ---------------------------------------------------------------------------
 # NVML peak sampler

--- a/src/nemo_safe_synthesizer/observability.py
+++ b/src/nemo_safe_synthesizer/observability.py
@@ -81,6 +81,8 @@ __all__ = [
     "traced_system",
     "traced_backend",
     "heartbeat",
+    "NvmlPeakSampler",
+    "read_loadavg",
 ]
 
 
@@ -1005,3 +1007,139 @@ def heartbeat(
             _logger.error(f"{message} failed", extra={"ctx": ctx})
         else:
             _logger.info(f"{message} complete", extra={"ctx": _extra()})
+
+
+# ---------------------------------------------------------------------------
+# Hardware sampling primitives (shared across training + generation backends)
+# ---------------------------------------------------------------------------
+
+#: Plain stdlib logger for the degraded-mode hardware-sampling primitives.
+#: Avoids reentrancy with the structlog machinery this module configures.
+_hw_logger = logging.getLogger(__name__)
+
+
+def _default_nvml_device_index() -> int:
+    """Physical NVML index of the first CUDA-visible device.
+
+    NVML's ``nvmlDeviceGetHandleByIndex`` enumerates *physical* GPUs and
+    ignores ``CUDA_VISIBLE_DEVICES``, whereas the workload (single-GPU here)
+    runs on CUDA logical device 0 -- which the env var may remap to a different
+    physical GPU. Returns the physical index of the first visible device so the
+    sampler tracks the GPU the workload actually uses.
+
+    Falls back to ``0`` when ``CUDA_VISIBLE_DEVICES`` is unset, empty, or not a
+    plain integer list (e.g. ``GPU-<uuid>`` / ``MIG-...`` specs this does not
+    decode) -- degraded mode, consistent with the rest of this primitive.
+    """
+    raw = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if not raw:
+        return 0
+    first = raw.split(",")[0].strip()
+    try:
+        return int(first)
+    except ValueError:
+        return 0
+
+
+class NvmlPeakSampler:
+    """Daemon-thread sampler tracking peak device VRAM via NVML.
+
+    Use as a context manager wrapping the work whose peak VRAM you want::
+
+        with NvmlPeakSampler() as vram:
+            ...  # build engine / run training / generate
+        peak_gb = vram.peak_gb  # float | None
+
+    Returns ``None`` from :attr:`peak_gb` when NVML isn't available (driver
+    missing, pynvml import failed, device index invalid). Reads at the driver
+    layer, so it sees allocations made by worker subprocesses regardless of
+    which process holds the torch handle. Reports device-wide VRAM -- on a
+    dedicated host that equals the workload's allocation; on a shared GPU it
+    includes other process allocations.
+
+    ``device_index`` defaults to the first ``CUDA_VISIBLE_DEVICES`` entry (see
+    :func:`_default_nvml_device_index`) so the sampler follows the workload's
+    GPU on multi-GPU hosts instead of always reading physical GPU 0. Pass an
+    explicit index to override.
+    """
+
+    def __init__(self, device_index: int | None = None, interval_seconds: float = 0.25) -> None:
+        self._device_index = _default_nvml_device_index() if device_index is None else device_index
+        self._interval = interval_seconds
+        self._stop = threading.Event()
+        self._peak_bytes = 0
+        self._lock = threading.Lock()
+        self._thread: threading.Thread | None = None
+        self._handle: Any = None
+        self._pynvml: Any = None
+
+    def __enter__(self) -> NvmlPeakSampler:
+        try:
+            import pynvml  # noqa: PLC0415 -- soft dep, no top-level cost
+        except ImportError:
+            _hw_logger.debug("nvml-sampler: pynvml unavailable; peak VRAM will be None")
+            return self
+        try:
+            pynvml.nvmlInit()
+            self._pynvml = pynvml
+            self._handle = pynvml.nvmlDeviceGetHandleByIndex(self._device_index)
+        except pynvml.NVMLError as exc:  # driver missing, bad index, etc. -- degraded mode
+            _hw_logger.warning("nvml-sampler: init failed; peak VRAM will be None: %s", exc)
+            if self._pynvml is not None:
+                try:
+                    self._pynvml.nvmlShutdown()
+                except self._pynvml.NVMLError:
+                    _hw_logger.debug("nvml-sampler: nvmlShutdown failed after init error", exc_info=True)
+            self._pynvml = None
+            return self
+        self._thread = threading.Thread(target=self._run, daemon=True, name=f"nvml-sampler[{self._device_index}]")
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        if self._pynvml is not None:
+            try:
+                self._pynvml.nvmlShutdown()
+            except self._pynvml.NVMLError:  # shutdown is best-effort; init already succeeded
+                _hw_logger.debug("nvml-sampler: nvmlShutdown failed", exc_info=True)
+
+    @property
+    def peak_gb(self) -> float | None:
+        """Peak device-wide VRAM (GiB) observed during sampling; ``None`` if NVML unavailable."""
+        if self._pynvml is None:
+            return None
+        with self._lock:
+            return self._peak_bytes / (1024**3)
+
+    def _run(self) -> None:
+        """Poll loop. Tolerates transient NVML errors without dying."""
+        assert self._pynvml is not None
+        while not self._stop.is_set():
+            try:
+                info = self._pynvml.nvmlDeviceGetMemoryInfo(self._handle)
+                used = int(info.used)
+                with self._lock:
+                    if used > self._peak_bytes:
+                        self._peak_bytes = used
+            except self._pynvml.NVMLError:  # transient driver hiccup -- keep sampling
+                pass
+            self._stop.wait(self._interval)
+
+
+def read_loadavg() -> tuple[float, float, float] | None:
+    """Return ``/proc/loadavg`` as a (1m, 5m, 15m) triple; ``None`` when unavailable.
+
+    Linux-only. Cheap (one syscall). Safe to call from any process -- the read
+    is host-scoped, not process-scoped. Designed to bracket a workload: caller
+    reads pre + post, the pair is informative about whether host load drifted
+    during the run.
+    """
+    try:
+        with open("/proc/loadavg", encoding="utf-8") as f:
+            parts = f.read().split()
+        return (float(parts[0]), float(parts[1]), float(parts[2]))
+    except (OSError, ValueError, IndexError):
+        return None

--- a/tests/generation/test_vllm_backend.py
+++ b/tests/generation/test_vllm_backend.py
@@ -475,13 +475,14 @@ class TestGenerationObservabilityEmission:
                 return_value={"kv_cache_usage_perc": 0.4, "prefix_cache_hit_rate": 0.9, "spec_accept_rate": None},
             ),
             patch("nemo_safe_synthesizer.generation.vllm_backend.read_loadavg", return_value=(1.0, 2.0, 3.0)),
-            patch("nemo_safe_synthesizer.generation.vllm_backend.log_generation_observability") as mock_log_wandb,
+            patch("nemo_safe_synthesizer.generation.vllm_backend.log_observability_event") as mock_log_wandb,
             patch("nemo_safe_synthesizer.generation.vllm_backend.logger") as mock_logger,
         ):
             backend._emit_generation_observability(sampler, (0.5, 0.6, 0.7))
 
         mock_log_wandb.assert_called_once()
         (event,) = mock_log_wandb.call_args.args
+        assert mock_log_wandb.call_args.kwargs == {"prefix": "vllm_gen"}
         assert isinstance(event, GenerationObservability)
         assert event.peak_vram_gb == 12.5
         assert event.kv_cache_usage_perc == 0.4

--- a/tests/generation/test_vllm_backend.py
+++ b/tests/generation/test_vllm_backend.py
@@ -406,7 +406,7 @@ class TestInitializeModelRef:
     ):
         """``initialize()`` probes the engine once and caches the effective runtime config.
 
-        The cached dict is the source the ``vllm.generation.complete`` event reads
+        The cached dict is the source the generation-complete event reads
         at end of generation, so the init-time wiring is part of the
         observability contract.
         """
@@ -439,7 +439,7 @@ class TestInitializeModelRef:
 
 
 class TestGenerationObservabilityEmission:
-    """The ``vllm.generation.complete`` production emission contract.
+    """The generation-complete production emission contract.
 
     Covers the path that backend sampling-plumbing tests skip: that
     ``generate()`` always runs the finalizer, and that the finalizer
@@ -493,8 +493,8 @@ class TestGenerationObservabilityEmission:
         # is read fresh inside the finalizer.
         assert event.loadavg_pre == (0.5, 0.6, 0.7)
         assert event.loadavg_post == (1.0, 2.0, 3.0)
-        # The same event is mirrored to structured logs as ``vllm.generation.complete``.
-        mock_logger.runtime.info.assert_called_once_with("vllm.generation.complete", extra={"ctx": event.model_dump()})
+        # The same event is mirrored to structured logs as "vLLM generation complete".
+        mock_logger.runtime.info.assert_called_once_with("vLLM generation complete", extra={"ctx": event.model_dump()})
 
     def test_emit_swallows_failures(self, base_params, mock_model_metadata, mock_schema, mock_workdir):
         """A failure inside emission must not propagate — observability is best-effort."""

--- a/tests/generation/test_vllm_backend.py
+++ b/tests/generation/test_vllm_backend.py
@@ -19,7 +19,7 @@ from nemo_safe_synthesizer.config.generate import ValidationParameters
 from nemo_safe_synthesizer.defaults import DEFAULT_SAMPLING_PARAMETERS
 from nemo_safe_synthesizer.errors import ParameterError
 from nemo_safe_synthesizer.generation.processors import TabularDataProcessor
-from nemo_safe_synthesizer.generation.vllm_observability import CellObservability
+from nemo_safe_synthesizer.generation.vllm_observability import GenerationObservability
 from nemo_safe_synthesizer.llm.metadata import ModelMetadata
 
 
@@ -406,7 +406,7 @@ class TestInitializeModelRef:
     ):
         """``initialize()`` probes the engine once and caches the effective runtime config.
 
-        The cached dict is the source the ``vllm.cell.complete`` event reads
+        The cached dict is the source the ``vllm.generation.complete`` event reads
         at end of generation, so the init-time wiring is part of the
         observability contract.
         """
@@ -438,30 +438,30 @@ class TestInitializeModelRef:
         assert backend._engine_runtime_config == {"max_num_seqs": 256, "enable_prefix_caching": True}
 
 
-class TestCellObservabilityEmission:
-    """The ``vllm.cell.complete`` production emission contract.
+class TestGenerationObservabilityEmission:
+    """The ``vllm.generation.complete`` production emission contract.
 
     Covers the path that backend sampling-plumbing tests skip: that
     ``generate()`` always runs the finalizer, and that the finalizer
-    assembles and routes a ``CellObservability`` without ever breaking
+    assembles and routes a ``GenerationObservability`` without ever breaking
     generation.
     """
 
     def test_generate_runs_finalizer_even_when_body_fails(
         self, base_params, mock_model_metadata, mock_schema, mock_workdir
     ):
-        """A failure inside the generation loop must still emit the cell event."""
+        """A failure inside the generation loop must still emit the generation event."""
         backend = create_backend(base_params, mock_model_metadata, mock_schema, mock_workdir)
         backend.prepare_params = MagicMock(side_effect=StopIteration("short-circuit"))
 
-        with patch.object(backend, "_emit_cell_observability") as mock_emit:
+        with patch.object(backend, "_emit_generation_observability") as mock_emit:
             with pytest.raises(StopIteration):
                 backend.generate()
 
         mock_emit.assert_called_once()
 
     def test_emit_assembles_and_routes_event(self, base_params, mock_model_metadata, mock_schema, mock_workdir):
-        """The finalizer builds a CellObservability from probes and routes it to logs + wandb."""
+        """The finalizer builds a GenerationObservability from probes and routes it to logs + wandb."""
         backend = create_backend(base_params, mock_model_metadata, mock_schema, mock_workdir)
         backend.llm = None
         backend._engine_runtime_config = {"enable_prefix_caching": True}
@@ -475,13 +475,14 @@ class TestCellObservabilityEmission:
                 return_value={"kv_cache_usage_perc": 0.4, "prefix_cache_hit_rate": 0.9, "spec_accept_rate": None},
             ),
             patch("nemo_safe_synthesizer.generation.vllm_backend.read_loadavg", return_value=(1.0, 2.0, 3.0)),
-            patch("nemo_safe_synthesizer.generation.vllm_backend.log_cell_observability") as mock_log_wandb,
+            patch("nemo_safe_synthesizer.generation.vllm_backend.log_generation_observability") as mock_log_wandb,
+            patch("nemo_safe_synthesizer.generation.vllm_backend.logger") as mock_logger,
         ):
-            backend._emit_cell_observability(sampler, (0.5, 0.6, 0.7))
+            backend._emit_generation_observability(sampler, (0.5, 0.6, 0.7))
 
         mock_log_wandb.assert_called_once()
         (event,) = mock_log_wandb.call_args.args
-        assert isinstance(event, CellObservability)
+        assert isinstance(event, GenerationObservability)
         assert event.peak_vram_gb == 12.5
         assert event.kv_cache_usage_perc == 0.4
         assert event.prefix_cache_hit_rate == 0.9
@@ -491,6 +492,8 @@ class TestCellObservabilityEmission:
         # is read fresh inside the finalizer.
         assert event.loadavg_pre == (0.5, 0.6, 0.7)
         assert event.loadavg_post == (1.0, 2.0, 3.0)
+        # The same event is mirrored to structured logs as ``vllm.generation.complete``.
+        mock_logger.runtime.info.assert_called_once_with("vllm.generation.complete", extra={"ctx": event.model_dump()})
 
     def test_emit_swallows_failures(self, base_params, mock_model_metadata, mock_schema, mock_workdir):
         """A failure inside emission must not propagate — observability is best-effort."""
@@ -505,7 +508,7 @@ class TestCellObservabilityEmission:
             side_effect=RuntimeError("probe blew up"),
         ):
             # Must not raise.
-            backend._emit_cell_observability(sampler, None)
+            backend._emit_generation_observability(sampler, None)
 
 
 class TestResolveTemperature:

--- a/tests/generation/test_vllm_backend.py
+++ b/tests/generation/test_vllm_backend.py
@@ -19,6 +19,7 @@ from nemo_safe_synthesizer.config.generate import ValidationParameters
 from nemo_safe_synthesizer.defaults import DEFAULT_SAMPLING_PARAMETERS
 from nemo_safe_synthesizer.errors import ParameterError
 from nemo_safe_synthesizer.generation.processors import TabularDataProcessor
+from nemo_safe_synthesizer.generation.vllm_observability import CellObservability
 from nemo_safe_synthesizer.llm.metadata import ModelMetadata
 
 
@@ -394,6 +395,117 @@ class TestInitializeModelRef:
         assert backend.llm is mock_llm
         assert mock_vllm.call_args.kwargs["model"] == str(snapshot)
         assert mock_vllm.call_args.kwargs["trust_remote_code"] is True
+
+    def test_initialize_caches_engine_runtime_config(
+        self,
+        base_params,
+        mock_model_metadata,
+        mock_schema,
+        mock_workdir,
+        fixture_cached_nvidia_snapshot,
+    ):
+        """``initialize()`` probes the engine once and caches the effective runtime config.
+
+        The cached dict is the source the ``vllm.cell.complete`` event reads
+        at end of generation, so the init-time wiring is part of the
+        observability contract.
+        """
+        cache_root, _ = fixture_cached_nvidia_snapshot
+        base_params.training.pretrained_model = "nvidia/Nemotron-Mini-4B-Instruct"
+        backend = create_backend(base_params, mock_model_metadata, mock_schema, mock_workdir)
+        # Pre-condition: nothing cached before initialize().
+        assert backend._engine_runtime_config == {}
+
+        mock_llm = MagicMock()
+        mock_llm.get_tokenizer.return_value = MagicMock()
+
+        with (
+            patch(
+                "nemo_safe_synthesizer.generation.vllm_backend.ModelRef._default_hf_cache_root",
+                return_value=cache_root,
+            ),
+            patch("nemo_safe_synthesizer.generation.vllm_backend.vLLM", return_value=mock_llm),
+            patch("nemo_safe_synthesizer.generation.vllm_backend.get_max_vram", return_value={0: 0.8}),
+            patch("nemo_safe_synthesizer.generation.vllm_backend.create_processor", return_value=MagicMock()),
+            patch(
+                "nemo_safe_synthesizer.generation.vllm_backend.probe_engine_runtime_config",
+                return_value={"max_num_seqs": 256, "enable_prefix_caching": True},
+            ) as mock_probe,
+        ):
+            backend.initialize()
+
+        mock_probe.assert_called_once_with(mock_llm)
+        assert backend._engine_runtime_config == {"max_num_seqs": 256, "enable_prefix_caching": True}
+
+
+class TestCellObservabilityEmission:
+    """The ``vllm.cell.complete`` production emission contract.
+
+    Covers the path that backend sampling-plumbing tests skip: that
+    ``generate()`` always runs the finalizer, and that the finalizer
+    assembles and routes a ``CellObservability`` without ever breaking
+    generation.
+    """
+
+    def test_generate_runs_finalizer_even_when_body_fails(
+        self, base_params, mock_model_metadata, mock_schema, mock_workdir
+    ):
+        """A failure inside the generation loop must still emit the cell event."""
+        backend = create_backend(base_params, mock_model_metadata, mock_schema, mock_workdir)
+        backend.prepare_params = MagicMock(side_effect=StopIteration("short-circuit"))
+
+        with patch.object(backend, "_emit_cell_observability") as mock_emit:
+            with pytest.raises(StopIteration):
+                backend.generate()
+
+        mock_emit.assert_called_once()
+
+    def test_emit_assembles_and_routes_event(self, base_params, mock_model_metadata, mock_schema, mock_workdir):
+        """The finalizer builds a CellObservability from probes and routes it to logs + wandb."""
+        backend = create_backend(base_params, mock_model_metadata, mock_schema, mock_workdir)
+        backend.llm = None
+        backend._engine_runtime_config = {"enable_prefix_caching": True}
+
+        sampler = MagicMock()
+        sampler.peak_gb = 12.5
+
+        with (
+            patch(
+                "nemo_safe_synthesizer.generation.vllm_backend.read_vllm_runtime_metrics",
+                return_value={"kv_cache_usage_perc": 0.4, "prefix_cache_hit_rate": 0.9, "spec_accept_rate": None},
+            ),
+            patch("nemo_safe_synthesizer.generation.vllm_backend.read_loadavg", return_value=(1.0, 2.0, 3.0)),
+            patch("nemo_safe_synthesizer.generation.vllm_backend.log_cell_observability") as mock_log_wandb,
+        ):
+            backend._emit_cell_observability(sampler, (0.5, 0.6, 0.7))
+
+        mock_log_wandb.assert_called_once()
+        (event,) = mock_log_wandb.call_args.args
+        assert isinstance(event, CellObservability)
+        assert event.peak_vram_gb == 12.5
+        assert event.kv_cache_usage_perc == 0.4
+        assert event.prefix_cache_hit_rate == 0.9
+        assert event.spec_accept_rate is None
+        assert event.engine_runtime_config == {"enable_prefix_caching": True}
+        # ``loadavg_pre`` is the value captured before generation; ``loadavg_post``
+        # is read fresh inside the finalizer.
+        assert event.loadavg_pre == (0.5, 0.6, 0.7)
+        assert event.loadavg_post == (1.0, 2.0, 3.0)
+
+    def test_emit_swallows_failures(self, base_params, mock_model_metadata, mock_schema, mock_workdir):
+        """A failure inside emission must not propagate — observability is best-effort."""
+        backend = create_backend(base_params, mock_model_metadata, mock_schema, mock_workdir)
+        backend.llm = None
+
+        sampler = MagicMock()
+        sampler.peak_gb = 1.0
+
+        with patch(
+            "nemo_safe_synthesizer.generation.vllm_backend.read_vllm_runtime_metrics",
+            side_effect=RuntimeError("probe blew up"),
+        ):
+            # Must not raise.
+            backend._emit_cell_observability(sampler, None)
 
 
 class TestResolveTemperature:

--- a/tests/generation/test_vllm_observability.py
+++ b/tests/generation/test_vllm_observability.py
@@ -20,6 +20,7 @@ import pytest
 from pydantic import ValidationError
 
 from nemo_safe_synthesizer.generation.vllm_observability import (
+    ENGINE_CONFIG_CHECKED_FIELDS,
     METRIC_KV_CACHE_USAGE_PERC,
     METRIC_PREFIX_CACHE_HITS,
     METRIC_PREFIX_CACHE_QUERIES,
@@ -250,6 +251,64 @@ class TestProbeEngineRuntimeConfig:
         assert out["enable_chunked_prefill"] is True
         assert out["enable_prefix_caching"] is True
         assert out["kv_cache_dtype"] == "auto"  # legacy name surfaced under the modern key
+
+    def test_extracts_speculative_method(self) -> None:
+        """``speculative_config.method`` surfaces under ``speculative_method``."""
+        llm = SimpleNamespace(
+            llm_engine=SimpleNamespace(
+                vllm_config=SimpleNamespace(
+                    scheduler_config=None,
+                    cache_config=None,
+                    speculative_config=SimpleNamespace(method="eagle"),
+                ),
+            ),
+        )
+        out = probe_engine_runtime_config(llm)
+        assert out["speculative_method"] == "eagle"
+
+    def test_one_bad_section_does_not_sink_the_whole_probe(self) -> None:
+        """A section attribute that raises degrades that field only, not the result.
+
+        Field-granular degradation is the contract that replaced the old
+        whole-body try/except.
+        """
+
+        class _Exploding:
+            @property
+            def enable_prefix_caching(self) -> bool:
+                raise RuntimeError("boom")
+
+        llm = SimpleNamespace(
+            llm_engine=SimpleNamespace(
+                vllm_config=SimpleNamespace(
+                    scheduler_config=SimpleNamespace(max_num_seqs=128),
+                    cache_config=_Exploding(),
+                    speculative_config=None,
+                ),
+            ),
+        )
+        out = probe_engine_runtime_config(llm)
+        # The healthy field still lands; the exploding one is simply absent.
+        assert out["max_num_seqs"] == 128
+        assert "enable_prefix_caching" not in out
+
+
+class TestEngineConfigCheckedFields:
+    """``ENGINE_CONFIG_CHECKED_FIELDS`` is derived from the probe table."""
+
+    def test_checked_fields_match_expected_set(self) -> None:
+        """The engagement-checked fields are exactly the probe's ``checked=True`` keys."""
+        assert set(ENGINE_CONFIG_CHECKED_FIELDS) == {
+            "max_num_seqs",
+            "max_num_batched_tokens",
+            "enable_chunked_prefill",
+            "enable_prefix_caching",
+            "kv_cache_dtype",
+        }
+
+    def test_speculative_method_probed_but_not_checked(self) -> None:
+        """``speculative_method`` is observability-only — excluded from the check."""
+        assert "speculative_method" not in ENGINE_CONFIG_CHECKED_FIELDS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/generation/test_vllm_observability.py
+++ b/tests/generation/test_vllm_observability.py
@@ -392,20 +392,20 @@ class TestNvmlPeakSampler:
 
 
 # ---------------------------------------------------------------------------
-# log_generation_observability contracts
+# log_observability_event contracts
 # ---------------------------------------------------------------------------
 
 
-class TestLogGenerationObservability:
+class TestLogObservabilityEvent:
     """The wandb-side helper's degraded-mode + best-effort contracts."""
 
     def test_no_op_when_no_active_wandb_run(self, populated_event: GenerationObservability) -> None:
         """``wandb.run is None`` → return without raising or logging."""
         from nemo_safe_synthesizer.cli import wandb_setup
 
-        with patch.object(wandb_setup.wandb, "run", None):
-            # Should not raise; nothing to assert beyond "doesn't blow up".
-            wandb_setup.log_generation_observability(populated_event)
+        with patch.object(wandb_setup.wandb, "run", None), patch.object(wandb_setup.wandb, "log") as mock_log:
+            wandb_setup.log_observability_event(populated_event, prefix="vllm_gen")
+            mock_log.assert_not_called()
 
     def test_calls_wandb_log_when_run_is_active(self, populated_event: GenerationObservability) -> None:
         """When a run is active, the flattened payload is passed to ``wandb.log``."""
@@ -413,11 +413,11 @@ class TestLogGenerationObservability:
 
         fake_run = MagicMock()
         with patch.object(wandb_setup.wandb, "run", fake_run), patch.object(wandb_setup.wandb, "log") as mock_log:
-            wandb_setup.log_generation_observability(populated_event)
+            wandb_setup.log_observability_event(populated_event, prefix="vllm_gen")
             mock_log.assert_called_once()
             (call_args,) = mock_log.call_args.args
             # The payload contains exactly the keys from to_wandb_payload (namespaced + flattened).
-            assert call_args == populated_event.to_wandb_payload()
+            assert call_args == populated_event.to_wandb_payload(prefix="vllm_gen")
 
     def test_wandb_log_exception_swallowed(self, populated_event: GenerationObservability) -> None:
         """A wandb failure must not break generation — best-effort emission."""
@@ -429,4 +429,4 @@ class TestLogGenerationObservability:
             patch.object(wandb_setup.wandb, "log", side_effect=RuntimeError("wandb down")),
         ):
             # Should not raise.
-            wandb_setup.log_generation_observability(populated_event)
+            wandb_setup.log_observability_event(populated_event, prefix="vllm_gen")

--- a/tests/generation/test_vllm_observability.py
+++ b/tests/generation/test_vllm_observability.py
@@ -1,0 +1,373 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ``vllm_observability``.
+
+Scope: contracts consumers depend on — degraded-mode behavior, stable
+dict keys, schema round-trip, flattening semantics. NOT testing
+implementation details (field counts, log wording, init constants);
+those would break on every refactor without adding value.
+"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from nemo_safe_synthesizer.generation.vllm_observability import (
+    METRIC_KV_CACHE_USAGE_PERC,
+    METRIC_PREFIX_CACHE_HITS,
+    METRIC_PREFIX_CACHE_QUERIES,
+    METRIC_SPEC_NUM_ACCEPTED_TOKENS,
+    METRIC_SPEC_NUM_DRAFT_TOKENS,
+    CellObservability,
+    NvmlPeakSampler,
+    flag_engagement_mismatches,
+    probe_engine_runtime_config,
+    read_loadavg,
+    read_vllm_runtime_metrics,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+def _metric(name: str, value: float | int) -> Any:
+    """Build a minimal metric-like object with ``.name`` and ``.value``."""
+    m = MagicMock()
+    m.name = name
+    m.value = value
+    return m
+
+
+@pytest.fixture
+def mock_llm_no_metrics() -> Any:
+    """LLM mock that returns an empty metric list."""
+    llm = MagicMock()
+    llm.get_metrics.return_value = []
+    return llm
+
+
+@pytest.fixture
+def mock_llm_full_metrics() -> Any:
+    """LLM mock returning all known counters/gauges."""
+    llm = MagicMock()
+    llm.get_metrics.return_value = [
+        _metric(METRIC_KV_CACHE_USAGE_PERC, 0.42),
+        _metric(METRIC_PREFIX_CACHE_HITS, 80),
+        _metric(METRIC_PREFIX_CACHE_QUERIES, 100),
+        _metric(METRIC_SPEC_NUM_ACCEPTED_TOKENS, 720),
+        _metric(METRIC_SPEC_NUM_DRAFT_TOKENS, 1000),
+    ]
+    return llm
+
+
+@pytest.fixture
+def populated_event() -> CellObservability:
+    """A CellObservability with one value of each non-trivial field shape."""
+    return CellObservability(
+        peak_vram_gb=64.5,
+        kv_cache_usage_perc=0.42,
+        prefix_cache_hit_rate=0.99,
+        spec_accept_rate=0.72,
+        loadavg_pre=(2.5, 3.0, 3.5),
+        loadavg_post=(4.0, 3.5, 3.2),
+        engine_runtime_config={"enable_prefix_caching": True, "max_num_seqs": 256},
+        flag_did_not_engage=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CellObservability schema contracts
+# ---------------------------------------------------------------------------
+
+
+class TestCellObservabilitySchema:
+    """Schema contracts: defaults, round-trip, extra-fields policy."""
+
+    def test_all_measurement_fields_optional(self) -> None:
+        """Producers populate what they have; missing fields default to None/empty.
+
+        Important because the four primitives each have degraded-mode
+        paths that return None — the schema must accept that.
+        """
+        event = CellObservability()
+        assert event.peak_vram_gb is None
+        assert event.kv_cache_usage_perc is None
+        assert event.loadavg_pre is None
+        assert event.engine_runtime_config == {}
+        assert event.flag_did_not_engage is False
+
+    def test_json_round_trip_lossless(self, populated_event: CellObservability) -> None:
+        """Consumers depend on JSON round-trip — structured logs serialize to JSON, deserializers must rebuild the same event."""
+        rt = CellObservability.model_validate_json(populated_event.model_dump_json())
+        assert rt == populated_event
+
+    def test_extra_fields_forbidden(self) -> None:
+        """``extra='forbid'`` is the contract that forces schema updates when fields are added — silent drift would break consumers."""
+        with pytest.raises(ValidationError):
+            CellObservability.model_validate({"peak_vram_gb": 1.0, "unknown_field": "x"})
+
+
+# ---------------------------------------------------------------------------
+# to_wandb_payload flattening contracts
+# ---------------------------------------------------------------------------
+
+
+class TestToWandbPayload:
+    """Wandb-side flattening: namespace, None-drop, tuple unpack, dict flatten."""
+
+    def test_keys_are_namespaced_under_prefix(self, populated_event: CellObservability) -> None:
+        """Custom prefix prevents collision with other wandb metrics in the same run."""
+        payload = populated_event.to_wandb_payload(prefix="custom")
+        assert payload  # non-empty
+        assert all(k.startswith("custom/") for k in payload)
+
+    def test_none_values_dropped_explicitly(self) -> None:
+        """Wandb drops None silently anyway; we drop them explicitly so the payload's shape is predictable."""
+        event = CellObservability(peak_vram_gb=10.0, kv_cache_usage_perc=None)
+        payload = event.to_wandb_payload()
+        assert "vllm_cell/peak_vram_gb" in payload
+        assert "vllm_cell/kv_cache_usage_perc" not in payload
+
+    def test_loadavg_tuples_unpacked_to_per_horizon_scalars(self) -> None:
+        """3-tuples become 3 scalars — wandb plots scalars cleanly, tuples become opaque blobs."""
+        event = CellObservability(loadavg_pre=(1.0, 2.0, 3.0))
+        payload = event.to_wandb_payload()
+        assert payload["vllm_cell/loadavg_pre_1m"] == 1.0
+        assert payload["vllm_cell/loadavg_pre_5m"] == 2.0
+        assert payload["vllm_cell/loadavg_pre_15m"] == 3.0
+        # Raw tuple key is gone — only the unpacked scalars are exposed.
+        assert "vllm_cell/loadavg_pre" not in payload
+
+    def test_engine_config_flattened_under_engine_runtime_namespace(self) -> None:
+        """Engine-config dict gets flattened to scalars under ``engine_runtime/``."""
+        event = CellObservability(engine_runtime_config={"a": 1, "b": True})
+        payload = event.to_wandb_payload()
+        assert payload["vllm_cell/engine_runtime/a"] == 1
+        assert payload["vllm_cell/engine_runtime/b"] is True
+
+
+# ---------------------------------------------------------------------------
+# flag_engagement_mismatches contracts
+# ---------------------------------------------------------------------------
+
+
+class TestFlagEngagementMismatches:
+    """The 'only check explicitly-set fields against probed values' contract."""
+
+    @pytest.mark.parametrize(
+        ("intended", "actual", "expect_mismatch"),
+        [
+            # Clean match — no mismatch.
+            ({"enable_prefix_caching": True}, {"enable_prefix_caching": True}, False),
+            # Disagreement — mismatch.
+            ({"enable_prefix_caching": False}, {"enable_prefix_caching": True}, True),
+            # Caller didn't explicitly set the field → skip (no reference value).
+            ({"enable_prefix_caching": None}, {"enable_prefix_caching": True}, False),
+            # Probe didn't return the field → skip (probe is best-effort).
+            ({"enable_prefix_caching": True}, {}, False),
+            # Both empty — vacuously clean.
+            ({}, {}, False),
+        ],
+    )
+    def test_only_checks_when_both_sides_have_a_value(
+        self, intended: dict[str, Any], actual: dict[str, Any], expect_mismatch: bool
+    ) -> None:
+        mismatches = flag_engagement_mismatches(intended, actual)
+        assert bool(mismatches) is expect_mismatch
+        if expect_mismatch:
+            # Description must include the field name so operators can act.
+            assert any("enable_prefix_caching" in m for m in mismatches)
+
+
+# ---------------------------------------------------------------------------
+# read_loadavg contracts
+# ---------------------------------------------------------------------------
+
+
+class TestReadLoadavg:
+    def test_shape_when_available(self) -> None:
+        """Returns a 3-tuple of non-negative floats on Linux."""
+        result = read_loadavg()
+        if result is None:
+            pytest.skip("/proc/loadavg unavailable on this host")
+        assert isinstance(result, tuple)
+        assert len(result) == 3
+        assert all(isinstance(x, float) and x >= 0.0 for x in result)
+
+    def test_returns_none_on_read_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """OSError on the file open is the canonical 'unavailable' signal — degraded-mode contract."""
+        monkeypatch.setattr("builtins.open", MagicMock(side_effect=OSError("not available")))
+        assert read_loadavg() is None
+
+
+# ---------------------------------------------------------------------------
+# probe_engine_runtime_config contracts
+# ---------------------------------------------------------------------------
+
+
+class TestProbeEngineRuntimeConfig:
+    @pytest.mark.parametrize("bad_input", [None, object(), "not an llm"])
+    def test_empty_dict_on_any_failure(self, bad_input: Any) -> None:
+        """Best-effort probe: anything not vLLM-shaped returns ``{}`` rather than raising."""
+        assert probe_engine_runtime_config(bad_input) == {}
+
+    def test_extracts_known_fields_from_vllm_config(self) -> None:
+        """When the engine exposes vllm_config, the documented fields land in the result.
+
+        Uses ``SimpleNamespace`` instead of ``MagicMock`` because the
+        probe's "modern-name first, legacy fallback" logic relies on
+        ``getattr(obj, name, None)`` returning ``None`` for missing
+        attributes — MagicMock auto-creates them, which doesn't match
+        real vLLM behavior.
+        """
+        llm = SimpleNamespace(
+            llm_engine=SimpleNamespace(
+                vllm_config=SimpleNamespace(
+                    scheduler_config=SimpleNamespace(
+                        max_num_seqs=256,
+                        max_num_batched_tokens=8192,
+                        chunked_prefill_enabled=True,
+                    ),
+                    cache_config=SimpleNamespace(
+                        enable_prefix_caching=True,
+                        cache_dtype="auto",  # legacy attribute name
+                    ),
+                    speculative_config=None,
+                ),
+            ),
+        )
+        out = probe_engine_runtime_config(llm)
+        assert out["max_num_seqs"] == 256
+        assert out["max_num_batched_tokens"] == 8192
+        assert out["enable_chunked_prefill"] is True
+        assert out["enable_prefix_caching"] is True
+        assert out["kv_cache_dtype"] == "auto"  # legacy name surfaced under the modern key
+
+
+# ---------------------------------------------------------------------------
+# read_vllm_runtime_metrics contracts
+# ---------------------------------------------------------------------------
+
+
+_STABLE_METRIC_KEYS = {"kv_cache_usage_perc", "prefix_cache_hit_rate", "spec_accept_rate"}
+
+
+class TestReadVllmRuntimeMetrics:
+    def test_stable_keys_when_engine_returns_nothing(self, mock_llm_no_metrics: Any) -> None:
+        """Callers depend on the dict having these three keys regardless of which metrics were exposed."""
+        result = read_vllm_runtime_metrics(mock_llm_no_metrics)
+        assert set(result.keys()) == _STABLE_METRIC_KEYS
+        assert all(v is None for v in result.values())
+
+    def test_pulls_each_metric_into_its_slot(self, mock_llm_full_metrics: Any) -> None:
+        """Every documented metric lands in its named slot, with derivations applied for the rates."""
+        result = read_vllm_runtime_metrics(mock_llm_full_metrics)
+        assert result["kv_cache_usage_perc"] == 0.42
+        assert result["prefix_cache_hit_rate"] == pytest.approx(0.8)  # 80/100
+        assert result["spec_accept_rate"] == pytest.approx(0.72)  # 720/1000
+
+    def test_stable_keys_when_get_metrics_raises(self) -> None:
+        """Exception in ``get_metrics()`` → degraded-mode dict with Nones, not propagation."""
+        llm = MagicMock()
+        llm.get_metrics.side_effect = RuntimeError("engine dead")
+        result = read_vllm_runtime_metrics(llm)
+        assert set(result.keys()) == _STABLE_METRIC_KEYS
+        assert all(v is None for v in result.values())
+
+    def test_zero_denominator_yields_none_not_divide_by_zero(self) -> None:
+        """``num_draft_tokens == 0`` is "speculation registered but no drafts proposed" — return None, don't divide."""
+        llm = MagicMock()
+        llm.get_metrics.return_value = [
+            _metric(METRIC_SPEC_NUM_ACCEPTED_TOKENS, 0),
+            _metric(METRIC_SPEC_NUM_DRAFT_TOKENS, 0),
+        ]
+        result = read_vllm_runtime_metrics(llm)
+        assert result["spec_accept_rate"] is None
+
+
+# ---------------------------------------------------------------------------
+# NvmlPeakSampler contracts
+# ---------------------------------------------------------------------------
+
+
+class TestNvmlPeakSampler:
+    def test_context_manager_protocol(self) -> None:
+        """``__enter__`` returns self; ``__exit__`` cleans up without raising."""
+        sampler = NvmlPeakSampler()
+        result = sampler.__enter__()
+        try:
+            assert result is sampler
+        finally:
+            sampler.__exit__(None, None, None)
+
+    def test_peak_gb_typed_correctly(self) -> None:
+        """``peak_gb`` is ``float | None`` — the only two shapes consumers handle."""
+        with NvmlPeakSampler(interval_seconds=0.05) as sampler:
+            time.sleep(0.15)
+        assert sampler.peak_gb is None or isinstance(sampler.peak_gb, float)
+
+    def test_pynvml_unavailable_yields_none_peak(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ImportError on pynvml → sampler enters degraded mode, peak_gb is None."""
+        # Force the import to fail by patching ``__import__`` for the pynvml name only.
+        real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+        def _fail_pynvml(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "pynvml":
+                raise ImportError("simulated pynvml unavailable")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.__import__", _fail_pynvml)
+        with NvmlPeakSampler() as sampler:
+            pass
+        assert sampler.peak_gb is None
+
+
+# ---------------------------------------------------------------------------
+# log_cell_observability contracts
+# ---------------------------------------------------------------------------
+
+
+class TestLogCellObservability:
+    """The wandb-side helper's degraded-mode + best-effort contracts."""
+
+    def test_no_op_when_no_active_wandb_run(self, populated_event: CellObservability) -> None:
+        """``wandb.run is None`` → return without raising or logging."""
+        from nemo_safe_synthesizer.cli import wandb_setup
+
+        with patch.object(wandb_setup.wandb, "run", None):
+            # Should not raise; nothing to assert beyond "doesn't blow up".
+            wandb_setup.log_cell_observability(populated_event)
+
+    def test_calls_wandb_log_when_run_is_active(self, populated_event: CellObservability) -> None:
+        """When a run is active, the flattened payload is passed to ``wandb.log``."""
+        from nemo_safe_synthesizer.cli import wandb_setup
+
+        fake_run = MagicMock()
+        with patch.object(wandb_setup.wandb, "run", fake_run), patch.object(
+            wandb_setup.wandb, "log"
+        ) as mock_log:
+            wandb_setup.log_cell_observability(populated_event)
+            mock_log.assert_called_once()
+            (call_args,) = mock_log.call_args.args
+            # The payload contains exactly the keys from to_wandb_payload (namespaced + flattened).
+            assert call_args == populated_event.to_wandb_payload()
+
+    def test_wandb_log_exception_swallowed(self, populated_event: CellObservability) -> None:
+        """A wandb failure must not break generation — best-effort emission."""
+        from nemo_safe_synthesizer.cli import wandb_setup
+
+        fake_run = MagicMock()
+        with patch.object(wandb_setup.wandb, "run", fake_run), patch.object(
+            wandb_setup.wandb, "log", side_effect=RuntimeError("wandb down")
+        ):
+            # Should not raise.
+            wandb_setup.log_cell_observability(populated_event)

--- a/tests/generation/test_vllm_observability.py
+++ b/tests/generation/test_vllm_observability.py
@@ -33,7 +33,6 @@ from nemo_safe_synthesizer.generation.vllm_observability import (
     read_vllm_runtime_metrics,
 )
 
-
 # ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------
@@ -352,9 +351,7 @@ class TestLogCellObservability:
         from nemo_safe_synthesizer.cli import wandb_setup
 
         fake_run = MagicMock()
-        with patch.object(wandb_setup.wandb, "run", fake_run), patch.object(
-            wandb_setup.wandb, "log"
-        ) as mock_log:
+        with patch.object(wandb_setup.wandb, "run", fake_run), patch.object(wandb_setup.wandb, "log") as mock_log:
             wandb_setup.log_cell_observability(populated_event)
             mock_log.assert_called_once()
             (call_args,) = mock_log.call_args.args
@@ -366,8 +363,9 @@ class TestLogCellObservability:
         from nemo_safe_synthesizer.cli import wandb_setup
 
         fake_run = MagicMock()
-        with patch.object(wandb_setup.wandb, "run", fake_run), patch.object(
-            wandb_setup.wandb, "log", side_effect=RuntimeError("wandb down")
+        with (
+            patch.object(wandb_setup.wandb, "run", fake_run),
+            patch.object(wandb_setup.wandb, "log", side_effect=RuntimeError("wandb down")),
         ):
             # Should not raise.
             wandb_setup.log_cell_observability(populated_event)

--- a/tests/generation/test_vllm_observability.py
+++ b/tests/generation/test_vllm_observability.py
@@ -26,7 +26,7 @@ from nemo_safe_synthesizer.generation.vllm_observability import (
     METRIC_PREFIX_CACHE_QUERIES,
     METRIC_SPEC_NUM_ACCEPTED_TOKENS,
     METRIC_SPEC_NUM_DRAFT_TOKENS,
-    CellObservability,
+    GenerationObservability,
     NvmlPeakSampler,
     flag_engagement_mismatches,
     probe_engine_runtime_config,
@@ -70,9 +70,9 @@ def mock_llm_full_metrics() -> Any:
 
 
 @pytest.fixture
-def populated_event() -> CellObservability:
-    """A CellObservability with one value of each non-trivial field shape."""
-    return CellObservability(
+def populated_event() -> GenerationObservability:
+    """A GenerationObservability with one value of each non-trivial field shape."""
+    return GenerationObservability(
         peak_vram_gb=64.5,
         kv_cache_usage_perc=0.42,
         prefix_cache_hit_rate=0.99,
@@ -85,11 +85,11 @@ def populated_event() -> CellObservability:
 
 
 # ---------------------------------------------------------------------------
-# CellObservability schema contracts
+# GenerationObservability schema contracts
 # ---------------------------------------------------------------------------
 
 
-class TestCellObservabilitySchema:
+class TestGenerationObservabilitySchema:
     """Schema contracts: defaults, round-trip, extra-fields policy."""
 
     def test_all_measurement_fields_optional(self) -> None:
@@ -98,22 +98,22 @@ class TestCellObservabilitySchema:
         Important because the four primitives each have degraded-mode
         paths that return None — the schema must accept that.
         """
-        event = CellObservability()
+        event = GenerationObservability()
         assert event.peak_vram_gb is None
         assert event.kv_cache_usage_perc is None
         assert event.loadavg_pre is None
         assert event.engine_runtime_config == {}
         assert event.flag_did_not_engage is False
 
-    def test_json_round_trip_lossless(self, populated_event: CellObservability) -> None:
+    def test_json_round_trip_lossless(self, populated_event: GenerationObservability) -> None:
         """Consumers depend on JSON round-trip — structured logs serialize to JSON, deserializers must rebuild the same event."""
-        rt = CellObservability.model_validate_json(populated_event.model_dump_json())
+        rt = GenerationObservability.model_validate_json(populated_event.model_dump_json())
         assert rt == populated_event
 
     def test_extra_fields_forbidden(self) -> None:
         """``extra='forbid'`` is the contract that forces schema updates when fields are added — silent drift would break consumers."""
         with pytest.raises(ValidationError):
-            CellObservability.model_validate({"peak_vram_gb": 1.0, "unknown_field": "x"})
+            GenerationObservability.model_validate({"peak_vram_gb": 1.0, "unknown_field": "x"})
 
 
 # ---------------------------------------------------------------------------
@@ -124,7 +124,7 @@ class TestCellObservabilitySchema:
 class TestToWandbPayload:
     """Wandb-side flattening: namespace, None-drop, tuple unpack, dict flatten."""
 
-    def test_keys_are_namespaced_under_prefix(self, populated_event: CellObservability) -> None:
+    def test_keys_are_namespaced_under_prefix(self, populated_event: GenerationObservability) -> None:
         """Custom prefix prevents collision with other wandb metrics in the same run."""
         payload = populated_event.to_wandb_payload(prefix="custom")
         assert payload  # non-empty
@@ -132,27 +132,29 @@ class TestToWandbPayload:
 
     def test_none_values_dropped_explicitly(self) -> None:
         """Wandb drops None silently anyway; we drop them explicitly so the payload's shape is predictable."""
-        event = CellObservability(peak_vram_gb=10.0, kv_cache_usage_perc=None)
+        event = GenerationObservability(peak_vram_gb=10.0, kv_cache_usage_perc=None)
         payload = event.to_wandb_payload()
-        assert "vllm_cell/peak_vram_gb" in payload
-        assert "vllm_cell/kv_cache_usage_perc" not in payload
+        assert "vllm_gen/peak_vram_gb" in payload
+        assert "vllm_gen/kv_cache_usage_perc" not in payload
 
     def test_loadavg_tuples_unpacked_to_per_horizon_scalars(self) -> None:
         """3-tuples become 3 scalars — wandb plots scalars cleanly, tuples become opaque blobs."""
-        event = CellObservability(loadavg_pre=(1.0, 2.0, 3.0))
+        event = GenerationObservability(loadavg_pre=(1.0, 2.0, 3.0))
         payload = event.to_wandb_payload()
-        assert payload["vllm_cell/loadavg_pre_1m"] == 1.0
-        assert payload["vllm_cell/loadavg_pre_5m"] == 2.0
-        assert payload["vllm_cell/loadavg_pre_15m"] == 3.0
+        assert payload["vllm_gen/loadavg_pre_1m"] == 1.0
+        assert payload["vllm_gen/loadavg_pre_5m"] == 2.0
+        assert payload["vllm_gen/loadavg_pre_15m"] == 3.0
         # Raw tuple key is gone — only the unpacked scalars are exposed.
-        assert "vllm_cell/loadavg_pre" not in payload
+        assert "vllm_gen/loadavg_pre" not in payload
 
     def test_engine_config_flattened_under_engine_runtime_namespace(self) -> None:
         """Engine-config dict gets flattened to scalars under ``engine_runtime/``."""
-        event = CellObservability(engine_runtime_config={"a": 1, "b": True})
+        event = GenerationObservability(engine_runtime_config={"a": 1, "b": True, "c": None})
         payload = event.to_wandb_payload()
-        assert payload["vllm_cell/engine_runtime/a"] == 1
-        assert payload["vllm_cell/engine_runtime/b"] is True
+        assert payload["vllm_gen/engine_runtime/a"] == 1
+        assert payload["vllm_gen/engine_runtime/b"] is True
+        # None values are dropped, symmetric with the scalar-field handling.
+        assert "vllm_gen/engine_runtime/c" not in payload
 
 
 # ---------------------------------------------------------------------------
@@ -390,34 +392,34 @@ class TestNvmlPeakSampler:
 
 
 # ---------------------------------------------------------------------------
-# log_cell_observability contracts
+# log_generation_observability contracts
 # ---------------------------------------------------------------------------
 
 
-class TestLogCellObservability:
+class TestLogGenerationObservability:
     """The wandb-side helper's degraded-mode + best-effort contracts."""
 
-    def test_no_op_when_no_active_wandb_run(self, populated_event: CellObservability) -> None:
+    def test_no_op_when_no_active_wandb_run(self, populated_event: GenerationObservability) -> None:
         """``wandb.run is None`` → return without raising or logging."""
         from nemo_safe_synthesizer.cli import wandb_setup
 
         with patch.object(wandb_setup.wandb, "run", None):
             # Should not raise; nothing to assert beyond "doesn't blow up".
-            wandb_setup.log_cell_observability(populated_event)
+            wandb_setup.log_generation_observability(populated_event)
 
-    def test_calls_wandb_log_when_run_is_active(self, populated_event: CellObservability) -> None:
+    def test_calls_wandb_log_when_run_is_active(self, populated_event: GenerationObservability) -> None:
         """When a run is active, the flattened payload is passed to ``wandb.log``."""
         from nemo_safe_synthesizer.cli import wandb_setup
 
         fake_run = MagicMock()
         with patch.object(wandb_setup.wandb, "run", fake_run), patch.object(wandb_setup.wandb, "log") as mock_log:
-            wandb_setup.log_cell_observability(populated_event)
+            wandb_setup.log_generation_observability(populated_event)
             mock_log.assert_called_once()
             (call_args,) = mock_log.call_args.args
             # The payload contains exactly the keys from to_wandb_payload (namespaced + flattened).
             assert call_args == populated_event.to_wandb_payload()
 
-    def test_wandb_log_exception_swallowed(self, populated_event: CellObservability) -> None:
+    def test_wandb_log_exception_swallowed(self, populated_event: GenerationObservability) -> None:
         """A wandb failure must not break generation — best-effort emission."""
         from nemo_safe_synthesizer.cli import wandb_setup
 
@@ -427,4 +429,4 @@ class TestLogCellObservability:
             patch.object(wandb_setup.wandb, "log", side_effect=RuntimeError("wandb down")),
         ):
             # Should not raise.
-            wandb_setup.log_cell_observability(populated_event)
+            wandb_setup.log_generation_observability(populated_event)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+from nemo_safe_synthesizer.observability import NvmlPeakSampler, _default_nvml_device_index, read_loadavg
+
+
+@pytest.mark.skipif(not Path("/proc/loadavg").exists(), reason="/proc/loadavg is Linux-specific")
+def test_read_loadavg_returns_float_triple_on_linux() -> None:
+    loadavg = read_loadavg()
+
+    assert loadavg is not None
+    assert len(loadavg) == 3
+    assert all(isinstance(value, float) for value in loadavg)
+
+
+@pytest.mark.parametrize(
+    ("visible_devices", "expected"),
+    [
+        (None, 0),
+        ("", 0),
+        ("2,3", 2),
+        (" GPU-abc123 ", 0),
+    ],
+)
+def test_default_nvml_device_index_reads_first_cuda_visible_device(
+    monkeypatch: pytest.MonkeyPatch,
+    visible_devices: str | None,
+    expected: int,
+) -> None:
+    if visible_devices is None:
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+    else:
+        monkeypatch.setenv("CUDA_VISIBLE_DEVICES", visible_devices)
+
+    assert _default_nvml_device_index() == expected
+
+
+def test_nvml_peak_sampler_degrades_when_pynvml_is_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setitem(sys.modules, "pynvml", None)
+
+    with NvmlPeakSampler(interval_seconds=0.001) as sampler:
+        assert sampler.peak_gb is None
+
+
+def test_nvml_peak_sampler_shuts_down_when_handle_lookup_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeNvmlError(Exception):
+        pass
+
+    fake_pynvml = SimpleNamespace(shutdown_calls=0)
+
+    def nvml_init() -> None:
+        return None
+
+    def get_handle_by_index(_device_index: int) -> object:
+        raise FakeNvmlError("bad device")
+
+    def nvml_shutdown() -> None:
+        fake_pynvml.shutdown_calls += 1
+
+    fake_pynvml.NVMLError = FakeNvmlError
+    fake_pynvml.nvmlInit = nvml_init
+    fake_pynvml.nvmlDeviceGetHandleByIndex = get_handle_by_index
+    fake_pynvml.nvmlShutdown = nvml_shutdown
+    monkeypatch.setitem(sys.modules, "pynvml", fake_pynvml)
+
+    with NvmlPeakSampler(interval_seconds=0.001) as sampler:
+        assert sampler.peak_gb is None
+
+    assert fake_pynvml.shutdown_calls == 1

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import sys
-from types import SimpleNamespace
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 


### PR DESCRIPTION
## Summary

Adds a self-contained `vllm_observability` module that lifts four measurement primitives + the structured event schema out of any specific consumer (production `VllmBackend` or benchmark harness) and into a shared, well-tested surface. Wires the primitives into `VllmBackend.generate()` so **every production generation invocation now emits a `vllm.cell.complete` structured event** carrying peak device VRAM, host loadavg pre/post, vLLM's KV-cache fraction / prefix-cache hit rate / speculative-decoding acceptance, and the engine's effective runtime config.

The primitives are deliberately generic — they're observability infrastructure, not benchmark-specific. The companion PR (`binaryaaron/vllm-benchmark-harness-work`) imports them and composes the schema rather than re-defining its fields, which fixes the architectural smell where observability fields had been locked inside `CandidateMetrics`.

## What this changes for production

Every `VllmBackend.generate()` call now writes:

| Surface | What lands |
|---|---|
| Structured log | `logger.runtime.info("vllm.cell.complete", extra={"ctx": event.model_dump()})` |
| Wandb (when active run) | `wandb.log(event.to_wandb_payload())` — keys namespaced under `vllm_cell/` |

Operators get **flag-engagement drift detection** (cross-checks intended config against probed `vllm_config`), **KV-cache pressure visibility**, **out-of-process peak VRAM** via NVML (sidesteps the `VLLM_ENABLE_V1_MULTIPROCESSING=1` blind spot where `torch.cuda.max_memory_allocated()` in the harness reads 0), and **host load bracketing** per cell.

## Primitives + schema

| Primitive | Surface |
|---|---|
| `NvmlPeakSampler` | Context-manager + daemon thread polling `pynvml` at 250ms cadence |
| `read_loadavg()` | `/proc/loadavg` snapshot as `(1m, 5m, 15m)` tuple |
| `probe_engine_runtime_config(llm)` | Best-effort introspection of `vllm_config.{scheduler,cache,speculative}_config` |
| `read_vllm_runtime_metrics(llm)` | `LLM.get_metrics()` reader → `{kv_cache_usage_perc, prefix_cache_hit_rate, spec_accept_rate}` |
| `flag_engagement_mismatches(intended, actual)` | Dict-vs-dict cross-check; only checks explicitly-set fields |
| `CellObservability` pydantic model | The event schema, `extra="forbid"` so producers must update on schema change |
| `log_cell_observability(event)` | wandb_setup.py helper; no-op when no active run; best-effort emission |

Every primitive is degraded-mode by design: missing pynvml / non-Linux / unavailable metric / failed call → `None` or empty dict, never raises.

## Architectural choices worth flagging

- **`phase=GENERATE` + `job_type="benchmark"` instead of a new `WandbPhase.BENCHMARK`** — a benchmark cell is structurally a `GENERATE` phase invocation that's measured rather than consumed; `job_type` is the right discriminator. Keeps production-generate and benchmark cells in the same wandb workspace section for cross-comparison.
- **Composition over duplication** — the schema is one model. Consumers (production + benchmark) embed it via `observability: CellObservability` rather than re-declaring fields. Adding a new measurement primitive in the future requires touching this module only.
- **Soft dependency throughout** — wandb missing / `WANDB_MODE=disabled` / `wandb.init` raises / `wandb.log` raises → warning, generation continues. Production reliability isn't gated on observability working.
- **No PR-1 dependency** — primitives use `pynvml` + `/proc/loadavg` + vLLM's public `llm.get_metrics()` / `llm.llm_engine.vllm_config` surface. No imports from `vllm_engine_factory` / `vllm_trace` etc. This PR lands independently of PR-1's review timing.

## Test coverage

`tests/generation/test_vllm_observability.py` — 28 contract tests, ~7s wall:

- Schema: defaults all optional, JSON round-trip lossless, `extra='forbid'` enforced.
- `to_wandb_payload`: namespacing, None-dropping, tuple unpacking, dict flattening.
- `flag_engagement_mismatches`: parametrized matrix (clean match / disagreement / unset-intended / missing-actual / both-empty).
- `read_loadavg`: shape on Linux, None on read failure.
- `probe_engine_runtime_config`: empty dict on any failure (parametrized), extracts known fields when vllm_config is real-shaped.
- `read_vllm_runtime_metrics`: stable dict keys, correct derivation, exception → degraded mode, zero-denominator → None.
- `NvmlPeakSampler`: context-manager protocol, `peak_gb` typed `float | None`, pynvml ImportError → None.
- `log_cell_observability`: no-op when no active run, calls `wandb.log` with the flattened payload when active, swallows `wandb.log` exceptions.

Tests deliberately focus on contracts, NOT implementation details (field counts, log wording, etc.) — that's documented inline so reviewers know the scope choice was intentional.

## Test plan

- [ ] Lint / typecheck passes
- [ ] Unit tests (`tests/generation/test_vllm_observability.py`) pass — 28 tests
- [ ] Manual: run `safe-synthesizer run generate ...` against a small dataset, confirm a `vllm.cell.complete` event lands in the structured log
- [ ] Manual: run with `WANDB_MODE=online`, confirm the wandb run page shows the `vllm_cell/*` metrics
- [ ] Manual: run with no GPU / pynvml unavailable, confirm `peak_vram_gb: None` and no exception

## What's NOT in this PR

- `compilation_config` + `kv_cache_metrics` fields on a future `BenchmarkEngineConfig` — those are benchmark-side knobs, deferred to the companion PR.
- Within-call sampling cadence (peak-VRAM progression during long generates) — v1 emits one event per `generate()` call; future improvement via the existing `NvmlPeakSampler` thread.
- `VllmBackend.generate()` end-to-end integration test — requires actual vLLM spin-up; covered by production usage + the companion PR's benchmark integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-of-generation observability: peak GPU memory sampling, vLLM runtime metrics, engine runtime config capture, and pre/post host load snapshots; formatted payloads mirrored to structured logs and WandB when available.
  * Public helpers to produce WandB-friendly payloads.

* **Bug Fixes**
  * Observability is best-effort: telemetry/wandb failures are swallowed and won’t interrupt generation.

* **Tests**
  * Expanded tests covering observability schema, metric extraction, NVML sampler, payload formatting, and WandB/logging resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->