### PR TITLE
fix(tools): accept any mise version >= pinned min_version

### DIFF
--- a/tools/install-mise.sh
+++ b/tools/install-mise.sh
@@ -134,10 +134,23 @@ unsigned_install_or_fail() {
 
 expected="${MISE_VERSION#v}"
 
-# version_ge A B -> true when A >= B (dotted numeric semver). `sort -VC`
-# succeeds when its input is already in version order, i.e. B <= A.
+# version_ge A B -> true when A >= B for dotted numeric versions (e.g.
+# 2026.5.15). Hand-rolled rather than `sort -V`: version sort is GNU
+# coreutils only, and the BSD `sort` shipped with macOS rejects -V, which
+# would make every comparison fail and reject an otherwise-valid mise.
+# Missing components are treated as 0 (1.2 == 1.2.0); 10# forces base-10 so
+# zero-padded fields like "05" aren't read as octal.
 version_ge() {
-    printf '%s\n%s\n' "$2" "$1" | sort -VC
+    local IFS=.
+    local -a a=($1) b=($2)
+    local i n=${#a[@]}
+    ((${#b[@]} > n)) && n=${#b[@]}
+    for ((i = 0; i < n; i++)); do
+        local x="${a[i]:-0}" y="${b[i]:-0}"
+        ((10#$x > 10#$y)) && return 0
+        ((10#$x < 10#$y)) && return 1
+    done
+    return 0
 }
 
 # mise --version prints "<semver> <target> (<date>)" to stdout plus "available

--- a/tools/install-mise.sh
+++ b/tools/install-mise.sh
@@ -134,6 +134,12 @@ unsigned_install_or_fail() {
 
 expected="${MISE_VERSION#v}"
 
+# version_ge A B -> true when A >= B (dotted numeric semver). `sort -VC`
+# succeeds when its input is already in version order, i.e. B <= A.
+version_ge() {
+    printf '%s\n%s\n' "$2" "$1" | sort -VC
+}
+
 # mise --version prints "<semver> <target> (<date>)" to stdout plus "available
 # update" nags to stderr, so take only the first field on stdout.
 #
@@ -157,12 +163,14 @@ if command -v mise >/dev/null 2>&1; then
         echo "       or remove ${mise_path} and rerun 'make setup'" >&2
         exit 1
     fi
-    if [[ "$installed" == "$expected" ]]; then
-        echo "mise ${installed} already installed"
+    # `.mise.toml` pins min_version, so any version >= the pinned one is
+    # acceptable; only abort when the installed binary is older.
+    if version_ge "$installed" "$expected"; then
+        echo "mise ${installed} already installed (satisfies min ${expected})"
         exit 0
     fi
-    echo "ERROR: found mise ${installed} on PATH but this repo pins ${MISE_VERSION}" >&2
-    echo "       run 'mise self-update ${expected}' or uninstall the current mise and rerun 'make setup'" >&2
+    echo "ERROR: found mise ${installed} on PATH but this repo requires >= ${MISE_VERSION}" >&2
+    echo "       run 'mise self-update' or uninstall the current mise and rerun 'make setup'" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## Summary
- `tools/install-mise.sh` required an exact match against `.mise.toml` `min_version`, so a newer mise already on PATH aborted `make setup` with a misleading "repo pins" error.
- `min_version` is a floor, not a pin: now compare with a `sort -VC`-based `version_ge` and only fail when the installed mise is older than the pinned version.
- Updated the already-installed and error messages to reflect `>= min` semantics.

## Test plan
- [x] `mise 2026.5.15` on PATH, min `2026.5.2` -> exits 0 ("satisfies min")
- [x] Simulated older install (`MISE_VERSION=2099.1.1`) -> exits 1 with self-update guidance

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version check now accepts any installed tool version that is greater than or equal to the pinned minimum instead of requiring an exact match.
  * Improved error messaging when the installed version is too old, with clearer guidance to update or reinstall and retry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->