### PR TITLE
fix: change default batch sizes for dp workloads

### DIFF
--- a/script/slurm/configs/mistral-dp.yaml
+++ b/script/slurm/configs/mistral-dp.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 training:
-  batch_size: 4
+  batch_size: 2
   gradient_accumulation_steps: 16
   pretrained_model: mistralai/Mistral-7B-Instruct-v0.3
 privacy:

--- a/script/slurm/configs/mistral-dp.yaml
+++ b/script/slurm/configs/mistral-dp.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 training:
-  batch_size: 8  # DP is not constrained to batch size of 1
+  batch_size: 4
+  gradient_accumulation_steps: 16
   pretrained_model: mistralai/Mistral-7B-Instruct-v0.3
 privacy:
   dp_enabled: true

--- a/script/slurm/configs/smollm3-dp.yaml
+++ b/script/slurm/configs/smollm3-dp.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 training:
-  batch_size: 8  # DP is not constrained to batch size of 1
+  batch_size: 4
+  gradient_accumulation_steps: 16
   pretrained_model: HuggingFaceTB/SmolLM3-3B
 privacy:
   dp_enabled: true

--- a/script/slurm/configs/tinyllama-dp.yaml
+++ b/script/slurm/configs/tinyllama-dp.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 training:
-  batch_size: 4  # DP is not constrained to batch size of 1
+  batch_size: 4
   gradient_accumulation_steps: 16
   pretrained_model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 privacy:

--- a/script/slurm/configs/tinyllama-dp.yaml
+++ b/script/slurm/configs/tinyllama-dp.yaml
@@ -2,7 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 training:
-  batch_size: 8  # DP is not constrained to batch size of 1
+  batch_size: 4  # DP is not constrained to batch size of 1
+  gradient_accumulation_steps: 16
   pretrained_model: TinyLlama/TinyLlama-1.1B-Chat-v1.0
 privacy:
   dp_enabled: true

--- a/tests/e2e/required_configs/mistral-dp.yaml
+++ b/tests/e2e/required_configs/mistral-dp.yaml
@@ -10,7 +10,7 @@ generation:
 privacy:
   dp_enabled: true
 training:
-  batch_size: 4
+  batch_size: 2
   gradient_accumulation_steps: 16
   pretrained_model: mistralai/Mistral-7B-Instruct-v0.3
   learning_rate: 0.0001

--- a/tests/e2e/required_configs/mistral-dp.yaml
+++ b/tests/e2e/required_configs/mistral-dp.yaml
@@ -10,6 +10,7 @@ generation:
 privacy:
   dp_enabled: true
 training:
-  batch_size: 8
+  batch_size: 4
+  gradient_accumulation_steps: 16
   pretrained_model: mistralai/Mistral-7B-Instruct-v0.3
   learning_rate: 0.0001

--- a/tests/e2e/required_configs/smollm3-dp.yaml
+++ b/tests/e2e/required_configs/smollm3-dp.yaml
@@ -9,5 +9,6 @@ generation:
 privacy:
   dp_enabled: true
 training:
-  batch_size: 8
+  batch_size: 4
+  gradient_accumulation_steps: 16
   pretrained_model: HuggingFaceTB/SmolLM3-3B

--- a/tests/e2e/required_configs/tinyllama-dp.yaml
+++ b/tests/e2e/required_configs/tinyllama-dp.yaml
@@ -10,5 +10,6 @@ generation:
 privacy:
   dp_enabled: true
 training:
-  batch_size: 8
+  batch_size: 4
+  gradient_accumulation_steps: 16
   pretrained_model: TinyLlama/TinyLlama-1.1B-Chat-v1.0


### PR DESCRIPTION
followup from #483 - there's a regression in memory performance in transformers v5. this is the minimal fix for our specific workloads; I'll put up a more comprehensive change that should help with observability and memory pressure during training after this.


## Summary

This PR lowers the physical microbatch size used by the DP run configs from `8` to `4` and raises `gradient_accumulation_steps` to `16`.

The effective batch size stays at `64`, but each forward/backward pass uses fewer examples. This is the minimal fix for the recent larger-model DP OOMs without changing the shared training defaults for non-DP runs.

## Why

DP training is not inherently constrained to `batch_size: 1`, but larger physical batches increase activation and per-sample-gradient memory. The prior DP configs used `batch_size: 8` with the global default accumulation of `8`. Moving to `4 x 16` preserves optimizer-step batch semantics while reducing peak memory pressure.

## Changes

- Update DP SLURM configs to use:
  - `training.batch_size: 4`
  - `training.gradient_accumulation_steps: 16`
- Update required e2e DP configs to match the new DP run shape.

## Test Plan

- `make check`
- slurm run (will report back)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reduced per-device training batch sizes across distributed-parallel configs (mostly 8→4; one model adjusted to 2).
  * Standardized/added gradient accumulation to 16 across DP training configs to preserve effective batch size.
  * Result: improved memory efficiency and more balanced resource use for distributed training runs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Safe-Synthesizer/pull/528?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->