### PR TITLE
chore: pre-sync venv before submitting slurm batch jobs

### DIFF
--- a/script/slurm/README.md
+++ b/script/slurm/README.md
@@ -117,7 +117,7 @@ Edit `env_variables.sh` to match your environment. Key items:
 - `NSS_DIR`: path to this repository.
 - `ADAPTER_PATH`: base path for workdirs (each run creates a subdirectory with adapter, logs, and outputs).
 - `VLLM_CACHE_ROOT`, `UV_CACHE_DIR`, `UV_PYTHON_INSTALL_DIR`, `UV_PYTHON_BIN_DIR`, `UV_TOOL_DIR`, `HF_HOME`: cache locations to avoid stressing login nodes.
-- `NSS_PYTHON_VERSION`: Python version used for PyPI-mode Slurm virtualenvs. Defaults to `3.13` and is included in the cached venv name to avoid reusing venvs created with older Python versions.
+- `NSS_PYTHON_VERSION`: Python version used for Slurm virtualenvs. Defaults to the repo's pinned version from `.python-version` (so it tracks Python bumps automatically) and falls back to `3.13`. For PyPI mode it is also included in the cached venv name to avoid reusing venvs created with older Python versions. Export it before sourcing `env_variables.sh` to override.
 - `NSS_SHARED_DIR`: location of shared files such as benchmark data and container images, see section below for details.
 
 NSS CLI Environment Variables (used by `safe-synthesizer` CLI via pydantic-settings):

--- a/script/slurm/README.md
+++ b/script/slurm/README.md
@@ -134,6 +134,11 @@ In `slurm_nss_matrix.sh`, each job extracts the dataset and config that it shoul
 
 ### Submit jobs
 
+> **Run one submit at a time.** `submit_slurm_jobs.sh` builds the shared
+> `${NSS_DIR}/.venv` on the login node before submitting. Running multiple submits
+> concurrently (especially from different login nodes, where the build lock is not
+> reliable across hosts) can corrupt that venv and lets branch switches race. Let
+> one submit finish before starting another.
 
 Run the submit script (flags are order-independent) from this directory:
 

--- a/script/slurm/env_variables.sh
+++ b/script/slurm/env_variables.sh
@@ -29,7 +29,17 @@ export UV_CACHE_DIR="${LUSTRE_DIR}/.cache/uv"
 export UV_PYTHON_INSTALL_DIR="${LUSTRE_DIR}/.local/share/uv/python"
 export UV_PYTHON_BIN_DIR="${LUSTRE_DIR}/.local/bin"
 export UV_TOOL_DIR="${LUSTRE_DIR}/.local/share/uv/tools"
-export NSS_PYTHON_VERSION="${NSS_PYTHON_VERSION:-3.13}"
+# Python version for Slurm virtualenvs. Defaults to the repo's pinned version
+# (.python-version) so it tracks dependency/Python bumps automatically; override
+# by exporting NSS_PYTHON_VERSION before sourcing this file.
+if [[ -z "${NSS_PYTHON_VERSION:-}" ]]; then
+    if [[ -f "${NSS_DIR}/.python-version" ]]; then
+        NSS_PYTHON_VERSION="$(tr -d '[:space:]' < "${NSS_DIR}/.python-version")"
+    else
+        NSS_PYTHON_VERSION="3.13"
+    fi
+fi
+export NSS_PYTHON_VERSION
 export HF_HOME="${LUSTRE_DIR}/.cache/huggingface"
 export WANDB_MODE="online" # "online", "offline" or "disabled"
 export NEMO_DEPLOYMENT_TYPE="slurm-nvidia-internal" # sets the values for telemetry

--- a/script/slurm/env_variables.sh
+++ b/script/slurm/env_variables.sh
@@ -29,6 +29,10 @@ export UV_CACHE_DIR="${LUSTRE_DIR}/.cache/uv"
 export UV_PYTHON_INSTALL_DIR="${LUSTRE_DIR}/.local/share/uv/python"
 export UV_PYTHON_BIN_DIR="${LUSTRE_DIR}/.local/bin"
 export UV_TOOL_DIR="${LUSTRE_DIR}/.local/share/uv/tools"
+# Cap concurrent wheel downloads. The repo venv pre-build pulls large CUDA/torch/
+# vLLM/flashinfer wheels, and uv's default high concurrency might spike memory on
+# the login node. Override by exporting UV_CONCURRENT_DOWNLOADS first.
+export UV_CONCURRENT_DOWNLOADS="${UV_CONCURRENT_DOWNLOADS:-20}"
 # Python version for Slurm virtualenvs. Defaults to the repo's pinned version
 # (.python-version) so it tracks dependency/Python bumps automatically; override
 # by exporting NSS_PYTHON_VERSION before sourcing this file.

