### PR TITLE
chore(ci): add 5-day cooldown for github-actions dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,9 +18,10 @@ updates:
     open-pull-requests-limit: 10
     commit-message:
       prefix: "chore(ci)"
-    ignore:
-      # FW-CI reusable workflows are pinned to immutable commits.
-      - dependency-name: "NVIDIA-NeMo/FW-CI-templates"
+    # Delay version-update PRs until releases are at least 5 days old (supply-chain risk).
+    # Security updates are not subject to cooldown. See dependabot cooldown docs.
+    cooldown:
+      default-days: 5
     groups:
       github-actions:
         patterns:


### PR DESCRIPTION
## Summary

- Add a 5-day `cooldown` to the `github-actions` Dependabot config so version-update PRs are only proposed for releases at least 5 days old, reducing exposure to fresh supply-chain releases.
- Remove the `ignore` entry for `NVIDIA-NeMo/FW-CI-templates` so Dependabot can propose updates for those reusable workflows again.

## Test plan

- [ ] Confirm `.github/dependabot.yml` validates (Dependabot tab on merge)
- [ ] Monitor next weekly Dependabot run for expected cooldown behavior on new action releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted dependency update automation settings to reduce notification frequency for version updates while ensuring security patches are processed immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->