### PR TITLE
fix: telemetry fix when running in notebook

### DIFF
--- a/src/nemo_safe_synthesizer/telemetry.py
+++ b/src/nemo_safe_synthesizer/telemetry.py
@@ -17,12 +17,13 @@ import asyncio
 import os
 import platform
 import threading
-from concurrent.futures import Future
+from collections.abc import Coroutine
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path, PureWindowsPath
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, cast
 from urllib.parse import urlsplit, urlunsplit
 
 from pydantic import BaseModel, Field
@@ -77,7 +78,7 @@ def _redact_endpoint(endpoint: str) -> str:
     except ValueError:
         return "<invalid-endpoint>"
     query = "<redacted>" if parsed.query else ""
-    return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment))
+    return cast(str, urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, parsed.fragment)))
 
 
 def _deployment_type() -> DeploymentTypeEnum:
@@ -333,7 +334,9 @@ class TelemetryHandler:
       a daemon thread with its own event loop that drives periodic flushing.
       ``stop()`` schedules a final flush, then stops the loop and joins the thread.
     - **Fire-and-flush mode**: skip ``start()``, ``enqueue()`` events, then call
-      ``stop()`` to flush once via ``asyncio.run``. No background thread is created.
+      ``stop()`` to flush once. No background thread is created unless the caller
+      already has a running event loop, in which case the one-shot flush is
+      offloaded to a worker thread with its own loop.
 
     Args:
         flush_interval_seconds (float): The interval in seconds to flush the events.
@@ -458,9 +461,9 @@ class TelemetryHandler:
         # Fire-and-flush: no background thread; flush once on a fresh loop.
         if self._events or self._dlq:
             try:
-                asyncio.run(self._flush_events())
+                self._run_sync(self._flush_events())
             except Exception:  # noqa: BLE001
-                pass  # best-effort: telemetry must not disrupt callers
+                logger.runtime.debug("Telemetry stop flush failed", exc_info=True)
 
     def flush(self) -> None:
         """Flush all queued events immediately and wait for completion."""
@@ -473,9 +476,29 @@ class TelemetryHandler:
             return
         if self._events or self._dlq:
             try:
-                asyncio.run(self._flush_events())
+                self._run_sync(self._flush_events())
             except Exception:  # noqa: BLE001
-                pass  # best-effort
+                logger.runtime.debug("Telemetry flush failed", exc_info=True)
+
+    @staticmethod
+    def _run_sync(coro: Coroutine[Any, Any, Any]) -> Any:
+        """Run a coroutine synchronously from sync or async caller contexts.
+
+        ``asyncio.run`` raises when called from a thread that already has a
+        running event loop, such as a notebook kernel or an async SDK caller. In
+        that case, run the coroutine in a worker thread so telemetry still gets
+        a fresh event loop while remaining synchronous to the caller.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop is not None:
+            pool = ThreadPoolExecutor(max_workers=1)
+            future = pool.submit(asyncio.run, coro)
+            return future.result(timeout=30)
+        return asyncio.run(coro)
 
     async def _astop_inner(self) -> None:
         """Async shutdown body run on the background loop."""

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -543,6 +543,62 @@ class TestAflushAwaits:
 
 
 # =============================================================================
+# TelemetryHandler — sync flush from async caller contexts
+# =============================================================================
+
+
+class TestFlushFromRunningLoop:
+    """Regression coverage for notebooks and async SDK callers."""
+
+    def test_flush_runs_to_completion_when_loop_is_running(self) -> None:
+        sent: list[int] = []
+
+        async def fake_flush(self) -> None:  # noqa: ARG001 - bound-method signature
+            sent.append(1)
+
+        async def driver() -> None:
+            handler = TelemetryHandler(source_client_version="1.0.0")
+            handler._events.append(
+                QueuedEvent(
+                    event=NSSTrainingAndGenerationEvent(task="run", task_status=TaskStatusEnum.COMPLETED),
+                    timestamp=datetime.now(timezone.utc),
+                )
+            )
+            with patch.object(TelemetryHandler, "_flush_events", new=fake_flush):
+                handler.flush()
+
+        asyncio.run(driver())
+        assert sent == [1]
+
+    def test_stop_flushes_fire_and_flush_path_when_loop_is_running(self, monkeypatch) -> None:
+        monkeypatch.setenv("NEMO_TELEMETRY_ENABLED", "true")
+        sent: list[int] = []
+
+        async def fake_send(events):
+            sent.append(len(events))
+
+        async def driver() -> None:
+            handler = TelemetryHandler(source_client_version="1.0.0")
+            with patch.object(handler, "_send_events", side_effect=fake_send):
+                handler.enqueue(NSSTrainingAndGenerationEvent(task="run", task_status=TaskStatusEnum.COMPLETED))
+                handler.stop()
+                assert handler._events == []
+
+        asyncio.run(driver())
+        assert sent == [1]
+
+    def test_run_sync_propagates_exception_to_flush_boundary(self) -> None:
+        async def boom() -> None:
+            raise RuntimeError("kaboom")
+
+        async def driver() -> None:
+            with pytest.raises(RuntimeError, match="kaboom"):
+                TelemetryHandler._run_sync(boom())
+
+        asyncio.run(driver())
+
+
+# =============================================================================
 # TelemetryHandler — sync lifecycle and context manager
 # =============================================================================
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed telemetry shutdown and flush failing in environments with a running event loop (e.g., notebooks, async SDK callers).
  * Improved error visibility by logging exceptions when one-shot flushes fail instead of hiding them.

* **Documentation**
  * Clarified telemetry handler behavior and "fire-and-flush" mode in docs.

* **Tests**
  * Added regression tests covering flush/stop behavior and exception propagation when called from a running event loop.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->