### PR TITLE
fix: honor disabled evaluation flag

### DIFF
--- a/src/nemo_safe_synthesizer/sdk/library_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/library_builder.py
@@ -196,8 +196,8 @@ class SafeSynthesizer(ConfigBuilder):
     generator: GeneratorBackend
     """Generation backend instance, populated after ``generate()``."""
 
-    evaluator: Evaluator
-    """Evaluator instance, populated after ``evaluate()``."""
+    evaluator: Evaluator | None
+    """Evaluator instance, populated after ``evaluate()`` when evaluation is enabled."""
 
     results: SafeSynthesizerResults
     """Final pipeline results, populated after ``evaluate()`` or ``run()``."""
@@ -601,16 +601,24 @@ class SafeSynthesizer(ConfigBuilder):
                 assert self._pii_replacer_time is not None
                 assert self._column_statistics is not None
 
-        self.evaluator = Evaluator(
-            config=self._nss_config,
-            generate_results=self.generator.gen_results,
-            pii_replacer_time=self._pii_replacer_time,
-            column_statistics=self._column_statistics,
-            training_df=self._original_training_df,
-            test_df=self._test_df,
-            workdir=self._workdir,
-        )
-        self.evaluator.evaluate()
+        evaluation_time = None
+        report = None
+        if self._nss_config.evaluation.enabled:
+            self.evaluator = Evaluator(
+                config=self._nss_config,
+                generate_results=self.generator.gen_results,
+                pii_replacer_time=self._pii_replacer_time,
+                column_statistics=self._column_statistics,
+                training_df=self._original_training_df,
+                test_df=self._test_df,
+                workdir=self._workdir,
+            )
+            self.evaluator.evaluate()
+            evaluation_time = self.evaluator.evaluation_time
+            report = self.evaluator.report
+        else:
+            logger.info("Evaluation disabled; skipping evaluation.")
+            self.evaluator = None
 
         training_time = None
         if trainer := getattr(self, "trainer", {}):
@@ -625,8 +633,8 @@ class SafeSynthesizer(ConfigBuilder):
             total_time=time.monotonic() - self._total_start,
             training_time=training_time,
             generation_time=generation_time,
-            evaluation_time=self.evaluator.evaluation_time,
-            report=self.evaluator.report,
+            evaluation_time=evaluation_time,
+            report=report,
             generate_results=self.generator.gen_results,
         )
         return self

--- a/tests/sdk/test_process_data.py
+++ b/tests/sdk/test_process_data.py
@@ -21,6 +21,8 @@ import pytest
 from nemo_safe_synthesizer.cli.artifact_structure import Workdir
 from nemo_safe_synthesizer.config import SafeSynthesizerParameters
 from nemo_safe_synthesizer.errors import ParameterError
+from nemo_safe_synthesizer.generation.results import GenerateJobResults
+from nemo_safe_synthesizer.generation.utils import GenerationStatus
 from nemo_safe_synthesizer.preflight import PreflightReport, PreflightStage
 from nemo_safe_synthesizer.sdk.library_builder import SafeSynthesizer
 
@@ -370,6 +372,43 @@ class TestEvaluateUsesOriginalTrainingDf:
         # Evaluation metrics must reflect real data, not PII-replaced tokens
         call_kwargs = mock_evaluator_cls.call_args[1]
         pd.testing.assert_frame_equal(call_kwargs["training_df"], train_split)
+
+    @patch("nemo_safe_synthesizer.sdk.library_builder.Evaluator")
+    def test_evaluate_disabled_skips_evaluator_and_builds_results(
+        self,
+        mock_evaluator_cls,
+        fixture_process_data_setup_without_pii,
+    ):
+        """When evaluation is disabled, ``evaluate()`` still prepares saveable results."""
+        builder, train_split, test_split, _, _ = fixture_process_data_setup_without_pii
+        assert builder._nss_config is not None
+        builder._nss_config.evaluation.enabled = False
+        builder._training_df = train_split
+        builder._original_training_df = train_split
+        builder._test_df = test_split
+        builder._total_start = 0.0
+
+        synthetic_df = pd.DataFrame({"patient_name": ["Synthetic Person"], "patient_age": [42]})
+        mock_gen = MagicMock()
+        mock_gen.gen_results = GenerateJobResults(
+            df=synthetic_df,
+            status=GenerationStatus.COMPLETE,
+            num_valid_records=1,
+            num_invalid_records=0,
+            num_prompts=1,
+            valid_record_fraction=1.0,
+            batch_valid_record_fractions=[1.0],
+            elapsed_time=1.0,
+        )
+        builder.generator = mock_gen
+
+        builder.evaluate()
+
+        mock_evaluator_cls.assert_not_called()
+        assert builder.evaluator is None
+        assert builder.results.evaluation_report_html is None
+        assert builder.results.summary.timing.evaluation_time_sec is None
+        pd.testing.assert_frame_equal(builder.results.synthetic_data, synthetic_df)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Skip Evaluator when evaluation.enabled=false.
- Still populate SDK results so synthetic data can be saved.
- Add SDK regression coverage for disabled evaluation.

## Test plan
- pytest tests/sdk/test_process_data.py -q -n0
- format, ruff, copyright, and diff whitespace checks
- typecheck still reports existing telemetry constructor diagnostics outside this diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Evaluation can now be skipped cleanly when disabled, without blocking result generation.
  * Evaluation timing and report fields are left empty when no evaluation is run.
  * The synthesizer’s evaluator is now treated as optional, preventing errors in non-evaluation runs.

* **Tests**
  * Added coverage for the disabled-evaluation path to confirm results are still built and no evaluator is created.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->