--- a/script/slurm/slurm_nss_matrix.sh
+++ b/script/slurm/slurm_nss_matrix.sh
@@ -106,7 +106,10 @@ apt-get update && apt-get install -y --no-install-recommends \
 
 # Ensure Python environment is available inside the container
 source "${LUSTRE_DIR}/.uv/bin/env"
-NSS_PYTHON_VERSION="${NSS_PYTHON_VERSION:-3.13}"
+
+# NSS_PYTHON_VERSION is resolved in env_variables.sh (from .python-version, with
+# an optional override), which is always sourced before this script runs.
+
 if [[ -n "${NSS_VERSION:-}" ]]; then
     # Install nemo-safe-synthesizer from PyPI into a versioned venv cached on
     # lustre so concurrent array jobs can share it without redundant downloads.
@@ -121,9 +124,21 @@ if [[ -n "${NSS_VERSION:-}" ]]; then
     NSS_RUN_CMD="${PYPI_VENV}/bin/safe-synthesizer"
     echo "[NSS SLURM] Using PyPI install: nemo-safe-synthesizer==${NSS_VERSION} on Python ${NSS_PYTHON_VERSION}"
 else
-    uv sync --frozen --extra cu129 --extra engine --group dev
+    # Repo mode. The shared ${NSS_DIR}/.venv is bind-mounted from Lustre into
+    # every container, so running `uv sync` in each array task means dozens of
+    # jobs create/recreate the same directory at once (uv recreates it whenever
+    # the pinned Python changes), which corrupts the venv on Lustre. Instead the
+    # venv is built once on the login node by submit_slurm_jobs.sh before the
+    # array is submitted; tasks only activate it here. Invoke the venv binary
+    # directly so `uv run` can't trigger an implicit re-sync.
+    if [[ ! -x "${NSS_DIR}/.venv/bin/python" ]]; then
+        echo "[NSS SLURM] ERROR: no pre-built repo venv at ${NSS_DIR}/.venv" >&2
+        echo "[NSS SLURM] Submit via submit_slurm_jobs.sh (it builds the venv once), or build it manually: (cd ${NSS_DIR} && mise run bootstrap-nss cu129)" >&2
+        exit 1
+    fi
+    echo "[NSS SLURM] Using pre-built repo venv at ${NSS_DIR}/.venv"
     source "${NSS_DIR}/.venv/bin/activate"
-    NSS_RUN_CMD="uv run safe-synthesizer"
+    NSS_RUN_CMD="${NSS_DIR}/.venv/bin/safe-synthesizer"
 fi
 echo "[NSS SLURM] nemo-safe-synthesizer version: $(python -c 'from nemo_safe_synthesizer.package_info import __version__; print(__version__)')"
 

--- a/script/slurm/slurm_nss_matrix.sh
+++ b/script/slurm/slurm_nss_matrix.sh
@@ -131,8 +131,11 @@ else
     # venv is built once on the login node by submit_slurm_jobs.sh before the
     # array is submitted; tasks only activate it here. Invoke the venv binary
     # directly so `uv run` can't trigger an implicit re-sync.
-    if [[ ! -x "${NSS_DIR}/.venv/bin/python" ]]; then
-        echo "[NSS SLURM] ERROR: no pre-built repo venv at ${NSS_DIR}/.venv" >&2
+    # Check the safe-synthesizer entry point (not just python): a partial
+    # install can leave python present but the package missing, which would
+    # otherwise fail much later with a generic "command not found".
+    if [[ ! -x "${NSS_DIR}/.venv/bin/safe-synthesizer" ]]; then
+        echo "[NSS SLURM] ERROR: no usable repo venv at ${NSS_DIR}/.venv (missing safe-synthesizer entry point)" >&2
         echo "[NSS SLURM] Submit via submit_slurm_jobs.sh (it builds the venv once), or build it manually: (cd ${NSS_DIR} && mise run bootstrap-nss cu129)" >&2
         exit 1
     fi

--- a/script/slurm/slurm_nss_matrix.sh
+++ b/script/slurm/slurm_nss_matrix.sh
@@ -124,16 +124,9 @@ if [[ -n "${NSS_VERSION:-}" ]]; then
     NSS_RUN_CMD="${PYPI_VENV}/bin/safe-synthesizer"
     echo "[NSS SLURM] Using PyPI install: nemo-safe-synthesizer==${NSS_VERSION} on Python ${NSS_PYTHON_VERSION}"
 else
