### PR TITLE
chore: Group dependabot PRs to bump github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,7 @@ updates:
           - "actions/*"
           - "astral-sh/*"
           - "codecov/*"
+          - "docker/*"
+          - "dorny/*"
+          - "github/codeql-action/*"
+          - "NVIDIA-NeMo/FW-CI-templates*"


### PR DESCRIPTION
# Summary

Reduce quantity of PRs from dependabot by grouping the github action bumps into a single PR.

## Pre-Review Checklist

Change to .github dependabot config, not covered by any CI tests.

Ensure that the following pass:

- [ ] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

