### PR TITLE
chore: set github action targets to SHAs

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -63,7 +63,7 @@ runs:
     # (b) dorny/paths-filter can diff against git history on push events.
     - name: Detect changed paths
       id: filter
-      uses: dorny/paths-filter@v3
+      uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
       with:
         filters: |
           src:

--- a/.github/actions/setup-gpu-test-env/action.yml
+++ b/.github/actions/setup-gpu-test-env/action.yml
@@ -44,7 +44,7 @@ runs:
         sudo apt-get install -y --no-install-recommends make
 
     - name: Setup uv cache
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       with:
         enable-cache: true
         cache-dependency-glob: |

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -47,7 +47,7 @@ runs:
   steps:
     - name: Checkout repository
       if: inputs.checkout == 'true'
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         ref: ${{ inputs.ref || github.ref }}
         fetch-depth: ${{ inputs.fetch-depth }}
@@ -69,13 +69,13 @@ runs:
 
     - name: Set up Python ${{ inputs.python-version }}
       if: inputs.python-version != ''
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Set up Python from .python-version
       if: inputs.python-version == ''
-      uses: actions/setup-python@v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
       with:
         python-version-file: ".python-version"
 
@@ -89,7 +89,7 @@ runs:
 
     - name: Install uv (fallback when mise is skipped)
       if: inputs.bootstrap-tools != 'true'
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
       with:
         enable-cache: true
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,10 +18,10 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(ci)"
+    ignore:
+      # FW-CI reusable workflows are pinned to immutable commits.
+      - dependency-name: "NVIDIA-NeMo/FW-CI-templates"
     groups:
-      fw-ci-templates:
-        patterns:
-          - "NVIDIA-NeMo/FW-CI-templates"
       github-actions:
         patterns:
           - "actions/*"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -226,7 +226,7 @@ The workflow performs the following steps:
 
 ## Reusable Workflows
 