-    # Repo mode. The shared ${NSS_DIR}/.venv is bind-mounted from Lustre into
-    # every container, so running `uv sync` in each array task means dozens of
-    # jobs create/recreate the same directory at once (uv recreates it whenever
-    # the pinned Python changes), which corrupts the venv on Lustre. Instead the
-    # venv is built once on the login node by submit_slurm_jobs.sh before the
-    # array is submitted; tasks only activate it here. Invoke the venv binary
-    # directly so `uv run` can't trigger an implicit re-sync.
-    # Check the safe-synthesizer entry point (not just python): a partial
-    # install can leave python present but the package missing, which would
-    # otherwise fail much later with a generic "command not found".
+    # Repo mode: activate the venv pre-built once on the login node by
+    # submit_slurm_jobs.sh, rather than each array task running `uv sync` against
+    # the shared Lustre .venv (which could race and corrupt it).
     if [[ ! -x "${NSS_DIR}/.venv/bin/safe-synthesizer" ]]; then
         echo "[NSS SLURM] ERROR: no usable repo venv at ${NSS_DIR}/.venv (missing safe-synthesizer entry point)" >&2
         echo "[NSS SLURM] Submit via submit_slurm_jobs.sh (it builds the venv once), or build it manually: (cd ${NSS_DIR} && mise run bootstrap-nss cu129)" >&2

--- a/script/slurm/submit_slurm_jobs.sh
+++ b/script/slurm/submit_slurm_jobs.sh
@@ -131,6 +131,41 @@ export ACCOUNT
 export EXP_NAME
 export NSS_VERSION
 
+# nss_prebuild_repo_venv: In repo mode (no --nss-version) the shared
+# ${NSS_DIR}/.venv is bind-mounted into every job container from Lustre. If each
+# array task ran `uv sync`, dozens of jobs would create/recreate the same
+# directory at once and corrupt it. Build it once here on the login node so the
+# array tasks (see slurm_nss_matrix.sh) only activate it.
+prebuild_repo_venv() {
+  if [[ -n "${NSS_VERSION:-}" ]]; then
+    return 0  # PyPI mode manages its own versioned venv
+  fi
+  if [[ -n "${DRY_RUN:-}" ]]; then
+    echo "[submit] --dry-run: skipping repo venv pre-build"
+    return 0
+  fi
+
+  local lock_dir="${LUSTRE_DIR}/.locks"
+  local lock_file="${lock_dir}/nss-repo-venv.lock"
+  mkdir -p "${lock_dir}"
+
+  echo "[submit] pre-building repo venv at ${NSS_DIR}/.venv (python=${NSS_PYTHON_VERSION})"
+  (
+    flock -x 200
+    unset VIRTUAL_ENV
+    cd "${NSS_DIR}"
+    uv sync --frozen --extra cu129 --extra engine --group dev --python "${NSS_PYTHON_VERSION}"
+  ) 200>"${lock_file}"
+
+  if [[ ! -x "${NSS_DIR}/.venv/bin/python" ]]; then
+    echo "[submit] ERROR: repo venv pre-build did not create ${NSS_DIR}/.venv/bin/python" >&2
+    exit 1
+  fi
+  echo "[submit] repo venv ready: $("${NSS_DIR}/.venv/bin/python" --version 2>&1)"
+}
+
+prebuild_repo_venv
+
 # Build configs list: CLI override (comma-separated) takes precedence; otherwise use CONFIGS from env
 declare -a CONFIGS_LIST
 if [ -n "${CONFIGS_CSV:-}" ]; then

--- a/script/slurm/submit_slurm_jobs.sh
+++ b/script/slurm/submit_slurm_jobs.sh
@@ -157,8 +157,12 @@ prebuild_repo_venv() {
     uv sync --frozen --extra cu129 --extra engine --group dev --python "${NSS_PYTHON_VERSION}"
   ) 200>"${lock_file}"
 
