### PR TITLE
fix: slurm venv functional check

### DIFF
--- a/script/slurm/submit_slurm_jobs.sh
+++ b/script/slurm/submit_slurm_jobs.sh
@@ -158,7 +158,7 @@ prebuild_repo_venv() {
   ) 200>"${lock_file}"
 
   # Functionally verify the venv by running safe-synthesizer once
-  if ! "${NSS_DIR}/.venv/bin/safe-synthesizer" --version >/dev/null 2>&1; then
+  if ! "${NSS_DIR}/.venv/bin/safe-synthesizer" --help >/dev/null 2>&1; then
     echo "[submit] ERROR: repo venv at ${NSS_DIR}/.venv is not functional (safe-synthesizer failed to run)" >&2
     echo "[submit] Rebuild it: (cd ${NSS_DIR} && rm -rf .venv && mise run bootstrap-nss cu129)" >&2
     exit 1


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->
In my PR #573 yesterday, there was a bug where we check for the health of the venv. `safe-synthesizer` command doesn't have flag `--version`, so i've switched it to `--help` here 😓 

Before
```
(nemo-safe-synthesizer) ninaxu@cs-oci-ord-vscode-02:/lustre/fsw/portfolios/nemotron/projects/nemotron_data_dev/users/ninaxu/Safe-Synthesizer/script/slurm$ bash submit_slurm_jobs.sh --dataset-urls dialogs --configs smollm3-nodp,smollm3-dp,mistral-nodp,tinyllama-dp
[submit] pre-building repo venv at /lustre/fsw/portfolios/nemotron/projects/nemotron_data_dev/users/ninaxu/Safe-Synthesizer/.venv (python=3.13)
      Built nemo-safe-synthesizer @ file:///lustre/fs11/portfolios/nemotron/projects/nemotron_data_dev/users/ninaxu/Safe-Synthesizer
Prepared 1 package in 7.18s
Uninstalled 1 package in 70ms
Installed 1 package in 173ms
 - nemo-safe-synthesizer==0.1.2.post12.dev0+a0cba235 (from file:///lustre/fs11/portfolios/nemotron/projects/nemotron_data_dev/users/ninaxu/Safe-Synthesizer)
 + nemo-safe-synthesizer==0.1.2.post14.dev0+dea46c63 (from file:///lustre/fs11/portfolios/nemotron/projects/nemotron_data_dev/users/ninaxu/Safe-Synthesizer)
[submit] ERROR: repo venv at /lustre/fsw/portfolios/nemotron/projects/nemotron_data_dev/users/ninaxu/Safe-Synthesizer/.venv is not functional (safe-synthesizer failed to run)
[submit] Rebuild it: (cd /lustre/fsw/portfolios/nemotron/projects/nemotron_data_dev/users/ninaxu/Safe-Synthesizer && rm -rf .venv && mise run bootstrap-nss cu129)
```

Tested it just now and submitting slurm jobs works fine
```
(nemo-safe-synthesizer) ninaxu@cs-oci-ord-vscode-02:/lustre/fsw/portfolios/nemotron/projects/nemotron_data_dev/users/ninaxu/Safe-Synthesizer/script/slurm$ bash submit_slurm_jobs.sh --dataset-urls dialogs --configs smollm3-nodp,smollm3-dp,mistral-nodp,tinyllama-dp
[submit] pre-building repo venv at /lustre/fsw/portfolios/nemotron/projects/nemotron_data_dev/users/ninaxu/Safe-Synthesizer/.venv (python=3.13)
Audited 325 packages in 556ms
[submit] repo venv ready: Python 3.13.12
Submitting array jobs (pipeline=end_to_end, RUNS=1, PARTITION=polar4, EXP_NAME=nss_exp, GROUP=, WANDB_PROJECT=nss_exp)
DATASETS: dialogs
CONFIGS_LIST: smollm3-nodp smollm3-dp mistral-nodp tinyllama-dp
total_tasks: 4
PACKED_DATASETS: dialogs,dialogs,dialogs,dialogs
PACKED_CONFIGS: smollm3-nodp,smollm3-dp,mistral-nodp,tinyllama-dp
Using container image: /lustre/fsw/portfolios/nemotron/projects/nemotron_data_dev/users/kendrickb/shared_safe_synthesizer/images/cuda_12_8_1_cudnn_runtime_ubuntu24_04.sqsh
array_spec: 0-3
28889054
Done submitting jobs to slurm cluster. Monitor with: squeue -u ninaxu
```

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build process validation for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->