### PR TITLE
chore: Add nvidia-internal option for deployment type for telemetry

### DIFF
--- a/src/nemo_safe_synthesizer/telemetry.py
+++ b/src/nemo_safe_synthesizer/telemetry.py
@@ -53,6 +53,7 @@ class DeploymentTypeEnum(str, Enum):
     NMP = "nmp"  # Deployed through NVIDIA NeMo Platform
     SLURM = "slurm"  # Deployed through SLURM
     SLURM_INTERNAL = "slurm-nvidia-internal"  # Deployed through SLURM internal (NVIDIA internal cluster)
+    NVIDIA_INTERNAL = "nvidia-internal"  # Deployed in NVIDIA internal environments
     UNDEFINED = "undefined"
 
 
@@ -165,7 +166,7 @@ def bucket_columns(n: int) -> str:
 
 class NSSTrainingAndGenerationEvent(BaseModel):
     _event_name: ClassVar[str] = "train_and_generation_event"
-    _schema_version: ClassVar[str] = "1.7"
+    _schema_version: ClassVar[str] = "1.9"
 
     nemo_source: NemoSourceEnum = Field(
         default=NemoSourceEnum.SAFE_SYNTHESIZER,

--- a/tests/telemetry/test_telemetry.py
+++ b/tests/telemetry/test_telemetry.py
@@ -96,6 +96,10 @@ class TestEnvHelpers:
         # Must not raise — telemetry must never block runtime over a misconfigured env var.
         assert _deployment_type() == DeploymentTypeEnum.UNDEFINED
 
+    def test_deployment_type_nvidia_internal(self, monkeypatch):
+        monkeypatch.setenv("NEMO_DEPLOYMENT_TYPE", DeploymentTypeEnum.NVIDIA_INTERNAL.value)
+        assert _deployment_type() == DeploymentTypeEnum.NVIDIA_INTERNAL
+
 
 # =============================================================================
 # Model telemetry sanitization
@@ -183,6 +187,9 @@ class TestNSSTrainingAndGenerationEvent:
 
     def test_event_name(self):
         assert NSSTrainingAndGenerationEvent._event_name == "train_and_generation_event"
+
+    def test_schema_version(self):
+        assert NSSTrainingAndGenerationEvent._schema_version == "1.9"
 
     def test_feature_flags(self):
         event = NSSTrainingAndGenerationEvent(


### PR DESCRIPTION
# Summary

Update schema version and add nvidia-internal as a valid value for NEMO_DEPLOYMENT_TYPE to identify internal experimentation with NSS.

## Pre-Review Checklist


Ensure that the following pass:

- [x] `mise run format && mise run check` or via prek validation.
- [x] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional deployment type option.
  * Updated telemetry events to report a newer schema version.

* **Tests**
  * Added coverage for the new deployment type behavior.
  * Added a check to confirm the telemetry schema version is reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->