-  if [[ ! -x "${NSS_DIR}/.venv/bin/python" ]]; then
-    echo "[submit] ERROR: repo venv pre-build did not create ${NSS_DIR}/.venv/bin/python" >&2
+  # Functionally verify the venv by running safe-synthesizer once. This catches
+  # partial installs and corrupted libs that a file-existence check would miss,
+  # so array tasks fail fast here instead of much later. Cheap since it runs once.
+  if ! "${NSS_DIR}/.venv/bin/safe-synthesizer" --version >/dev/null 2>&1; then
+    echo "[submit] ERROR: repo venv at ${NSS_DIR}/.venv is not functional (safe-synthesizer failed to run)" >&2
+    echo "[submit] Rebuild it: (cd ${NSS_DIR} && rm -rf .venv && mise run bootstrap-nss cu129)" >&2
     exit 1
   fi
   echo "[submit] repo venv ready: $("${NSS_DIR}/.venv/bin/python" --version 2>&1)"

--- a/script/slurm/submit_slurm_jobs.sh
+++ b/script/slurm/submit_slurm_jobs.sh
@@ -157,9 +157,7 @@ prebuild_repo_venv() {
     uv sync --frozen --extra cu129 --extra engine --group dev --python "${NSS_PYTHON_VERSION}"
   ) 200>"${lock_file}"
 
-  # Functionally verify the venv by running safe-synthesizer once. This catches
-  # partial installs and corrupted libs that a file-existence check would miss,
-  # so array tasks fail fast here instead of much later. Cheap since it runs once.
+  # Functionally verify the venv by running safe-synthesizer once
   if ! "${NSS_DIR}/.venv/bin/safe-synthesizer" --version >/dev/null 2>&1; then
     echo "[submit] ERROR: repo venv at ${NSS_DIR}/.venv is not functional (safe-synthesizer failed to run)" >&2
     echo "[submit] Rebuild it: (cd ${NSS_DIR} && rm -rf .venv && mise run bootstrap-nss cu129)" >&2


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

In repo mode (no `--nss-version`), `${NSS_DIR}/.venv` is bind-mounted into every
job container from Lustre. Each array task running `uv sync` means dozens of jobs
create/recreate the same directory at once — and `uv` recreates the venv whenever
the pinned Python changes — which could corrupt the shared venv on Lustre and fails
jobs before they start.

This moves the sync to a single login-node build at submit time; array tasks only
activate the venv.

## Changes

- **`submit_slurm_jobs.sh`**: build the repo venv once on the login node
  (`uv sync --frozen ...` at the pinned Python, `flock`-guarded) before submitting
  the array. Skipped on `--dry-run` and in PyPI mode.
- **`slurm_nss_matrix.sh`**: repo mode now only activates `${NSS_DIR}/.venv` and
  runs the venv binary directly (no per-task `uv sync`, no implicit `uv run`
  re-sync). Fails fast with a clear message if the venv is missing.
- **`env_variables.sh`**: resolve `NSS_PYTHON_VERSION` from `.python-version`
  (override-able, falls back to `3.13`) so Slurm venvs track Python bumps. This is
  now the single source of truth for the version.
- **`README.md`**: update `NSS_PYTHON_VERSION` docs.

## Notes

- PyPI mode (`--nss-version`) behavior is unchanged.
- Resulting venv contents are identical to before (frozen lockfile) — only the
  build moves from N racy per-task syncs to one safe pre-build.

## Test plan

- [x] Full matrix submit (e.g. `--max-concurrent-slurm-jobs 50`) completes without
      `.venv` stale-handle / "failed to remove" errors.
- [x] `--dry-run` submit skips the pre-build.
- [ ] PyPI mode (`--nss-version`) still builds its versioned venv.

This is what happened when I submitted a batch job from an outdated venv:
```
bash submit_slurm_jobs.sh --runs 5 --exp-name nss_weekly_run_2026-06-08 --dataset-group short --max-concurrent-slurm-jobs 50 
[submit] pre-building repo venv at /lustre/fsw/portfolios/nemotron/projects/nemotron_data_dev/users/ninaxu/Safe-Synthesizer/.venv (python=3.13)
Using CPython 3.13.12
Removed virtual environment at: .venv
Creating virtual environment at: .venv
      Built nemo-safe-synthesizer @ file:///lustre/fs11/portfolios/nemotron/projects/nemotron_data
Prepared 1 package in 6.69s
Installed 335 packages in 2m 45s
 + accelerate==1.12.0
 + aiohappyeyeballs==2.6.1
….
```
## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Python-version selection behavior and added guidance to run job submissions one at a time to avoid concurrent environment build corruption.

* **Improvements**
  * Python version now defaults to the repository's pinned version with an automatic fallback.
  * Added a cap on concurrent package downloads for greater stability.
  * Shared virtual environment is prebuilt and validated before batch runs to reduce repeated setup and failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->