### PR TITLE
refactor(records): add JSON record boundaries

### DIFF
--- a/src/nemo_safe_synthesizer/data_processing/record_utils.py
+++ b/src/nemo_safe_synthesizer/data_processing/record_utils.py
@@ -13,21 +13,27 @@ import calendar
 import json
 import re
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping, Sequence
 from csv import QUOTE_NONNUMERIC
 from dataclasses import dataclass, field
 from datetime import datetime
 from io import StringIO
+from typing import Any
 
 import jsonschema
 import pandas as pd
 
 from ..observability import get_logger
+from .records.json_types import JsonSchema, JsonValue, is_json_object
 
 RECORD_REGEX_PATTERN = r"{.+?}(?:\n|$)"
 RECORD_REGEX_PATTEN_LOOKAHEAD = r"{.+?}(?=\n|$)"
 
 logger = get_logger()
+
+RecordDict = dict[str, Any]
+RecordMapping = Mapping[str, Any]
+RawRecordMapping = Mapping[Any, Any]
 
 
 @dataclass
@@ -50,7 +56,7 @@ class ParsedRecord:
     text: str
     """Original regex-matched JSON string (invariant under reclassification)."""
 
-    parsed: dict | None = None
+    parsed: RecordDict | None = None
     """Parsed dict when validation succeeded, ``None`` when invalid."""
 
     error: tuple[str, str] | None = None
@@ -102,7 +108,7 @@ class ParsedResponse:
     """Index of the prompt within the batch (set by the processor call)."""
 
     @property
-    def valid_records(self) -> list[dict]:
+    def valid_records(self) -> list[RecordDict]:
         """Parsed dicts for records that passed validation."""
         return [r.parsed for r in self.records if r.is_valid and r.parsed is not None]
 
@@ -117,7 +123,7 @@ class ParsedResponse:
         return [r.error for r in self.records if r.error is not None]
 
 
-def is_safe_for_float_conversion(value: str | int | float | None | list | dict) -> bool:
+def is_safe_for_float_conversion(value: JsonValue) -> bool:
     """Check if a value can be safely converted to float64 without overflow.
 
     Only ``int`` values can cause overflow; all other types are considered safe.
@@ -142,7 +148,7 @@ def is_safe_for_float_conversion(value: str | int | float | None | list | dict) 
     return True
 
 
-def check_record_for_large_numbers(record: dict) -> str | None:
+def check_record_for_large_numbers(record: RecordMapping) -> str | None:
     """Check if a record contains any numbers that would cause float64 overflow.
 
     Args:
@@ -161,7 +167,7 @@ def check_record_for_large_numbers(record: dict) -> str | None:
     return None
 
 
-def check_if_records_are_ordered(records: list[dict], order_by: str) -> bool:
+def check_if_records_are_ordered(records: Sequence[RecordMapping], order_by: str) -> bool:
     """Check if the records are in ascending order based on the given `order_by` column.
 
     Args:
@@ -174,6 +180,11 @@ def check_if_records_are_ordered(records: list[dict], order_by: str) -> bool:
     order_by_values = [rec[order_by] for rec in records]
     sorted_values = sorted([rec[order_by] for rec in records])
     return order_by_values == sorted_values
+
+
+def normalize_record_keys(record: RawRecordMapping) -> RecordDict:
+    """Return a record with string keys, matching JSON object semantics."""
+    return {str(key): value for key, value in record.items()}
 
 
 def extract_records_from_jsonl_string(jsonl_string: str) -> list[str]:
@@ -227,7 +238,7 @@ def timed_encode(
 
 def extract_and_validate_records(
     jsonl_string: str,
-    schema: dict,
+    schema: JsonSchema,
     encode: Callable[[str], list[int]] | None = None,
 ) -> ParsedResponse:
     """Extract and validate records from the given JSONL string.
