### PR TITLE
chore: add all model types to e2e test

### DIFF
--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -145,7 +145,7 @@ jobs:
           inputs.suite == 'e2e'
         )
       }}
-    timeout-minutes: 60
+    timeout-minutes: 210
     runs-on: linux-amd64-gpu-a100-latest-1
     steps:
       - name: checkout
@@ -158,8 +158,8 @@ jobs:
         uses: ./.github/actions/setup-gpu-test-env
 
       - name: Run GPU E2E tests
-        timeout-minutes: 45
         run: mise run test:e2e
+        timeout-minutes: 190
 
   # ---------------------------------------------------------------------------
   # Single required status check for branch protection.

--- a/.mise/tasks/tests.toml
+++ b/.mise/tasks/tests.toml
@@ -83,17 +83,25 @@ run = [{ task = "test:e2e:default" }, { task = "test:e2e:dp" }]
 ["test:e2e:default"]
 description = "Run default e2e tests (requires CUDA)"
 alias = "test-e2e-default"
-run = "uv run --frozen pytest --dist loadscope -vv -n 0 tests/e2e/test_safe_synthesizer.py -k default"
+run = [
+  { task = "bootstrap-nss", args = ["cu129"] },
+  "uv run --frozen pytest --dist loadscope -vv -n 0 tests/e2e/test_safe_synthesizer.py -k default"
+]
 
 ["test:e2e:dp"]
 description = "Run dp e2e tests (requires CUDA)"
 alias = "test-e2e-dp"
-run = "uv run --frozen pytest --dist loadscope -vv -n 0 tests/e2e/test_safe_synthesizer.py -k dp"
+run = [
+  { task = "bootstrap-nss", args = ["cu129"] },
+  "uv run --frozen pytest --dist loadscope -vv -n 0 tests/e2e/test_safe_synthesizer.py -k dp"
+]
 
 ["test:e2e:collect"]
 description = "Dry-run e2e and GPU selectors with pytest collection only. Does not run tests; useful before changing task selectors."
 alias = "test-e2e-collect"
