### PR TITLE
fix: update pii replace to work for other gliner version

### DIFF
--- a/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
@@ -606,6 +606,47 @@ class EntityExtractorGliner(EntityExtractor):
         extractor._batch_size = clsfy_cfg.gliner_batch_mode_batch_size
         return extractor
 
+    def _predict_entities(self, text: str, entity_labels: list[str]) -> list[dict]:
+        predict_entities = getattr(self._model, "predict_entities", None)
+        if predict_entities is not None:
+            return predict_entities(
+                text,
+                entity_labels,
+                threshold=self._ner_threshold,
+                flat_ner=False,
+            )
+
+        return self._model.batch_predict_entities(
+            [text],
+            entity_labels,
+            threshold=self._ner_threshold,
+            flat_ner=False,
+        )[0]
+
+    def _batch_predict_entities(self, texts: list[str], entity_labels: list[str]) -> list[list[dict]]:
+        batch_predict_entities = getattr(self._model, "batch_predict_entities", None)
+        if batch_predict_entities is not None:
+            return batch_predict_entities(
+                texts,
+                entity_labels,
+                threshold=self._ner_threshold,
+                flat_ner=False,
+            )
+
+        predict_entities = getattr(self._model, "predict_entities", None)
+        if predict_entities is not None:
+            return [
+                predict_entities(
+                    text,
+                    entity_labels,
+                    threshold=self._ner_threshold,
+                    flat_ner=False,
+                )
+                for text in texts
+            ]
+
+        raise AttributeError("GLiNER model has neither batch_predict_entities nor predict_entities")
+
     def _detect_entities_chunked(
         self,
         text: str,
@@ -629,7 +670,8 @@ class EntityExtractorGliner(EntityExtractor):
 
         if entity_labels is None:
             return []
-        entities_key = tuple(sorted(entity_labels))
+        gliner_entity_labels = sorted(entity_labels)
+        entities_key = tuple(gliner_entity_labels)
         start = 0
         entities = []
         # Occasionally text interpreted as type other than string by jinja
@@ -646,12 +688,7 @@ class EntityExtractorGliner(EntityExtractor):
             temp_entities = self._entity_cache.get((hash(chunk), entities_key))
             if temp_entities is None:
                 n_cache_miss += 1
-                temp_entities = self._model.predict_entities(
-                    chunk,
-                    entity_labels,
-                    threshold=self._ner_threshold,
-                    flat_ner=False,
-                )
+                temp_entities = self._predict_entities(chunk, gliner_entity_labels)
             for idx in range(len(temp_entities)):
                 temp_entities[idx]["start"] += start
                 temp_entities[idx]["end"] += start
@@ -717,7 +754,8 @@ class EntityExtractorGliner(EntityExtractor):
             entity_labels = self._entity_types
         if entity_labels is None:
             return
-        entities_key = tuple(sorted(entity_labels))
+        gliner_entity_labels = sorted(entity_labels)
+        entities_key = tuple(gliner_entity_labels)
         for text in texts:
             text = str(text)
             start = 0
@@ -728,12 +766,7 @@ class EntityExtractorGliner(EntityExtractor):
         for batch_n, batch in enumerate(
             [chunks[t : t + self._batch_size] for t in range(0, len(chunks), self._batch_size)]
         ):
-            entities_lists = self._model.batch_predict_entities(
-                batch,
-                entity_labels,
-                threshold=self._ner_threshold,
-                flat_ner=False,
-            )
+            entities_lists = self._batch_predict_entities(batch, gliner_entity_labels)
             if monotonic() - last_log > 30:
                 logger.info(
                     f"NER batch #{batch_n + 1} of {batch_n_total} complete.",

--- a/tests/pii_replacer/test_detect.py
+++ b/tests/pii_replacer/test_detect.py
@@ -87,6 +87,97 @@ def test_gliner_batch_predict_config():
         entity_extractor._model.batch_predict_entities.assert_called()  # ty: ignore[call-non-callable, unresolved-attribute] -- mock object
 
 
+def test_gliner_entity_labels_are_indexable():
+    cfg = ClassifyConfig(
+        valid_entities={"email", "name"},
+        ner_threshold=0.8,
+        ner_regexps_enabled=False,
+        ner_entities={"email", "name"},
+        gliner_enabled=True,
+        gliner_batch_mode_enabled=True,
+        gliner_batch_mode_chunk_length=10,
+        gliner_batch_mode_batch_size=20,
+        gliner_model="nvidia/gliner-PII",
+    )
+
+    with patch("nemo_safe_synthesizer.pii_replacer.data_editor.detect.GLiNER") as mock_gliner:
+        model = mock_gliner.from_pretrained.return_value
+        model.predict_entities.return_value = []
+        model.batch_predict_entities.return_value = [[]]
+
+        entity_extractor = EntityExtractorGliner.get_entity_extractor(cfg)
+        entity_extractor.extract_ner_predictions("abc", {"name", "email"})
+        entity_extractor.batch_update_cache(["abc"], None)
+
+        assert model.predict_entities.call_args.args[1] == ["email", "name"]
+        assert model.batch_predict_entities.call_args.args[1] == ["email", "name"]
+
+
+def test_gliner_batch_cache_falls_back_to_predict_entities_api():
+    cfg = ClassifyConfig(
+        valid_entities={"email", "name"},
+        ner_threshold=0.8,
+        ner_regexps_enabled=False,
+        ner_entities={"email", "name"},
+        gliner_enabled=True,
+        gliner_batch_mode_enabled=True,
+        gliner_batch_mode_chunk_length=10,
+        gliner_batch_mode_batch_size=20,
+        gliner_model="nvidia/gliner-PII",
+    )
+
+    class FakeGLiNER:
+        def __init__(self):
+            self.calls = []
+
+        def predict_entities(self, text, labels, **kwargs):
+            self.calls.append((text, labels, kwargs))
+            return []
+
+    model = FakeGLiNER()
+    with patch("nemo_safe_synthesizer.pii_replacer.data_editor.detect.GLiNER") as mock_gliner:
+        mock_gliner.from_pretrained.return_value = model
+
+        entity_extractor = EntityExtractorGliner.get_entity_extractor(cfg)
+        entity_extractor.batch_update_cache(["abc"], None)
+
+        assert len(model.calls) == 1
+        assert model.calls[0][0] == "abc"
+        assert model.calls[0][1] == ["email", "name"]
+
+
+def test_gliner_single_prediction_falls_back_to_batch_api():
+    cfg = ClassifyConfig(
+        valid_entities={"email", "name"},
+        ner_threshold=0.8,
+        ner_regexps_enabled=False,
+        ner_entities={"email", "name"},
+        gliner_enabled=True,
+        gliner_batch_mode_enabled=False,
+        gliner_batch_mode_chunk_length=10,
+        gliner_batch_mode_batch_size=20,
+        gliner_model="nvidia/gliner-PII",
+    )
+
+    class FakeGLiNER:
+        def __init__(self):
+            self.calls = []
+
+        def batch_predict_entities(self, texts, labels, **kwargs):
+            self.calls.append((texts, labels, kwargs))
+            return [[]]
+
+    model = FakeGLiNER()
+    with patch("nemo_safe_synthesizer.pii_replacer.data_editor.detect.GLiNER") as mock_gliner:
+        mock_gliner.from_pretrained.return_value = model
+
+        entity_extractor = EntityExtractorGliner.get_entity_extractor(cfg)
+        entity_extractor.extract_ner_predictions("abc", {"name", "email"})
+
+        assert model.calls[0][0] == ["abc"]
+        assert model.calls[0][1] == ["email", "name"]
+
+
 @pytest.mark.parametrize("offline_var", ["HF_HUB_OFFLINE", "TRANSFORMERS_OFFLINE"])
 @pytest.mark.parametrize("env_value", ["1", "yes", "on"])
 def test_gliner_local_files_only_follows_hf_offline_env(env_value, offline_var, monkeypatch):


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved entity detection robustness by correctly handling different GLiNER prediction modes and automatically falling back when batch prediction isn’t available.
  - Ensured entity label ordering is deterministic, improving consistency of detection results and cached outputs.

- **Tests**
  - Added coverage to verify deterministic label ordering.
  - Added coverage for correct fallback behavior between single and batch GLiNER prediction paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->