-All compliance and release workflows reuse templates from [NVIDIA-NeMo/FW-CI-templates](https://github.com/NVIDIA-NeMo/FW-CI-templates) (pinned to `v0.66.6`):
+Compliance workflows reuse templates from [NVIDIA-NeMo/FW-CI-templates](https://github.com/NVIDIA-NeMo/FW-CI-templates), pinned to immutable commit SHAs in the workflow files:
 
 - `_semantic_pull_request.yml` - Conventional commit validation
 - `_secrets-detector.yml` - Secrets scanning

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -55,6 +55,8 @@ jobs:
       any: ${{ steps.changes.outputs.any }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Detect changes
         id: changes
         uses: ./.github/actions/detect-changes
@@ -68,13 +70,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Python environment
         id: setup
         uses: ./.github/actions/setup-python-env
         with:
-          fetch-depth: 0
+          checkout: "false"
           bootstrap-tools: "true"
 
       - name: Bootstrap
@@ -95,13 +98,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Python environment
         id: setup
         uses: ./.github/actions/setup-python-env
         with:
-          fetch-depth: 0
+          checkout: "false"
           bootstrap-tools: "true"
 
       - name: Bootstrap
@@ -135,12 +139,14 @@ jobs:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Python environment
         id: setup
         uses: ./.github/actions/setup-python-env
         with:
+          checkout: "false"
           bootstrap-tools: "true"
 
       - name: Bootstrap
@@ -188,11 +194,13 @@ jobs:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup Python environment
         uses: ./.github/actions/setup-python-env
         with:
+          checkout: "false"
           bootstrap-tools: "true"
 
       - name: Run CPU smoke tests

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -54,7 +54,7 @@ jobs:
       docs_src: ${{ steps.changes.outputs.docs_src }}
       any: ${{ steps.changes.outputs.any }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Detect changes
         id: changes
         uses: ./.github/actions/detect-changes
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -133,7 +133,7 @@ jobs:
         python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -150,14 +150,14 @@ jobs:
         run: make test-ci
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: matrix.python-version == '3.11'
         with:
           name: coverage-report
           path: coverage.json
           retention-days: 30
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
         if: matrix.python-version == '3.11'
         with:
           files: coverage.json
@@ -186,7 +186,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,18 +35,18 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           languages: python
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4
         with:
           category: "/language:python"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -35,7 +35,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -31,4 +31,4 @@ permissions:
 
 jobs:
   conventional-commit:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_semantic_pull_request.yml@v0.89.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_semantic_pull_request.yml@63ee9e3b9fc4ca02af1bd75d3126e526b2a77a24 # v0.89.0

--- a/.github/workflows/dependabot-sync-lock.yml
+++ b/.github/workflows/dependabot-sync-lock.yml
@@ -42,13 +42,13 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: false
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -46,7 +46,7 @@ jobs:
         id: setup
         uses: ./.github/actions/setup-python-env
         with:
-          fetch-depth: 0
+          checkout: "false"
           bootstrap-tools: "true"
 
       - name: Install docs dependencies

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -59,7 +59,7 @@ jobs:
     outputs:
       src_test_deps: ${{ steps.changes.outputs.src_test_deps }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Detect changes
         id: changes
         uses: ./.github/actions/detect-changes
@@ -86,7 +86,7 @@ jobs:
     runs-on: linux-amd64-gpu-a100-latest-1
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
@@ -139,7 +139,7 @@ jobs:
     runs-on: linux-amd64-gpu-a100-latest-1
     steps:
       - name: checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -60,6 +60,8 @@ jobs:
       src_test_deps: ${{ steps.changes.outputs.src_test_deps }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
       - name: Detect changes
         id: changes
         uses: ./.github/actions/detect-changes
@@ -88,6 +90,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup GPU test environment
@@ -141,6 +144,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup GPU test environment

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,18 +42,18 @@ jobs:
       is_prerelease: ${{ steps.build.outputs.is_prerelease }}
     steps:
       - name: Checkout at release ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version-file: ".python-version"
 
@@ -71,7 +71,7 @@ jobs:
           echo "is_prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
           echo "Built: $WHEEL (version $VERSION)"
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: nemo-safe-synthesizer-${{ steps.build.outputs.version }}
           path: dist/*.whl
@@ -105,12 +105,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout at release ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Download wheel artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: nemo-safe-synthesizer-${{ needs.publish-wheel.outputs.version }}
           path: dist/
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout at release ref
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ defaults:
     shell: bash -x -e -u -o pipefail {0}
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   publish-wheel:
@@ -44,6 +44,7 @@ jobs:
       - name: Checkout at release ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
           fetch-tags: true
 
@@ -103,10 +104,13 @@ jobs:
     name: Create GitHub release
     needs: publish-wheel
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout at release ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Download wheel artifact
@@ -137,6 +141,8 @@ jobs:
     needs: publish-wheel
     if: ${{ needs.publish-wheel.outputs.is_prerelease != 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout at release ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -147,7 +153,7 @@ jobs:
       - name: Setup Python environment
         uses: ./.github/actions/setup-python-env
         with:
-          fetch-depth: 0
+          checkout: "false"
           bootstrap-tools: "true"
 
       - name: Install docs dependencies

--- a/.github/workflows/secrets-detector.yml
+++ b/.github/workflows/secrets-detector.yml
@@ -23,4 +23,4 @@ on:
 
 jobs:
   secrets-detector:
-    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_secrets-detector.yml@v0.83.0
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_secrets-detector.yml@ccb88af2bcd7109ec01a9ddacd371bedf0780b8b # v0.83.0


### PR DESCRIPTION
* Also remove auto update from dependabot
* Fixes #530

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned CI/CD action references to specific commit SHAs across workflows and reusable actions for deterministic runs.
  * Adjusted workflow permissions to reduce top-level write access and grant write where explicitly needed.
  * Updated Dependabot configuration to ignore a specific external template dependency.
* **Documentation**
  * Updated workflows README to reflect templates are pinned to immutable commit SHAs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA-NeMo/Safe-Synthesizer/pull/531?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->