### PR TITLE
chore(typecheck): include top-level tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -373,6 +373,4 @@ exclude = [
     ".uv_cache", # Cache Dir in CI
     "./docs/**/*.ipynb",
     "./src/nemo_safe_synthesizer/pii_replacer/",
-    "./tools/*.py",
-    "!./tools/gen_cuda_deps.py",
 ]

--- a/tests/tools/test_diff_lockfile.py
+++ b/tests/tools/test_diff_lockfile.py
@@ -9,12 +9,37 @@ from pathlib import Path
 from typing import Protocol, cast
 
 import pytest
+from packaging.version import Version
+
+
+class Package(Protocol):
+    """Typed package snapshot exposed by the dynamically loaded tool."""
+
+    name: str
+    version: Version
+    source: str
+
+
+class PackageChange(Protocol):
+    """Typed package delta exposed by the dynamically loaded tool."""
+
+    change: str
+    old: Package | None
+    new: Package | None
+
+
+class LockfileDiff(Protocol):
+    """Typed lockfile diff exposed by the dynamically loaded tool."""
+
+    root: list[PackageChange]
 
 
 class DiffLockfileTool(Protocol):
     """Typed interface exposed by the dynamically loaded lockfile tool."""
 
-    def parse_packages(self, content: str) -> dict[str, object]: ...
+    def parse_packages(self, content: str) -> dict[str, Package]: ...
+
+    def diff_packages(self, base: dict[str, Package], head: dict[str, Package], ref: str) -> LockfileDiff: ...
 
 
 def _load_tool(tool_path: Path) -> DiffLockfileTool:
@@ -54,3 +79,44 @@ source = { registry = "https://pypi.org/simple" }
         "cuda-python@https://pypi.org/simple@12.9.4",
         "cuda-python@https://pypi.org/simple@13.1.1",
     }
+
+
+def test_diff_packages_classifies_changed_duplicate_variant(diff_lockfile_tool: DiffLockfileTool) -> None:
+    base = diff_lockfile_tool.parse_packages(
+        """
+version = 1
+
+[[package]]
+name = "cuda-python"
+version = "12.9.4"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "cuda-python"
+version = "13.1.1"
+source = { registry = "https://pypi.org/simple" }
+""",
+    )
+    head = diff_lockfile_tool.parse_packages(
+        """
+version = 1
+
+[[package]]
+name = "cuda-python"
+version = "12.9.4"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "cuda-python"
+version = "13.2.0"
+source = { registry = "https://pypi.org/simple" }
+""",
+    )
+
+    diff = diff_lockfile_tool.diff_packages(base, head, ref="base..head")
+
+    assert len(diff.root) == 1
+    change = diff.root[0]
+    assert change.change == "upgraded"
+    assert change.old is not None and change.old.version == Version("13.1.1")
+    assert change.new is not None and change.new.version == Version("13.2.0")

