### PR TITLE
fix(eval): handle apostrophe in pii replay counting

### DIFF
--- a/src/nemo_safe_synthesizer/evaluation/components/pii_replay.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/pii_replay.py
@@ -116,9 +116,6 @@ class PIIReplay(Component):
             # These are the same in both cases. We want the size of that set of training[col] unique values.
             training_entity_unique_count = len(training_entity_unique_values)
             # We want the total number of rows in synthetic[column] that contain some value from the training[col] unique values.
-            # Use a vectorized isin() rather than DataFrame.query(): query() routes the
-            # backtick-quoted column name through the Python tokenizer, which fails on
-            # names containing quotes/apostrophes (e.g. "i'm fine") under Python 3.12+.
             synthetic_col = evaluation_datasets.synthetic[col]
             synthetic_entity_values = synthetic_col[synthetic_col.isin(training_entity_unique_values)]
             synthetic_entity_count = len(synthetic_entity_values)

--- a/src/nemo_safe_synthesizer/evaluation/components/pii_replay.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/pii_replay.py
@@ -116,9 +116,11 @@ class PIIReplay(Component):
             # These are the same in both cases. We want the size of that set of training[col] unique values.
             training_entity_unique_count = len(training_entity_unique_values)
             # We want the total number of rows in synthetic[column] that contain some value from the training[col] unique values.
-            synthetic_entity_values = (
-                evaluation_datasets.synthetic[col].to_frame().query(f"`{col}` in @training_entity_unique_values")[col]
-            )
+            # Use a vectorized isin() rather than DataFrame.query(): query() routes the
+            # backtick-quoted column name through the Python tokenizer, which fails on
+            # names containing quotes/apostrophes (e.g. "i'm fine") under Python 3.12+.
+            synthetic_col = evaluation_datasets.synthetic[col]
+            synthetic_entity_values = synthetic_col[synthetic_col.isin(training_entity_unique_values)]
             synthetic_entity_count = len(synthetic_entity_values)
             # With those query results, we also want the count of unique items in those filtered synthetic results.
             synthetic_entity_unique_count = len(synthetic_entity_values.unique())

--- a/tests/evaluation/components/test_pii_replay.py
+++ b/tests/evaluation/components/test_pii_replay.py
@@ -3,10 +3,12 @@
 
 import logging
 
+import pandas as pd
 import pytest
 
 from nemo_safe_synthesizer.evaluation.components.pii_replay import PIIReplay
 from nemo_safe_synthesizer.evaluation.data_model.evaluation_datasets import EvaluationDatasets
+from nemo_safe_synthesizer.pii_replacer.transform_result import ColumnStatistics
 
 logger = logging.getLogger(__name__)
 
@@ -28,3 +30,42 @@ def test_pii_replay(fixture_training_df_5k, fixture_synthetic_df_5k, fixture_tes
     assert pii_replay.pii_replay_data[0].total_synthetic_data == 2044
     assert pii_replay.pii_replay_data[0].unique_synthetic_data == 2
     assert pii_replay.pii_replay_data[0].unique_synthetic_data_percentage == 100.0
+
+
+def test_pii_replay_column_name_with_apostrophe():
+    """Regression: a classified column whose name contains an apostrophe must not crash.
+
+    PII replay previously filtered the synthetic column via ``DataFrame.query`` with a
+    backtick-quoted column name. Under Python 3.12+ the query parser routes the backtick
+    contents through CPython's tokenizer, so a name like ``judge's score`` raised
+    ``SyntaxError: Failed to parse backticks`` (unterminated string literal).
+    """
+    col = "judge's score"
+    training = pd.DataFrame({col: ["foo", "bar", "foo", "baz", "bar"]})
+    synthetic = pd.DataFrame({col: ["foo", "foo", "bar", "qux", "qux"]})
+    column_statistics = {
+        col: ColumnStatistics(
+            assigned_type="text",
+            assigned_entity="name",
+            detected_entity_counts={"name": 4},
+            detected_entity_values={"name": {"foo", "bar"}},
+            is_transformed=True,
+            transform_functions={"fake"},
+        )
+    }
+
+    evaluation_datasets = EvaluationDatasets.from_dataframes(
+        training, synthetic, column_statistics=column_statistics, enable_sampling=False
+    )
+    pii_replay = PIIReplay.from_evaluation_datasets(evaluation_datasets)
+
+    assert len(pii_replay.pii_replay_data) == 1
+    datum = pii_replay.pii_replay_data[0]
+    assert datum.column_name == col
+    assert datum.pii_type == "name"
+    assert datum.total_training_data == 4
+    assert datum.unique_training_data == 2
+    # synthetic values in {"foo", "bar"}: foo, foo, bar -> 3 rows, 2 unique
+    assert datum.total_synthetic_data == 3
+    assert datum.unique_synthetic_data == 2
+    assert datum.unique_synthetic_data_percentage == 100.0


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->
Fix a small bug where evaluation fails on column names that contain apostrophe since the python 3.13 upgrade. Wandb [test runs](https://wandb.ai/nemo-llm-service/pii-replay-apostrophe-fix/table?nw=nwuserninaxunvidia)

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [x] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #574 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a crash in PII replay evaluation when processing column names containing special characters such as apostrophes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->