### PR TITLE
chore: Exclude constraints.txt updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "chore(deps)"
+    # constraints.txt is generated from [tool.uv] constraint-dependencies in pyproject.toml
+    # via tools/patch_dependabot.py; do not update it independently.
+    exclude-paths:
+      - "constraints.txt"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
# Summary

`constraints.txt` is updated via the `tools/patch_dependabot.py` script based on constraint-dependencies in `pyproject.toml`. It's never right to update `constraints.txt` directly, and should only be due to vulnerabilities. But dependabot has been proposing lots of changes to this file, so exclude it from dependabot pip updates.

See #562 and many others for examples of the useless PRs created by dependabot.

## Pre-Review Checklist

dependabot CI config change, not covered in normal tests.

Ensure that the following pass:

- [ ] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot configuration to optimize dependency management workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->