### PR TITLE
chore: allow logs to pipe through with -s flag

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,11 +17,12 @@ name: CodeQL Security Scan
 # No path filter: security vulnerabilities can appear in any file type, so
 # this must run on every pull request regardless of which files changed.
 on:
+  push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
-  merge_group:
-    types: [checks_requested]
   schedule:
     - cron: "0 6 * * 0"  # Weekly on Sunday at 06:00 UTC
   workflow_dispatch:

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -43,6 +43,20 @@ uv run --frozen pytest tests/path/test_file.py::test_name -vvs -n0
 
 Test runner: `uv run --frozen pytest -n auto --dist loadscope -vv`
 
+## Viewing NSS Logs
+
+`pytest -s` / `--capture=no` initializes the NSS observability stack from
+`tests/conftest.py`, so `get_logger(__name__)` messages are routed to stdout in
+that pytest process. When you do not pass `-n` explicitly, the same hook also
+overrides this repo's default xdist worker count so `pytest -s` behaves like a
+single-process live-debug run. If you do pass `-n`, use `-n0` for visible logs
+because xdist does not stream worker stdout:
+
+```bash
+uv run --frozen pytest tests/path/test_file.py::test_name -vvs -n0
+NSS_LOG_LEVEL=DEBUG uv run --frozen pytest tests/path/test_file.py::test_name -vvs -n0
+```
+
 ## Config-Dataset Combo Tests
 
 Two test functions (`test_clinc_oos_dataset`, `test_dow_jones_index_dataset`) each parametrized over 6 model configs = 12 combinations. Each has a dedicated mise task:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,50 @@ shared across unit, smoke, and e2e tests.
 """
 
 import json
+import os
+import sys
 from pathlib import Path
 
 import pandas as pd
 import pytest
 from datasets import Dataset, load_dataset
+
+
+def _pytest_live_logging_requested(config: pytest.Config) -> bool:
+    """Return whether pytest is configured to stream test logs live."""
+    return config.getoption("capture", default=None) in {"no", "tee-sys"}
+
+
+def _xdist_option_was_explicit() -> bool:
+    """Return whether the command line explicitly selected an xdist worker count."""
+    return any(arg in {"-n", "--numprocesses"} or arg.startswith(("-n", "--numprocesses=")) for arg in sys.argv[1:])
+
+
+def _disable_default_xdist_for_live_logging(config: pytest.Config) -> None:
+    """Let ``pytest -s`` stream logs by running tests in the current process."""
+    if _xdist_option_was_explicit():
+        return
+    if hasattr(config.option, "numprocesses"):
+        config.option.numprocesses = 0
+    if hasattr(config.option, "dist"):
+        config.option.dist = "no"
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_configure(config: pytest.Config) -> None:
+    """Route NSS logs to stdout for local live-output pytest runs."""
+    if not _pytest_live_logging_requested(config):
+        return
+
+    _disable_default_xdist_for_live_logging(config)
+
+    os.environ.setdefault("NSS_LOG_FORMAT", "plain")
+    os.environ.setdefault("NSS_LOG_COLOR", "false")
+    os.environ.setdefault("NSS_LOG_LEVEL", "INFO")
+
+    from nemo_safe_synthesizer.observability import initialize_observability
+
+    initialize_observability()
 
 
 def pytest_collection_modifyitems(config, items):


### PR DESCRIPTION
* Allows for easier debugging when running tests
* Closes https://github.com/NVIDIA-NeMo/Safe-Synthesizer/issues/75

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for viewing test logs in live mode, including xdist behavior and debug logging options.

* **Tests**
  * Enabled automatic live log streaming during pytest runs when live output is requested to improve debugging visibility.

* **Chores**
  * CI workflow updated to run security analysis on main branch pushes in addition to pull requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->