@@ -280,7 +291,7 @@ def _parse_timestamp_to_seconds(value: object, time_format: str) -> int:
     """
     if time_format == "elapsed_seconds":
         # Value is already in seconds (int for now and float for future)
-        return int(float(value))  # ty: ignore[invalid-argument-type] -- third-party stub mismatch
+        return int(float(str(value)))
 
     # Parse using strptime format
     dt = datetime.strptime(str(value), time_format)
@@ -297,7 +308,7 @@ def _parse_timestamp_to_seconds(value: object, time_format: str) -> int:
     return dt.hour * 3600 + dt.minute * 60 + dt.second
 
 
-def _parse_and_validate_json(matched_json: str, schema: dict) -> tuple[dict | None, tuple[str, str] | None]:
+def _parse_and_validate_json(matched_json: str, schema: JsonSchema) -> tuple[RecordDict | None, tuple[str, str] | None]:
     """Parse JSON string and validate against schema.
 
     Args:
@@ -310,6 +321,9 @@ def _parse_and_validate_json(matched_json: str, schema: dict) -> tuple[dict | No
     """
     try:
         matched_dict = json.loads(matched_json)
+        if not is_json_object(matched_dict):
+            return None, ("Expected a JSON object", "Invalid JSON")
+
         jsonschema.validate(matched_dict, schema)
 
         error_msg = check_record_for_large_numbers(matched_dict)
@@ -321,11 +335,11 @@ def _parse_and_validate_json(matched_json: str, schema: dict) -> tuple[dict | No
     except json.JSONDecodeError as err:
         return None, (f"Invalid JSON: {err.msg}", "Invalid JSON")
     except jsonschema.exceptions.ValidationError as err:
-        return None, (err.message, err.validator)
+        return None, (err.message, str(err.validator))
 
 
 def _extract_timestamp_seconds(
-    record: dict, time_column: str, time_format: str
+    record: RecordMapping, time_column: str, time_format: str
 ) -> tuple[int | None, tuple[str, str] | None]:
     """Extract and parse timestamp from a record.
 
@@ -413,7 +427,7 @@ def _validate_time_interval(
 
 def extract_and_validate_timeseries_records(
     jsonl_string: str,
-    schema: dict,
+    schema: JsonSchema,
     time_column: str,
     interval_seconds: int | None,
     time_format: str,
@@ -541,7 +555,7 @@ def normalize_dataframe(dataframe: pd.DataFrame) -> pd.DataFrame:
         )
 
 
-def records_to_jsonl(records: pd.DataFrame | list[dict] | dict) -> str:
+def records_to_jsonl(records: pd.DataFrame | list[RawRecordMapping] | RawRecordMapping) -> str:
     """Convert list of records to a JSONL string.
 
     Args:
@@ -550,9 +564,10 @@ def records_to_jsonl(records: pd.DataFrame | list[dict] | dict) -> str:
     Returns:
         The JSONL string.
     """
-    if isinstance(records, pd.DataFrame):
-        return records.to_json(orient="records", lines=True, force_ascii=False)
-    elif isinstance(records, (list, dict)):
-        return pd.DataFrame(records).to_json(orient="records", lines=True, force_ascii=False)
-    else:
-        raise ValueError(f"Unsupported type: {type(records)}")
+    match records:
+        case pd.DataFrame() as dataframe:
+            return dataframe.to_json(orient="records", lines=True, force_ascii=False)
+        case list() | dict():
+            return pd.DataFrame(records).to_json(orient="records", lines=True, force_ascii=False)
+        case _:
+            raise ValueError(f"Unsupported type: {type(records)}")

--- a/src/nemo_safe_synthesizer/data_processing/record_utils.py
+++ b/src/nemo_safe_synthesizer/data_processing/record_utils.py
@@ -321,8 +321,10 @@ def _parse_and_validate_json(matched_json: str, schema: JsonSchema) -> tuple[Rec
     """
     try:
         matched_dict = json.loads(matched_json)
-        if not is_json_object(matched_dict):
+        if not isinstance(matched_dict, dict):
             return None, ("Expected a JSON object", "Invalid JSON type")
+        if not is_json_object(matched_dict):
+            return None, ("Object contains a value that is not valid JSON", "Invalid JSON value")
 
         jsonschema.validate(matched_dict, schema)
 

--- a/src/nemo_safe_synthesizer/data_processing/record_utils.py
+++ b/src/nemo_safe_synthesizer/data_processing/record_utils.py
@@ -322,7 +322,7 @@ def _parse_and_validate_json(matched_json: str, schema: JsonSchema) -> tuple[Rec
     try:
         matched_dict = json.loads(matched_json)
         if not is_json_object(matched_dict):
-            return None, ("Expected a JSON object", "Invalid JSON")
+            return None, ("Expected a JSON object", "Invalid JSON type")
 
         jsonschema.validate(matched_dict, schema)
 
@@ -564,10 +564,8 @@ def records_to_jsonl(records: pd.DataFrame | list[RawRecordMapping] | RawRecordM
     Returns:
         The JSONL string.
     """
-    match records:
-        case pd.DataFrame() as dataframe:
-            return dataframe.to_json(orient="records", lines=True, force_ascii=False)
-        case list() | dict():
-            return pd.DataFrame(records).to_json(orient="records", lines=True, force_ascii=False)
-        case _:
-            raise ValueError(f"Unsupported type: {type(records)}")
+    if isinstance(records, pd.DataFrame):
+        return records.to_json(orient="records", lines=True, force_ascii=False)
+    if isinstance(records, list | Mapping):
+        return pd.DataFrame(records).to_json(orient="records", lines=True, force_ascii=False)
+    raise ValueError(f"Unsupported type: {type(records)}")

--- a/src/nemo_safe_synthesizer/data_processing/records/base.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/base.py
@@ -91,17 +91,17 @@ def tokenize_header(field: str) -> list[str]:
 
 def get_type_as_string(value) -> str:
     """Return the JSON schema type name for a Python scalar value."""
-    if isinstance(value, str):
-        return STRING
-    elif isinstance(value, bool):
-        if str(value) in ("True", "False"):
+    match value:
+        case str():
+            return STRING
+        case bool():
             return BOOL
-    elif isinstance(value, Number):
-        return NUMBER
-    elif value is None:
-        return NULL
-
-    return NULL
+        case Number():
+            return NUMBER
+        case None:
+            return NULL
+        case _:
+            return NULL
 
 
 class KVPair:

--- a/src/nemo_safe_synthesizer/data_processing/records/json_record.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/json_record.py
@@ -12,17 +12,33 @@ dict using the ``NESTING_DELIM`` / ``ARRAY_POS`` markers.
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from itertools import chain, starmap
-from typing import Optional
+from typing import Any, Optional
+
+from typing_extensions import override
 
 from . import base
+from .json_types import JsonArray, JsonContainer, JsonObject, JsonScalar, JsonValue
 from .value_path import (
     value_path,
     value_path_to_field_name,
 )
 
+__all__ = [
+    "JSONRecord",
+    "JsonArray",
+    "JsonContainer",
+    "JsonObject",
+    "JsonScalar",
+    "JsonValue",
+    "convert_flat_dict_to_kv_pairs",
+    "flatten",
+    "remove_array_markers",
+]
 
-def flatten(raw, array_marker=base.ARRAY_POS):
+
+def flatten(raw: JsonContainer, array_marker: str = base.ARRAY_POS) -> dict[object, object]:
     """Recursively flatten a nested dict/list into a single-level dict.
 
     Keys are joined with ``NESTING_DELIM``; array indices are encoded as
@@ -36,36 +52,39 @@ def flatten(raw, array_marker=base.ARRAY_POS):
     Returns:
         A flat dict mapping composite keys to scalar values.
     """
-    if isinstance(raw, list):
-        # if the whole JSON document is an array, we wrap it in dict
-        raw = {None: raw}
+    match raw:
+        case list() as values:
+            # if the whole JSON document is an array, we wrap it in dict
+            flattened: dict[object, object] = {None: values}
+        case dict() as values:
+            flattened = {key: value for key, value in values.items()}
+        case _:
+            raise TypeError("flatten expects a JSON object or array")
 
-    def unpack_level(parent_key, parent_val):
-        if isinstance(parent_val, dict):
-            for key, value in parent_val.items():
-                tmp = str(parent_key) + base.NESTING_DELIM + key
-                yield tmp, value
-        elif isinstance(parent_val, list):
-            i = 0
-            for value in parent_val:
-                if parent_key is None:
-                    tmp = array_marker + str(i)
-                else:
-                    tmp = str(parent_key) + base.NESTING_DELIM + array_marker + str(i)
+    def unpack_level(parent_key: object, parent_val: object) -> Iterator[tuple[object, object]]:
+        match parent_val:
+            case dict() as values:
+                for key, value in values.items():
+                    yield str(parent_key) + base.NESTING_DELIM + str(key), value
+            case list() as values:
+                for i, value in enumerate(values):
+                    if parent_key is None:
+                        tmp = array_marker + str(i)
+                    else:
+                        tmp = str(parent_key) + base.NESTING_DELIM + array_marker + str(i)
 
-                yield tmp, value
-                i += 1
-        else:
-            yield parent_key, parent_val
+                    yield tmp, value
+            case scalar:
+                yield parent_key, scalar
 
     while True:
-        raw = dict(chain.from_iterable(starmap(unpack_level, raw.items())))
-        if not any(isinstance(value, dict) for value in raw.values()) and not any(
-            isinstance(value, list) for value in raw.values()
+        flattened = dict(chain.from_iterable(starmap(unpack_level, flattened.items())))
+        if not any(isinstance(value, dict) for value in flattened.values()) and not any(
+            isinstance(value, list) for value in flattened.values()
         ):
             break
 
-    return raw
+    return flattened
 
 
 def remove_array_markers(data: str) -> tuple[str, int, base.ValuePath]:
@@ -76,7 +95,7 @@ def remove_array_markers(data: str) -> tuple[str, int, base.ValuePath]:
     """
     array_count = 0
     parts = data.split(base.NESTING_DELIM)
-    path_items = []
+    path_items: list[str | int] = []
     for part in parts:
         if part.startswith(base.ARRAY_POS):
             array_count += 1
@@ -88,9 +107,9 @@ def remove_array_markers(data: str) -> tuple[str, int, base.ValuePath]:
     return value_path_to_field_name(path), array_count, path
 
 
-def convert_flat_dict_to_kv_pairs(data: dict) -> list[base.KVPair]:
+def convert_flat_dict_to_kv_pairs(data: dict[Any, Any]) -> list[base.KVPair]:
     """Convert a flattened dict (from ``flatten``) into a list of ``KVPair`` objects."""
-    out = []
+    out: list[base.KVPair] = []
     for k, v in data.items():
         k = str(k)
         new_key, array_count, value_path = remove_array_markers(k)
@@ -106,7 +125,7 @@ class JSONRecord(base.BaseRecord):
     Provides lookup by JSONPath or ``ValuePath``.
     """
 
-    def __init__(self, original):
+    def __init__(self, original: Any):
         super().__init__(original)
         self._unpack_json()
 
@@ -118,7 +137,8 @@ class JSONRecord(base.BaseRecord):
             self.fields.add(pair.field)
             self.kv_pairs.append(pair)
 
-    def unpack(self):
+    @override
+    def unpack(self) -> None:
         self.kv_pairs = []
         self.fields = set()
         self._unpack_json()

--- a/src/nemo_safe_synthesizer/data_processing/records/json_types.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/json_types.py
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared recursive JSON type aliases and runtime shape guards."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import TypeAlias
+
+from typing_extensions import TypeIs
+
+JsonScalar: TypeAlias = str | int | float | bool | None
+JsonValue: TypeAlias = JsonScalar | dict[str, "JsonValue"] | list["JsonValue"]
+JsonObject: TypeAlias = dict[str, JsonValue]
+JsonArray: TypeAlias = list[JsonValue]
+JsonContainer: TypeAlias = JsonObject | JsonArray
+JsonSchema: TypeAlias = Mapping[str, JsonValue]
+
+
+def is_json_value(value: object) -> TypeIs[JsonValue]:
+    """Return whether ``value`` is representable as JSON."""
+    match value:
+        case str() | int() | float() | bool() | None:
+            return True
+        case list() as values:
+            return all(is_json_value(item) for item in values)
+        case dict() as values:
+            return all(isinstance(key, str) and is_json_value(item) for key, item in values.items())
+        case _:
+            return False
+
+
+def is_json_object(value: object) -> TypeIs[JsonObject]:
+    """Return whether ``value`` is a JSON object with string keys."""
+    return isinstance(value, dict) and all(isinstance(key, str) and is_json_value(item) for key, item in value.items())

--- a/src/nemo_safe_synthesizer/data_processing/records/json_types.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/json_types.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from typing import TypeAlias
 
@@ -21,7 +22,9 @@ JsonSchema: TypeAlias = Mapping[str, JsonValue]
 def is_json_value(value: object) -> TypeIs[JsonValue]:
     """Return whether ``value`` is representable as JSON."""
     match value:
-        case str() | int() | float() | bool() | None:
+        case float() as number:
+            return math.isfinite(number)
+        case str() | int() | bool() | None:
             return True
         case list() as values:
             return all(is_json_value(item) for item in values)

--- a/src/nemo_safe_synthesizer/data_processing/records/json_types.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/json_types.py
@@ -11,6 +11,17 @@ from typing import TypeAlias
 
 from typing_extensions import TypeIs
 
+__all__ = [
+    "JsonArray",
+    "JsonContainer",
+    "JsonObject",
+    "JsonScalar",
+    "JsonSchema",
+    "JsonValue",
+    "is_json_object",
+    "is_json_value",
+]
+
 JsonScalar: TypeAlias = str | int | float | bool | None
 JsonValue: TypeAlias = JsonScalar | dict[str, "JsonValue"] | list["JsonValue"]
 JsonObject: TypeAlias = dict[str, JsonValue]
@@ -21,17 +32,15 @@ JsonSchema: TypeAlias = Mapping[str, JsonValue]
 
 def is_json_value(value: object) -> TypeIs[JsonValue]:
     """Return whether ``value`` is representable as JSON."""
-    match value:
-        case float() as number:
-            return math.isfinite(number)
-        case str() | int() | bool() | None:
-            return True
-        case list() as values:
-            return all(is_json_value(item) for item in values)
-        case dict() as values:
-            return all(isinstance(key, str) and is_json_value(item) for key, item in values.items())
-        case _:
-            return False
+    if isinstance(value, float):
+        return math.isfinite(value)
+    if isinstance(value, (str, int)) or value is None:
+        return True
+    if isinstance(value, list):
+        return all(is_json_value(item) for item in value)
+    if isinstance(value, dict):
+        return all(isinstance(key, str) and is_json_value(item) for key, item in value.items())
+    return False
 
 
 def is_json_object(value: object) -> TypeIs[JsonObject]:

--- a/src/nemo_safe_synthesizer/data_processing/records/json_types.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/json_types.py
@@ -32,15 +32,17 @@ JsonSchema: TypeAlias = Mapping[str, JsonValue]
 
 def is_json_value(value: object) -> TypeIs[JsonValue]:
     """Return whether ``value`` is representable as JSON."""
-    if isinstance(value, float):
-        return math.isfinite(value)
-    if isinstance(value, (str, int)) or value is None:
-        return True
-    if isinstance(value, list):
-        return all(is_json_value(item) for item in value)
-    if isinstance(value, dict):
-        return all(isinstance(key, str) and is_json_value(item) for key, item in value.items())
-    return False
+    match value:
+        case float() as number:
+            return math.isfinite(number)
+        case str() | int() | None:
+            return True
+        case list() as values:
+            return all(is_json_value(item) for item in values)
+        case dict() as values:
+            return all(isinstance(key, str) and is_json_value(item) for key, item in values.items())
+        case _:
+            return False
 
 
 def is_json_object(value: object) -> TypeIs[JsonObject]:

--- a/src/nemo_safe_synthesizer/data_processing/records/value_path.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/value_path.py
@@ -98,7 +98,7 @@ def unflatten(data: dict[ValuePath, Any]) -> Optional[dict[Any, Any] | list[Any]
 
 def _ensure_array_size(result: list[Any], item: int) -> None:
     if len(result) <= item:
-        for i in range(len(result), item + 1):
+        for _ in range(len(result), item + 1):
             result.append(None)
 
 

--- a/src/nemo_safe_synthesizer/data_processing/records/value_path.py
+++ b/src/nemo_safe_synthesizer/data_processing/records/value_path.py
@@ -73,7 +73,7 @@ def value_path_to_json_path(path: ValuePath) -> str:
 class InvalidPath(Exception): ...
 
 
-def unflatten(data: dict[ValuePath, Any]) -> Optional[dict | list]:
+def unflatten(data: dict[ValuePath, Any]) -> Optional[dict[Any, Any] | list[Any]]:
     """Reconstruct a nested dict/list from a flat ``{ValuePath: value}`` mapping.
 
     Args:
@@ -96,18 +96,20 @@ def unflatten(data: dict[ValuePath, Any]) -> Optional[dict | list]:
     return result
 
 
-def _ensure_array_size(result: list, item: int):
+def _ensure_array_size(result: list[Any], item: int) -> None:
     if len(result) <= item:
         for i in range(len(result), item + 1):
             result.append(None)
 
 
-def _ensure_dict_key(result: dict, item: str):
+def _ensure_dict_key(result: dict[Any, Any], item: str) -> None:
     if item not in result:
         result[item] = None
 
 
-def _unflatten_path(result: Optional[dict | list], path: ValuePath, value: Any) -> dict | list:
+def _unflatten_path(
+    result: Optional[dict[Any, Any] | list[Any]], path: ValuePath, value: Any
+) -> dict[Any, Any] | list[Any]:
     # Note: result will be a list when working with an array at this level of
     # the path, and thus the first element of path is an integer. Otherwise
     # working with an object at this level of the path, result will be a dict
@@ -137,7 +139,7 @@ def _unflatten_path(result: Optional[dict | list], path: ValuePath, value: Any) 
         return result
 
 
-def _unflatten_recursive(result: Any, prev_item: ValuePathItem, items: list[ValuePathItem], value: Any):
+def _unflatten_recursive(result: Any, prev_item: ValuePathItem, items: list[ValuePathItem], value: Any) -> None:
     # Note: result will be a list when working with an array at this level of
     # the path, and thus the first element of path is an integer. Otherwise
     # working with an object at this level of the path, result will be a dict

--- a/src/nemo_safe_synthesizer/generation/results.py
+++ b/src/nemo_safe_synthesizer/generation/results.py
@@ -14,6 +14,7 @@ import pandas as pd
 from ..data_processing.actions.utils import (
     MetadataColumns,
 )
+from ..data_processing.record_utils import normalize_record_keys
 from ..data_processing.stats import RunningStatistics
 from ..defaults import (
     EPS,
@@ -294,7 +295,7 @@ class GenerationBatches:
                 rid = record.parsed[record_id_key]
                 if new_record := id_to_valid_records.get(rid):
                     del new_record[record_id_key]
-                    record.parsed = new_record
+                    record.parsed = normalize_record_keys(new_record)
                 elif new_record := id_to_rejected_records.get(rid):
                     del new_record[record_id_key]
                     record.invalidate(rejected_record_to_error(new_record))

--- a/tests/data_processing/test_records.py
+++ b/tests/data_processing/test_records.py
@@ -12,6 +12,7 @@ import pytest
 
 from nemo_safe_synthesizer.data_processing.record_utils import (
     _extract_timestamp_seconds,
+    _parse_and_validate_json,
     _validate_time_interval,
     check_record_for_large_numbers,
     extract_and_validate_records,
@@ -175,6 +176,13 @@ def test_extract_and_validate_records_with_invalid_records(
     assert len(result.errors[0]) == 2
     assert result.errors[0][0] == "Invalid JSON: Expecting ',' delimiter"
     assert result.errors[0][1] == "Invalid JSON"
+
+
+def test_parse_and_validate_json_classifies_non_object_json_type():
+    parsed, error = _parse_and_validate_json("[1, 2, 3]", {"type": "object"})
+
+    assert parsed is None
+    assert error == ("Expected a JSON object", "Invalid JSON type")
 
 
 def test_extract_and_validate_records_with_invalid_schema(

--- a/tests/data_processing/test_records.py
+++ b/tests/data_processing/test_records.py
@@ -18,11 +18,31 @@ from nemo_safe_synthesizer.data_processing.record_utils import (
     is_safe_for_float_conversion,
     normalize_dataframe,
 )
+from nemo_safe_synthesizer.data_processing.records.json_record import flatten
+from nemo_safe_synthesizer.data_processing.records.json_types import is_json_object, is_json_value
 
 
 def _mock_encode(text: str) -> list[int]:
     """Deterministic mock tokenizer: one token per character."""
     return list(range(len(text)))
+
+
+def test_flatten_handles_top_level_array_and_nested_records():
+    assert flatten([{"name": "Alice"}, {"name": "Bob", "scores": [1, 2]}]) == {
+        "_nssarray_0*#N#*name": "Alice",
+        "_nssarray_1*#N#*name": "Bob",
+        "_nssarray_1*#N#*scores*#N#*_nssarray_0": 1,
+        "_nssarray_1*#N#*scores*#N#*_nssarray_1": 2,
+    }
+
+
+def test_json_type_guards_accept_recursive_json_objects():
+    value = {"name": "Alice", "scores": [1, 2, None], "profile": {"active": True}}
+
+    assert is_json_value(value) is True
+    assert is_json_object(value) is True
+    assert is_json_object({1: "not-json-object"}) is False
+    assert is_json_value({"bad": object()}) is False
 
 
 def test_is_safe_for_float_conversion():

--- a/tests/data_processing/test_records.py
+++ b/tests/data_processing/test_records.py
@@ -8,6 +8,7 @@ from io import BytesIO
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from nemo_safe_synthesizer.data_processing.record_utils import (
     _extract_timestamp_seconds,
@@ -43,6 +44,13 @@ def test_json_type_guards_accept_recursive_json_objects():
     assert is_json_object(value) is True
     assert is_json_object({1: "not-json-object"}) is False
     assert is_json_value({"bad": object()}) is False
+
+
+@pytest.mark.parametrize("value", ["NaN", "Infinity", "-Infinity"])
+def test_json_type_guards_reject_non_finite_numbers(value: str):
+    assert is_json_value(float(value)) is False
+    response = extract_and_validate_records('{"value": ' + value + "}", {"type": "object"})
+    assert response.valid_records == []
 
 
 def test_is_safe_for_float_conversion():

--- a/tests/data_processing/test_records.py
+++ b/tests/data_processing/test_records.py
@@ -52,6 +52,7 @@ def test_json_type_guards_reject_non_finite_numbers(value: str):
     assert is_json_value(float(value)) is False
     response = extract_and_validate_records('{"value": ' + value + "}", {"type": "object"})
     assert response.valid_records == []
+    assert response.errors == [("Object contains a value that is not valid JSON", "Invalid JSON value")]
 
 
 def test_is_safe_for_float_conversion():

--- a/tests/generation/test_generation.py
+++ b/tests/generation/test_generation.py
@@ -13,6 +13,7 @@ from nemo_safe_synthesizer.data_processing.actions.data_actions import (
     DateConstraint,
     data_actions_fn,
 )
+from nemo_safe_synthesizer.data_processing.record_utils import normalize_record_keys
 from nemo_safe_synthesizer.errors import GenerationError
 from nemo_safe_synthesizer.generation.batch import Batch
 from nemo_safe_synthesizer.generation.processors import ParsedRecord, ParsedResponse
@@ -260,11 +261,15 @@ def test_apply_data_actions(fixture_mock_processor, caplog):
     batch = Batch(fixture_mock_processor)
     batch._responses = [
         ParsedResponse(
-            records=[ParsedRecord(text=str(r), parsed=r) for r in data.iloc[:3].to_dict("records")],
+            records=[
+                ParsedRecord(text=str(r), parsed=normalize_record_keys(r)) for r in data.iloc[:3].to_dict("records")
+            ],
             prompt_number=1,
         ),
         ParsedResponse(
-            records=[ParsedRecord(text=str(r), parsed=r) for r in data.iloc[3:].to_dict("records")],
+            records=[
+                ParsedRecord(text=str(r), parsed=normalize_record_keys(r)) for r in data.iloc[3:].to_dict("records")
+            ],
             prompt_number=2,
         ),
     ]


### PR DESCRIPTION
## Summary
- Adds shared recursive JSON aliases and runtime guards for record handling.
- Narrows record key and generation result boundaries.

## Test plan
- [x] `mise run test -- tests/data_processing/test_records.py tests/generation/test_generation.py`
- [x] `mise run typecheck`

Related issue: #614

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared JSON type aliases and runtime type guards to improve schema validation safety.
  * Record keys are now consistently normalized for more predictable generated outputs.
* **Bug Fixes**
  * Non-object JSON inputs are now rejected earlier with clearer “invalid type” errors.
  * JSON-schema validation failures now report more informative details.
  * Elapsed-seconds timestamps use more consistent numeric coercion, and record key coercion is enforced.
* **Refactor**
  * Streamlined record flattening and type classification logic with stricter handling.
* **Tests**
  * Added coverage for top-level array flattening, JSON guards (including non-finite numbers), and non-object schema classification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->