-run = '''
+run = [
+  { task = "bootstrap-nss", args = ["cu129"] },
+  '''
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -106,6 +114,7 @@ uv run --frozen pytest -n auto --dist loadscope -vv tests/e2e/test_safe_synthesi
 echo "--- test-gpu-integration (dp) ---"
 uv run --frozen pytest -n auto --dist loadscope -vv tests/e2e/test_safe_synthesizer.py -k dp -o "addopts=" --collect-only -qq -p no:warnings 2>/dev/null || true
 '''
+]
 
 ["test:nss-config-dataset"]
 description = "Run pytest for one config and dataset combination"

--- a/.mise/tasks/tests.toml
+++ b/.mise/tasks/tests.toml
@@ -71,6 +71,7 @@ run = 'uv run --frozen pytest --dist loadscope -vv -n 0 tests/smoke/ -m "require
 description = "Run GPU integration e2e tests for default and DP configs. Requires CUDA; stages are sequential to control GPU load."
 alias = "test-gpu-integration"
 run = [
+  { task = "bootstrap-nss", args = ["cu129"] },
   "uv run --frozen pytest -n 0 --dist loadscope -vv tests/e2e/test_safe_synthesizer.py -k default",
   "uv run --frozen pytest -n 0 --dist loadscope -vv tests/e2e/test_safe_synthesizer.py -k dp",
 ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -517,6 +517,8 @@ mise run test:ci-container
 uv run --frozen pytest tests/cli/test_run.py
 ```
 
+`make test-e2e-default` and `make test-e2e-dp` each run the SafeSynthesizer e2e flow across Mistral 7B, SmolLM3 3B, and TinyLlama 1.1B. Each model case has a 30-minute timeout, so reserve up to 90 minutes for either target and up to 3 hours for the full `make test-e2e` target in cold-cache GPU environments.
+
 ### GPU Tests (CI)
 
 GPU tests run on NVIDIA self-hosted A100 runners -- they cannot run on a local machine unless you have a compatible GPU environment. `gpu-tests.yml` currently runs only on the nightly schedule or manual `workflow_dispatch`; the `push` trigger for copy-pr-bot PR branches is commented out due to internal blockers. We expect to re-enable PR GPU runs as soon as those blockers are resolved. The workflow has two main test jobs:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -517,7 +517,7 @@ mise run test:ci-container
 uv run --frozen pytest tests/cli/test_run.py
 ```
 
-`make test-e2e-default` and `make test-e2e-dp` each run the SafeSynthesizer e2e flow across Mistral 7B, SmolLM3 3B, and TinyLlama 1.1B. Each model case has a 30-minute timeout, so reserve up to 90 minutes for either target and up to 3 hours for the full `make test-e2e` target in cold-cache GPU environments.
+`mise run test:e2e:default` and `mise run test:e2e:dp` each run the SafeSynthesizer e2e flow across Mistral 7B, SmolLM3 3B, and TinyLlama 1.1B. Each model case has a 30-minute timeout, so reserve up to 90 minutes for either target and up to 3 hours for the full `mise run test:e2e` target in cold-cache GPU environments.
 
 ### GPU Tests (CI)
 

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -68,6 +68,12 @@ Details:
 - Each target bootstraps `cu129`, runs single-process (`-n 0`) with coverage
 - These are not part of `mise run test:e2e` -- they are standalone CI tasks
 
+## SafeSynthesizer E2E Matrix
+
+`make test-e2e-default` and `make test-e2e-dp` run `tests/e2e/test_safe_synthesizer.py` against the same three model families used by the 6-config coverage strategy: Mistral 7B, SmolLM3 3B, and TinyLlama 1.1B. The default target covers the no-DP path and the DP target covers the same model set with differential privacy enabled.
+
+These tests are GPU-only and intentionally slow. Each model case has a 30-minute timeout, so budget up to 90 minutes for either `make test-e2e-default` or `make test-e2e-dp`, and up to 3 hours for the full `make test-e2e` target in cold-cache environments. Warm Hugging Face caches are expected to finish sooner.
+
 ## Pytest Markers
 
 Defined in `pytest.ini` (`--strict-markers` is enabled):

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -70,9 +70,9 @@ Details:
 
 ## SafeSynthesizer E2E Matrix
 
-`make test-e2e-default` and `make test-e2e-dp` run `tests/e2e/test_safe_synthesizer.py` against the same three model families used by the 6-config coverage strategy: Mistral 7B, SmolLM3 3B, and TinyLlama 1.1B. The default target covers the no-DP path and the DP target covers the same model set with differential privacy enabled.
+`mise run test:e2e:default` and `mise run test:e2e:dp` run `tests/e2e/test_safe_synthesizer.py` against the same three model families used by the 6-config coverage strategy: Mistral 7B, SmolLM3 3B, and TinyLlama 1.1B. The default target covers the no-DP path and the DP target covers the same model set with differential privacy enabled.
 
-These tests are GPU-only and intentionally slow. Each model case has a 30-minute timeout, so budget up to 90 minutes for either `make test-e2e-default` or `make test-e2e-dp`, and up to 3 hours for the full `make test-e2e` target in cold-cache environments. Warm Hugging Face caches are expected to finish sooner.
+These tests are GPU-only and intentionally slow. Each model case has a 30-minute timeout, so budget up to 90 minutes for either `mise run test:e2e:default` or `mise run test:e2e:dp`, and up to 3 hours for the full `mise run test:e2e` target in cold-cache environments. Warm Hugging Face caches are expected to finish sooner.
 
 ## Pytest Markers
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -37,7 +37,7 @@ def fixture_save_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return tmp_path_factory.mktemp("nemo_safe_synthesizer_tmp")
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def fixture_financial_transactions_dataset() -> pd.DataFrame:
     """Gretel financial-transactions sample CSV fetched from GitHub."""
     return pd.read_csv(

--- a/tests/e2e/test_safe_synthesizer.py
+++ b/tests/e2e/test_safe_synthesizer.py
@@ -39,21 +39,28 @@ from nemo_safe_synthesizer.sdk.library_builder import SafeSynthesizer
 
 logger = get_logger(__name__)
 
+E2E_PRETRAINED_MODELS = [
+    pytest.param("mistralai/Mistral-7B-Instruct-v0.3", id="mistral"),
+    pytest.param("HuggingFaceTB/SmolLM3-3B", id="smollm3"),
+    pytest.param("TinyLlama/TinyLlama-1.1B-Chat-v1.0", id="tinyllama"),
+]
+
 
 @pytest.mark.e2e
 @pytest.mark.requires_gpu
-@pytest.mark.timeout(1000)
+@pytest.mark.timeout(1800)
 @pytest.mark.skipif(sys.platform == "darwin", reason="Not applicable on macOS")
-def test_train_and_generate_dp(fixture_financial_transactions_dataset, fixture_save_path):
+@pytest.mark.parametrize("pretrained_model", E2E_PRETRAINED_MODELS)
+def test_train_and_generate_dp(fixture_financial_transactions_dataset, fixture_save_path, pretrained_model):
     df = fixture_financial_transactions_dataset
     config = SafeSynthesizerParameters.from_params(
         replace_pii=None,
         num_input_records_to_sample=1500,
+        pretrained_model=pretrained_model,
         dp_enabled=True,
         epsilon=100.0,
         num_records=100,
         use_structured_generation=True,
-        structured_generation_backend="xgrammar",
     )
     logger.info(f"Running DP test with config: {config}")
 
@@ -70,12 +77,9 @@ def test_train_and_generate_dp(fixture_financial_transactions_dataset, fixture_s
 
 @pytest.mark.e2e
 @pytest.mark.requires_gpu
-@pytest.mark.timeout(900)
+@pytest.mark.timeout(1800)
 @pytest.mark.skipif(sys.platform == "darwin", reason="Not applicable on macOS")
-@pytest.mark.parametrize(
-    "pretrained_model",
-    ["mistralai/Mistral-7B-Instruct-v0.3", "HuggingFaceTB/SmolLM2-135M", "TinyLlama/TinyLlama-1.1B-Chat-v1.0"],
-)
+@pytest.mark.parametrize("pretrained_model", E2E_PRETRAINED_MODELS)
 def test_train_and_generate_defaults(fixture_financial_transactions_dataset, fixture_save_path, pretrained_model):
     df = fixture_financial_transactions_dataset
     config = SafeSynthesizerParameters.from_params(

--- a/tests/e2e/test_safe_synthesizer.py
+++ b/tests/e2e/test_safe_synthesizer.py
@@ -72,11 +72,16 @@ def test_train_and_generate_dp(fixture_financial_transactions_dataset, fixture_s
 @pytest.mark.requires_gpu
 @pytest.mark.timeout(900)
 @pytest.mark.skipif(sys.platform == "darwin", reason="Not applicable on macOS")
-def test_train_and_generate_defaults(fixture_financial_transactions_dataset, fixture_save_path):
+@pytest.mark.parametrize(
+    "pretrained_model",
+    ["mistralai/Mistral-7B-Instruct-v0.3", "HuggingFaceTB/SmolLM2-135M", "TinyLlama/TinyLlama-1.1B-Chat-v1.0"],
+)
+def test_train_and_generate_defaults(fixture_financial_transactions_dataset, fixture_save_path, pretrained_model):
     df = fixture_financial_transactions_dataset
     config = SafeSynthesizerParameters.from_params(
         replace_pii=None,
         num_input_records_to_sample=5000,
+        pretrained_model=pretrained_model,
     )
     logger.info(f"Running test_train_and_generate_defaults with config: {config}")
 


### PR DESCRIPTION
* ran make test-e2e-default
* Closes https://github.com/NVIDIA-NeMo/Safe-Synthesizer/issues/352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * End-to-end tests now run across three model families (Mistral 7B, SmolLM3 3B, TinyLlama 1.1B) via parameterized GPU test cases; per-case and total timeouts were increased and a save-path fixture scope was extended for greater stability.

* **Documentation**
  * Clarified which e2e targets run the SafeSynthesizer matrix and added guidance for per-model and overall GPU timeout expectations.

* **Chores**
  * Test task definitions updated to prepend required bootstrap steps before e2e commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->