--- a/tests/tools/test_diff_lockfile.py
+++ b/tests/tools/test_diff_lockfile.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Protocol, cast
+
+import pytest
+
+
+class DiffLockfileTool(Protocol):
+    """Typed interface exposed by the dynamically loaded lockfile tool."""
+
+    def parse_packages(self, content: str) -> dict[str, object]: ...
+
+
+def _load_tool(tool_path: Path) -> DiffLockfileTool:
+    spec = importlib.util.spec_from_file_location("diff_lockfile", tool_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {tool_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return cast(DiffLockfileTool, module)
+
+
+@pytest.fixture(scope="module")
+def diff_lockfile_tool(pytestconfig: pytest.Config) -> DiffLockfileTool:
+    """Load the lockfile helper from pytest's discovered repository root."""
+    return _load_tool(Path(pytestconfig.rootpath) / "tools" / "diff-lockfile.py")
+
+
+def test_parse_packages_preserves_same_source_versions(diff_lockfile_tool: DiffLockfileTool) -> None:
+    content = """
+version = 1
+
+[[package]]
+name = "cuda-python"
+version = "12.9.4"
+source = { registry = "https://pypi.org/simple" }
+
+[[package]]
+name = "cuda-python"
+version = "13.1.1"
+source = { registry = "https://pypi.org/simple" }
+"""
+
+    packages = diff_lockfile_tool.parse_packages(content)
+
+    assert set(packages) == {
+        "cuda-python@https://pypi.org/simple@12.9.4",
+        "cuda-python@https://pypi.org/simple@13.1.1",
+    }

--- a/tools/diff-lockfile.py
+++ b/tools/diff-lockfile.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import subprocess
 import tomllib
 from enum import Enum
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
 import git
 import typer
@@ -116,12 +116,17 @@ def get_lockfile_content(repo: git.Repo, ref: str, path: str) -> str:
     return blob.data_stream.read().decode()
 
 
-def _extract_source(raw: dict) -> str:
+def _extract_source(raw: dict[str, Any]) -> str:
     """Return a human-readable source string from a ``[[package]]`` entry."""
-    src = raw.get("source", {})
-    if isinstance(src, dict):
-        return src.get("registry", src.get("git", src.get("path", "")))
-    return str(src) if src else ""
+    match raw.get("source", {}):
+        case {"registry": value} | {"git": value} | {"path": value}:
+            return str(value) if value is not None else ""
+        case dict():
+            return ""
+        case src if src:
+            return str(src)
+        case _:
+            return ""
 
 
 def parse_packages(content: str) -> dict[str, Package]:

--- a/tools/diff-lockfile.py
+++ b/tools/diff-lockfile.py
@@ -136,9 +136,8 @@ def parse_packages(content: str) -> dict[str, Package]:
         content: Raw UTF-8 text of the lockfile.
 
     Returns:
-        A dict keyed by package name (or ``name@source`` when a name
-        appears more than once with different sources).  Values are
-        :class:`Package` instances.
+        A dict keyed by package name (or ``name@source@version`` when a name
+        appears more than once). Values are :class:`Package` instances.
     """
     data = tomllib.loads(content)
 
@@ -156,8 +155,10 @@ def parse_packages(content: str) -> dict[str, Package]:
             continue
         source = _extract_source(pkg)
 
-        # Disambiguate packages that appear under multiple sources
-        key = f"{name}@{source}" if name_counts.get(name, 1) > 1 else name
+        # uv.lock may contain several versions of a package from one source.
+        # Keep every variant instead of letting later entries overwrite earlier
+        # entries in this mapping.
+        key = f"{name}@{source}@{version}" if name_counts.get(name, 1) > 1 else name
         packages[key] = Package(name=name, version=Version(version), source=source)
 
     return packages

--- a/tools/diff-lockfile.py
+++ b/tools/diff-lockfile.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import subprocess
 import tomllib
+from collections.abc import Iterable
 from enum import Enum
 from typing import Annotated, Any, Optional
 
@@ -186,27 +187,60 @@ def diff_packages(
         differing package.
     """
     changes: list[PackageChange] = []
-    all_keys = sorted(set(base) | set(head))
+    base_by_name = _group_packages_by_name(base.values())
+    head_by_name = _group_packages_by_name(head.values())
 
-    for key in all_keys:
-        base_pkg = base.get(key)
-        head_pkg = head.get(key)
+    for name in sorted(set(base_by_name) | set(head_by_name)):
+        base_variants = list(base_by_name.get(name, []))
+        head_variants = list(head_by_name.get(name, []))
 
-        if base_pkg is None and head_pkg is not None:
-            changes.append(
-                PackageChange(name=head_pkg.name, change=ChangeType.added, new=head_pkg, ref=ref),
-            )
-        elif head_pkg is None and base_pkg is not None:
-            changes.append(
-                PackageChange(name=base_pkg.name, change=ChangeType.removed, old=base_pkg, ref=ref),
-            )
-        elif base_pkg is not None and head_pkg is not None and base_pkg.version != head_pkg.version:
-            direction = ChangeType.upgraded if head_pkg.version > base_pkg.version else ChangeType.downgraded
-            changes.append(
-                PackageChange(name=base_pkg.name, change=direction, old=base_pkg, new=head_pkg, ref=ref),
-            )
+        # A package moved between indexes without a version change is a no-op.
+        # Remove those exact matches before comparing variants from each source.
+        for base_pkg in tuple(base_variants):
+            for index, head_pkg in enumerate(head_variants):
+                if base_pkg.version == head_pkg.version:
+                    base_variants.remove(base_pkg)
+                    head_variants.pop(index)
+                    break
+
+        base_by_source = _group_packages_by_source(base_variants)
+        head_by_source = _group_packages_by_source(head_variants)
+        for source in sorted(set(base_by_source) | set(head_by_source)):
+            base_source_variants = sorted(base_by_source.get(source, []), key=lambda package: package.version)
+            head_source_variants = sorted(head_by_source.get(source, []), key=lambda package: package.version)
+
+            for base_pkg, head_pkg in zip(base_source_variants, head_source_variants, strict=False):
+                direction = ChangeType.upgraded if head_pkg.version > base_pkg.version else ChangeType.downgraded
+                changes.append(
+                    PackageChange(name=name, change=direction, old=base_pkg, new=head_pkg, ref=ref),
+                )
+
+            for base_pkg in base_source_variants[len(head_source_variants) :]:
+                changes.append(
+                    PackageChange(name=name, change=ChangeType.removed, old=base_pkg, ref=ref),
+                )
+            for head_pkg in head_source_variants[len(base_source_variants) :]:
+                changes.append(
+                    PackageChange(name=name, change=ChangeType.added, new=head_pkg, ref=ref),
+                )
 
     return LockfileDiff(changes)
+
+
+def _group_packages_by_name(packages: Iterable[Package]) -> dict[str, list[Package]]:
+    """Group package variants by normalized package name."""
+    grouped: dict[str, list[Package]] = {}
+    for package in packages:
+        grouped.setdefault(package.name, []).append(package)
+    return grouped
+
+
+def _group_packages_by_source(packages: Iterable[Package]) -> dict[str, list[Package]]:
+    """Group package variants by their source URL or path."""
+    grouped: dict[str, list[Package]] = {}
+    for package in packages:
+        grouped.setdefault(package.source, []).append(package)
+    return grouped
 
 
 # ---------------------------------------------------------------------------

--- a/tools/hf_network_guard_proxy.py
+++ b/tools/hf_network_guard_proxy.py
@@ -8,6 +8,7 @@
 #     "pydantic",
 #     "proxy.py>=2.4.10",
 #     "structlog",
+#     "typing-extensions>=4.15.0",
 # ]
 # ///
 # pyright: reportMissingImports=false
@@ -74,7 +75,7 @@ import subprocess
 import sys
 import threading
 import time
-from contextlib import nullcontext
+from contextlib import AbstractContextManager, nullcontext
 from dataclasses import dataclass, field
 from enum import IntEnum
 from multiprocessing import Manager
@@ -90,6 +91,7 @@ from proxy.http.exception import HttpRequestRejected
 from proxy.http.parser import HttpParser
 from proxy.http.proxy import HttpProxyBasePlugin
 from pydantic import BaseModel, ConfigDict, Field
+from typing_extensions import override
 
 DEFAULT_HOST = "127.0.0.1"
 DEFAULT_PORT = 8765
@@ -170,7 +172,7 @@ class ProxyState:
 class RunningServer:
     """Background proxy.py server instance."""
 
-    server: Proxy
+    server: AbstractContextManager[object]
     host: str
     port: int
     state: ProxyState
@@ -201,6 +203,7 @@ class GuardProxyPlugin(HttpProxyBasePlugin):
         cls.state = state
         cls.allow_passthrough_hf = allow_passthrough_hf
 
+    @override
     def before_upstream_connection(self, request: HttpParser) -> HttpParser | None:
         """Record the destination and decide whether proxy.py may connect upstream."""
         proxy_request = _proxy_request_from_proxy_py(request)

--- a/tools/patch_dependabot.py
+++ b/tools/patch_dependabot.py
@@ -7,6 +7,7 @@
 #     "requests>=2.33.0",
 #     "tomlkit>=0.13.0",
 #     "packaging>=24",
+#     "typing-extensions>=4.15.0",
 # ]
 # ///
 # What is this?
@@ -30,18 +31,23 @@ import json
 import os
 import subprocess
 from pathlib import Path
+from typing import Any, TypeAlias
 
 import requests
 import tomlkit
 import tomlkit.items
+from packaging.markers import Marker
 from packaging.requirements import Requirement
 from packaging.specifiers import SpecifierSet
 from packaging.utils import canonicalize_name
 from packaging.version import Version
 from tomlkit.container import OutOfOrderTableProxy
+from typing_extensions import TypeIs
 
 TOO_HARD_TO_UPGRADE = frozenset({canonicalize_name(n) for n in ("torch", "transformers", "vllm")})
 REPOSITORY_NAME = os.environ.get("REPOSITORY_NAME") or "NVIDIA-NeMo/Safe-Synthesizer"
+
+TomlTable: TypeAlias = tomlkit.TOMLDocument | tomlkit.items.Table | OutOfOrderTableProxy
 
 
 # ---------------------------------------------------------------------------
@@ -49,7 +55,7 @@ REPOSITORY_NAME = os.environ.get("REPOSITORY_NAME") or "NVIDIA-NeMo/Safe-Synthes
 # ---------------------------------------------------------------------------
 
 
-def _format_requirement(name: str, spec: SpecifierSet, marker) -> str:
+def _format_requirement(name: str, spec: SpecifierSet, marker: Marker | None) -> str:
     s = str(spec).strip()
     out = f"{name}{s}" if s else str(name)
     if marker is not None:
@@ -121,50 +127,72 @@ def _bump_direct_deps_in_doc(
     """
     changed: list[str] = []
 
-    proj = doc.get("project")
-    if _is_table(proj):
-        main_deps = proj.get("dependencies")  # type: ignore[union-attr]
-        if isinstance(main_deps, tomlkit.items.Array):
-            if _bump_array_item(main_deps, cname, floor, display_name):
-                changed.append("project.dependencies")
+    match _get_table(doc, "project"):
+        case None:
+            pass
+        case proj:
+            match _get_array(proj, "dependencies"):
+                case tomlkit.items.Array() as main_deps:
+                    if _bump_array_item(main_deps, cname, floor, display_name):
+                        changed.append("project.dependencies")
 
-        opt = proj.get("optional-dependencies")  # type: ignore[union-attr]
-        if _is_table(opt):
-            for extra_name, extra_arr in opt.items():  # type: ignore[union-attr]
-                if isinstance(extra_arr, tomlkit.items.Array):
-                    if _bump_array_item(extra_arr, cname, floor, display_name):
-                        changed.append(f"project.optional-dependencies.{extra_name}")
+            match _get_table(proj, "optional-dependencies"):
+                case None:
+                    pass
+                case opt:
+                    for extra_name, extra_arr in opt.items():
+                        match extra_arr:
+                            case tomlkit.items.Array() as extra_dependencies:
+                                if _bump_array_item(extra_dependencies, cname, floor, display_name):
+                                    changed.append(f"project.optional-dependencies.{extra_name}")
 
-    dep_groups = doc.get("dependency-groups")
-    if _is_table(dep_groups):
-        for gname, garr in dep_groups.items():  # type: ignore[union-attr]
-            if isinstance(garr, tomlkit.items.Array):
-                if _bump_array_item(garr, cname, floor, display_name):
-                    changed.append(f"dependency-groups.{gname}")
+    match _get_table(doc, "dependency-groups"):
+        case None:
+            pass
+        case dep_groups:
+            for gname, garr in dep_groups.items():
+                match garr:
+                    case tomlkit.items.Array() as group_dependencies:
+                        if _bump_array_item(group_dependencies, cname, floor, display_name):
+                            changed.append(f"dependency-groups.{gname}")
 
     return changed
 
 
 def _collect_direct_dep_names(doc: tomlkit.TOMLDocument) -> frozenset[str]:
     names: set[str] = set()
-    proj = doc.get("project")
-    if _is_table(proj):
-        for line in proj.get("dependencies") or []:  # type: ignore[union-attr]
-            n = _safe_req_name(str(line)) if isinstance(line, str) else None
-            if n:
-                names.add(n)
-        for lines in (proj.get("optional-dependencies") or {}).values():  # type: ignore[union-attr]
-            for line in lines or []:
+    match _get_table(doc, "project"):
+        case None:
+            pass
+        case proj:
+            for line in _get_array(proj, "dependencies") or []:
                 n = _safe_req_name(str(line)) if isinstance(line, str) else None
                 if n:
                     names.add(n)
-    dep_groups = doc.get("dependency-groups")
-    if _is_table(dep_groups):
-        for items in dep_groups.values():  # type: ignore[union-attr]
-            for item in items or []:
-                n = _safe_req_name(str(item)) if isinstance(item, str) else None
-                if n:
-                    names.add(n)
+
+            match _get_table(proj, "optional-dependencies"):
+                case None:
+                    pass
+                case optional_dependencies:
+                    for lines in optional_dependencies.values():
+                        match lines:
+                            case tomlkit.items.Array() as dependency_lines:
+                                for line in dependency_lines:
+                                    n = _safe_req_name(str(line)) if isinstance(line, str) else None
+                                    if n:
+                                        names.add(n)
+
+    match _get_table(doc, "dependency-groups"):
+        case None:
+            pass
+        case dep_groups:
+            for items in dep_groups.values():
+                match items:
+                    case tomlkit.items.Array() as dependency_items:
+                        for item in dependency_items:
+                            n = _safe_req_name(str(item)) if isinstance(item, str) else None
+                            if n:
+                                names.add(n)
     return frozenset(names)
 
 
@@ -205,16 +233,19 @@ def _write_constraints_txt(path: Path, constraint_lines: list[str]) -> None:
 
 
 def _replace_constraint_dependencies_array(doc: tomlkit.TOMLDocument, lines: list[str]) -> None:
-    if "tool" not in doc or not _is_table(doc["tool"]):
-        raise SystemExit("pyproject.toml: missing or invalid [tool] table")
-    uv = doc["tool"]["uv"]
-    if not _is_table(uv):
-        raise SystemExit("pyproject.toml: missing or invalid [tool.uv] table")
-    arr = tomlkit.array()
-    arr.multiline(True)
-    for line in sorted(lines):
-        arr.append(line)
-    uv["constraint-dependencies"] = arr
+    match _get_table(doc, "tool"):
+        case None:
+            raise SystemExit("pyproject.toml: missing or invalid [tool] table")
+        case tool:
+            match _get_table(tool, "uv"):
+                case None:
+                    raise SystemExit("pyproject.toml: missing or invalid [tool.uv] table")
+                case uv:
+                    arr = tomlkit.array()
+                    arr.multiline(True)
+                    for line in sorted(lines):
+                        arr.append(line)
+                    uv["constraint-dependencies"] = arr
 
 
 # ---------------------------------------------------------------------------
@@ -222,7 +253,7 @@ def _replace_constraint_dependencies_array(doc: tomlkit.TOMLDocument, lines: lis
 # ---------------------------------------------------------------------------
 
 
-def _collect_max_floors(deps: list[dict], too_hard: frozenset[str]) -> dict[str, str]:
+def _collect_max_floors(deps: list[dict[str, Any]], too_hard: frozenset[str]) -> dict[str, str]:
     """Map canonical name -> highest advisory floor version across all alerts."""
     out: dict[str, str] = {}
     for dep in deps:
@@ -240,7 +271,7 @@ def _collect_max_floors(deps: list[dict], too_hard: frozenset[str]) -> dict[str,
     return out
 
 
-def _advisory_spelling_by_canonical(deps: list[dict], cnames: frozenset[str]) -> dict[str, str]:
+def _advisory_spelling_by_canonical(deps: list[dict[str, Any]], cnames: frozenset[str]) -> dict[str, str]:
     out: dict[str, str] = {}
     for dep in deps:
         p = dep["dependency"]["package"]["name"]
@@ -257,8 +288,18 @@ def _advisory_spelling_by_canonical(deps: list[dict], cnames: frozenset[str]) ->
 # ---------------------------------------------------------------------------
 
 
-def _is_table(x: object) -> bool:
-    return isinstance(x, (tomlkit.items.Table, OutOfOrderTableProxy))
+def _is_table(x: object) -> TypeIs[TomlTable]:
+    return isinstance(x, (tomlkit.TOMLDocument, tomlkit.items.Table, OutOfOrderTableProxy))
+
+
+def _get_table(table: TomlTable, key: str) -> TomlTable | None:
+    value = table.get(key)
+    return value if _is_table(value) else None
+
+
+def _get_array(table: TomlTable, key: str) -> tomlkit.items.Array | None:
+    value = table.get(key)
+    return value if isinstance(value, tomlkit.items.Array) else None
 
 
 # ---------------------------------------------------------------------------
@@ -278,9 +319,9 @@ def main() -> None:
         if not github_token:
             raise SystemExit("GITHUB_TOKEN is not set, required to fetch dependabot alerts")
         headers = {"Authorization": f"Bearer {github_token}"}
-        all_deps: list[dict] = []
+        all_deps: list[dict[str, Any]] = []
         next_url: str | None = url
-        params: dict | None = {"per_page": 100}
+        params: dict[str, int] | None = {"per_page": 100}
         while next_url:
             response = requests.get(next_url, headers=headers, params=params)
             response.raise_for_status()
@@ -292,7 +333,7 @@ def main() -> None:
             json.dump(all_deps, f)
 
     with open(dependabot_file, encoding="utf-8") as f:
-        deps = json.load(f)
+        deps: list[dict[str, Any]] = json.load(f)
 
     doc = tomlkit.parse(pyproject_path.read_text(encoding="utf-8"))
     direct_dep_names = _collect_direct_dep_names(doc)
@@ -322,14 +363,23 @@ def main() -> None:
     # ------------------------------------------------------------------
     # Pass 2: transitive deps → constraint-dependencies
     # ------------------------------------------------------------------
-    uv_section = doc["tool"]["uv"] if _is_table(doc.get("tool")) else None
-    raw = uv_section.get("constraint-dependencies") if _is_table(uv_section) else None
-    if raw is None:
-        current: list[str] = []
-    elif not isinstance(raw, tomlkit.items.Array):
-        raise SystemExit("pyproject: [tool.uv] constraint-dependencies is not an array")
-    else:
-        current = [str(x) for x in raw if str(x).strip()]
+    match _get_table(doc, "tool"):
+        case None:
+            raw_constraints = None
+        case tool:
+            match _get_table(tool, "uv"):
+                case None:
+                    raw_constraints = None
+                case uv_section:
+                    raw_constraints = uv_section.get("constraint-dependencies")
+
+    match raw_constraints:
+        case None:
+            current: list[str] = []
+        case tomlkit.items.Array() as constraints:
+            current = [str(item) for item in constraints if str(item).strip()]
+        case _:
+            raise SystemExit("pyproject: [tool.uv] constraint-dependencies is not an array")
 
     updated = list(current)
     for cname, floor in sorted(floors.items()):

--- a/tools/release_version.py
+++ b/tools/release_version.py
@@ -19,7 +19,7 @@ import sys
 from collections.abc import Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Literal, Self, TypeAlias
+from typing import Literal, TypeAlias
 
 from packaging.version import InvalidVersion, Version
 
@@ -41,7 +41,7 @@ class StableVersion:
     minor: int
     patch: int
 
-    def bump(self, part: StableBump) -> Self:
+    def bump(self, part: StableBump) -> StableVersion:
         """Return the next stable base version for the requested bump part."""
         match part:
             case "major":


### PR DESCRIPTION
## Summary
- Removes the top-level tools exclusion from ty checks.
- Adds typed TOML and proxy helper boundaries for checked tools.

## Test plan
- [x] mise run typecheck
- [x] mise run format-check

Related issue: #614


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lockfile comparisons across registry, Git, path, and other package sources.
  * Preserved separate entries when the same package has multiple versions.
  * Improved dependency update handling and validation for missing or invalid configuration sections.

* **Maintenance**
  * Improved reliability and type safety across dependency, proxy, and release tooling.
  * Expanded automated validation for package metadata and lockfile processing.
  * Updated tooling configuration to include relevant validation targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->