### PR TITLE
fix(eval): add bin cap and fall back

### DIFF
--- a/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
@@ -212,8 +212,14 @@ def get_auto_bins(x1: pd.Series, x2: pd.Series) -> dict:
     data = pd.concat([x1, x2]).to_numpy()
     finite_data = data[np.isfinite(data)]
 
+    def _single_value_fallback(value: float) -> dict:
+        """Build a one-bin range anchored at the observed value."""
+        return dict(start=value, end=value + 1.0, size=1.0)
+
     if finite_data.size == 0:
         return dict(start=0.0, end=1.0, size=1.0)
+    if np.nanmin(finite_data) == np.nanmax(finite_data):
+        return _single_value_fallback(float(np.nanmin(finite_data)))
 
     try:
         edges = np.histogram_bin_edges(finite_data, bins="auto")
@@ -221,14 +227,17 @@ def get_auto_bins(x1: pd.Series, x2: pd.Series) -> dict:
         end = float(edges[-1])
         auto_bin_count = max(len(edges) - 1, 1)
         bin_count = min(auto_bin_count, max_bins)
-    except ValueError:
-        # Fallback for edge cases where numpy "auto" overestimates bin count.
+    except Exception:
+        # Fallback for edge cases where numpy "auto" overestimates bin count
+        # and can raise ValueError/MemoryError before returning edges.
         start = float(np.nanmin(finite_data))
         end = float(np.nanmax(finite_data))
         bin_count = max_bins
 
-    if not np.isfinite(start) or not np.isfinite(end) or start == end:
+    if not np.isfinite(start) or not np.isfinite(end):
         return dict(start=0.0, end=1.0, size=1.0)
+    if start == end:
+        return _single_value_fallback(start)
 
     bin_size = (end - start) / float(bin_count)
     if not np.isfinite(bin_size) or bin_size <= 0:

--- a/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
@@ -202,14 +202,37 @@ def histogram(
 
 
 def get_auto_bins(x1: pd.Series, x2: pd.Series) -> dict:
-    """Get common bin edges for the training and synthetic principal components."""
-    data = pd.concat([x1, x2]).to_numpy()
-    edges = np.histogram_bin_edges(data, bins="auto")
+    """Get common histogram bins for training/synthetic PCA projections.
 
-    # Bin start, end, and size
-    start = edges[0]
-    end = edges[-1]
-    bin_size = edges[1] - edges[0]
+    NumPy ``bins="auto"`` is adaptive, but for some pathological distributions
+    (very small IQR with wide range/outliers) it can request an extreme number
+    of bins and raise. We cap to at most 100 bins for report stability.
+    """
+    max_bins = 100
+    data = pd.concat([x1, x2]).to_numpy()
+    finite_data = data[np.isfinite(data)]
+
+    if finite_data.size == 0:
+        return dict(start=0.0, end=1.0, size=1.0)
+
+    try:
+        edges = np.histogram_bin_edges(finite_data, bins="auto")
+        start = float(edges[0])
+        end = float(edges[-1])
+        auto_bin_count = max(len(edges) - 1, 1)
+        bin_count = min(auto_bin_count, max_bins)
+    except ValueError:
+        # Fallback for edge cases where numpy "auto" overestimates bin count.
+        start = float(np.nanmin(finite_data))
+        end = float(np.nanmax(finite_data))
+        bin_count = max_bins
+
+    if not np.isfinite(start) or not np.isfinite(end) or start == end:
+        return dict(start=0.0, end=1.0, size=1.0)
+
+    bin_size = (end - start) / float(bin_count)
+    if not np.isfinite(bin_size) or bin_size <= 0:
+        return dict(start=0.0, end=1.0, size=1.0)
 
     return dict(start=start, end=end, size=bin_size)
 

--- a/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
@@ -19,6 +19,9 @@ from ...evaluation.data_model.evaluation_score import (
     PrivacyGrade,
 )
 from ...evaluation.statistics.stats import get_numeric_distribution_bins
+from ...observability import get_logger
+
+logger = get_logger(__name__)
 
 _REPORT_PALETTE = ["#3C2ED1", "#1AA2E6"]
 _GRAPH_BARGAP = 0.2  # gap between bars of adjacent location coordinates
@@ -206,9 +209,9 @@ def get_auto_bins(x1: pd.Series, x2: pd.Series) -> dict:
 
     NumPy ``bins="auto"`` is adaptive, but for some pathological distributions
     (very small IQR with wide range/outliers) it can request an extreme number
-    of bins and raise. We cap to at most 1000 bins for report stability.
+    of bins and raise. We cap to at most 100 bins for report stability.
     """
-    max_bins = 1000
+    max_bins = 100
     data = pd.concat([x1, x2]).to_numpy()
     finite_data = data[np.isfinite(data)]
 
@@ -217,9 +220,9 @@ def get_auto_bins(x1: pd.Series, x2: pd.Series) -> dict:
         return dict(start=value, end=value + 1.0, size=1.0)
 
     if finite_data.size == 0:
-        return dict(start=0.0, end=1.0, size=1.0)
-    if np.nanmin(finite_data) == np.nanmax(finite_data):
-        return _single_value_fallback(float(np.nanmin(finite_data)))
+        return _single_value_fallback(0.0)
+    if np.min(finite_data) == np.max(finite_data):
+        return _single_value_fallback(float(np.min(finite_data)))
 
     try:
         edges = np.histogram_bin_edges(finite_data, bins="auto")
@@ -227,21 +230,26 @@ def get_auto_bins(x1: pd.Series, x2: pd.Series) -> dict:
         end = float(edges[-1])
         auto_bin_count = max(len(edges) - 1, 1)
         bin_count = min(auto_bin_count, max_bins)
-    except Exception:
+    except (ValueError, MemoryError) as exc:
         # Fallback for edge cases where numpy "auto" overestimates bin count
-        # and can raise ValueError/MemoryError before returning edges.
+        # and raises before returning edges (ValueError/MemoryError).
+        logger.warning(
+            "np.histogram_bin_edges(bins='auto') failed; falling back to %d bins: %s",
+            max_bins,
+            exc,
+        )
         start = float(np.nanmin(finite_data))
         end = float(np.nanmax(finite_data))
         bin_count = max_bins
 
     if not np.isfinite(start) or not np.isfinite(end):
-        return dict(start=0.0, end=1.0, size=1.0)
+        return _single_value_fallback(0.0)
     if start == end:
         return _single_value_fallback(start)
 
     bin_size = (end - start) / float(bin_count)
     if not np.isfinite(bin_size) or bin_size <= 0:
-        return dict(start=0.0, end=1.0, size=1.0)
+        return _single_value_fallback(0.0)
 
     return dict(start=start, end=end, size=bin_size)
 

--- a/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
@@ -238,8 +238,8 @@ def get_auto_bins(x1: pd.Series, x2: pd.Series) -> dict:
             max_bins,
             exc,
         )
-        start = float(np.nanmin(finite_data))
-        end = float(np.nanmax(finite_data))
+        start = float(np.min(finite_data))
+        end = float(np.max(finite_data))
         bin_count = max_bins
 
     if not np.isfinite(start) or not np.isfinite(end):

--- a/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
@@ -206,9 +206,9 @@ def get_auto_bins(x1: pd.Series, x2: pd.Series) -> dict:
 
     NumPy ``bins="auto"`` is adaptive, but for some pathological distributions
     (very small IQR with wide range/outliers) it can request an extreme number
-    of bins and raise. We cap to at most 100 bins for report stability.
+    of bins and raise. We cap to at most 1000 bins for report stability.
     """
-    max_bins = 100
+    max_bins = 1000
     data = pd.concat([x1, x2]).to_numpy()
     finite_data = data[np.isfinite(data)]
 

--- a/tests/evaluation/components/test_multi_modal_figures.py
+++ b/tests/evaluation/components/test_multi_modal_figures.py
@@ -200,6 +200,30 @@ class TestGetAutoBins:
         assert bins["start"] <= 1
         assert bins["end"] >= 5
 
+    def test_get_auto_bins_caps_at_100_bins_for_pathological_distribution(self):
+        # Tiny IQR + very large range can make numpy "auto" request huge bin counts.
+        x1 = pd.Series(np.concatenate([np.full(5000, 1.0), np.array([1e9])]))
+        x2 = pd.Series(np.full(5000, 1.0000001))
+        bins = get_auto_bins(x1, x2)
+
+        assert bins["size"] > 0
+        approx_bin_count = (bins["end"] - bins["start"]) / bins["size"]
+        assert approx_bin_count == pytest.approx(100.0, abs=1e-6)
+
+    def test_get_auto_bins_returns_safe_defaults_when_all_values_non_finite(self):
+        x1 = pd.Series([np.nan, np.inf, -np.inf])
+        x2 = pd.Series([np.nan, np.inf, -np.inf])
+        bins = get_auto_bins(x1, x2)
+
+        assert bins == {"start": 0.0, "end": 1.0, "size": 1.0}
+
+    def test_get_auto_bins_anchors_single_value_range_when_degenerate(self):
+        x1 = pd.Series([5.0, 5.0, 5.0])
+        x2 = pd.Series([5.0, 5.0, 5.0])
+        bins = get_auto_bins(x1, x2)
+
+        assert bins == {"start": 5.0, "end": 6.0, "size": 1.0}
+
 
 class TestGenerateMiaFigure:
     """Tests for generate_mia_figure function."""

--- a/tests/evaluation/components/test_multi_modal_figures.py
+++ b/tests/evaluation/components/test_multi_modal_figures.py
@@ -200,7 +200,7 @@ class TestGetAutoBins:
         assert bins["start"] <= 1
         assert bins["end"] >= 5
 
-    def test_get_auto_bins_caps_at_100_bins_for_pathological_distribution(self):
+    def test_get_auto_bins_caps_at_1000_bins_for_pathological_distribution(self):
         # Tiny IQR + very large range can make numpy "auto" request huge bin counts.
         x1 = pd.Series(np.concatenate([np.full(5000, 1.0), np.array([1e9])]))
         x2 = pd.Series(np.full(5000, 1.0000001))
@@ -208,7 +208,7 @@ class TestGetAutoBins:
 
         assert bins["size"] > 0
         approx_bin_count = (bins["end"] - bins["start"]) / bins["size"]
-        assert approx_bin_count == pytest.approx(100.0, abs=1e-6)
+        assert approx_bin_count == pytest.approx(1000.0, abs=1e-6)
 
     def test_get_auto_bins_returns_safe_defaults_when_all_values_non_finite(self):
         x1 = pd.Series([np.nan, np.inf, -np.inf])

--- a/tests/evaluation/components/test_multi_modal_figures.py
+++ b/tests/evaluation/components/test_multi_modal_figures.py
@@ -223,7 +223,7 @@ class TestGetAutoBins:
         bins = get_auto_bins(x1, x2)
 
         assert bins == {"start": 5.0, "end": 6.0, "size": 1.0}
-    
+
     def test_get_auto_bins_returns_plausible_bins_with_mixture_of_finite_and_nan(self):
         x1 = pd.Series([1.0, 2.0, 3.0, np.nan, np.nan, np.inf, -np.inf])
         x2 = pd.Series([1.0, 2.0, 3.0, np.nan, np.nan, np.inf, -np.inf])

--- a/tests/evaluation/components/test_multi_modal_figures.py
+++ b/tests/evaluation/components/test_multi_modal_figures.py
@@ -200,7 +200,7 @@ class TestGetAutoBins:
         assert bins["start"] <= 1
         assert bins["end"] >= 5
 
-    def test_get_auto_bins_caps_at_1000_bins_for_pathological_distribution(self):
+    def test_get_auto_bins_caps_at_100_bins_for_pathological_distribution(self):
         # Tiny IQR + very large range can make numpy "auto" request huge bin counts.
         x1 = pd.Series(np.concatenate([np.full(5000, 1.0), np.array([1e9])]))
         x2 = pd.Series(np.full(5000, 1.0000001))
@@ -208,7 +208,7 @@ class TestGetAutoBins:
 
         assert bins["size"] > 0
         approx_bin_count = (bins["end"] - bins["start"]) / bins["size"]
-        assert approx_bin_count == pytest.approx(1000.0, abs=1e-6)
+        assert approx_bin_count == pytest.approx(100.0, abs=1e-6)
 
     def test_get_auto_bins_returns_safe_defaults_when_all_values_non_finite(self):
         x1 = pd.Series([np.nan, np.inf, -np.inf])
@@ -223,6 +223,15 @@ class TestGetAutoBins:
         bins = get_auto_bins(x1, x2)
 
         assert bins == {"start": 5.0, "end": 6.0, "size": 1.0}
+    
+    def test_get_auto_bins_returns_plausible_bins_with_mixture_of_finite_and_nan(self):
+        x1 = pd.Series([1.0, 2.0, 3.0, np.nan, np.nan, np.inf, -np.inf])
+        x2 = pd.Series([1.0, 2.0, 3.0, np.nan, np.nan, np.inf, -np.inf])
+        bins = get_auto_bins(x1, x2)
+
+        assert bins["start"] <= 1.0
+        assert bins["end"] >= 3.0
+        assert bins["size"] > 0
 
 
 class TestGenerateMiaFigure:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

I ran into this issue where the report rendering failed because the text PCA graph failed, due to the auto bin function calculating 1B+ bins lol. 

Log:
```
{"level": "info", "lineno": 90, "filename": "evaluator.py", "qual_name": "Evaluator.evaluate", "_category_display": "runtime", "timestamp": "2026-05-27T07:27:45.742", "message": "Evaluation complete."}
{"exc_info": true, "level": "error", "lineno": 110, "filename": "multimodal_report.py", "qual_name": "MultimodalReport.jinja_context", "_category_display": "runtime", "timestamp": "2026-05-27T07:27:49.653", "message": "Failed to get jinja context"}
{"exc_info": true, "level": "error", "lineno": 109, "filename": "render.py", "qual_name": "render_report", "_category_display": "runtime", "timestamp": "2026-05-27T07:27:54.229", "message": "Failed to render report."}
```

Steps to reproduce: 
`safe-synthesizer run --config script/slurm/configs/smollm3-nodp.yaml --data-source /lustre/fsw/portfolios/nemotron/users/ninaxu/datasets/telco_churn_10000.csv`


This PR caps the bins to 1000, plus some other nice edge case catchers added by Cursor. Also planned: https://github.com/NVIDIA-NeMo/Safe-Synthesizer/issues/539

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `make format && make check` or via prek validation.
- [ ] `make test` passes locally
- [ ] `make test-e2e` passes locally
- [ ] `make test-ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of histogram binning in evaluation figures: handles non-finite values, provides a deterministic fallback for degenerate single-value distributions, and caps excessive bin counts to prevent unstable or unpredictable outputs.

* **Tests**
  * Added coverage validating capped bin counts, safe fallbacks for non-finite inputs, degenerate-value anchoring, and robust behavior with mixed finite/NaN/inf data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->