### PR TITLE
chore: add merge_group to enable merge queues

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -21,6 +21,8 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 defaults:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,8 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: "0 6 * * 0"  # Weekly on Sunday at 06:00 UTC
   workflow_dispatch:


### PR DESCRIPTION
* Add merge_group targets to allow merge_queues to run status checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations to enhance automated testing processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->