### PR TITLE
chore: refresh mise lockfile

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -10,7 +10,7 @@
 
 # Single source of truth for the pinned mise version. `tools/install-mise.sh`
 # reads `min_version` from this file; an older mise on PATH fails fast here too.
-min_version = '2026.5.2'
+min_version = '2026.7.5'
 
 [tools]
 # Tools for working with JSON, Git, and other system utilities.

--- a/mise.lock
+++ b/mise.lock
@@ -7,6 +7,7 @@ backend = "aqua:google/osv-scanner"
 [tools."aqua:google/osv-scanner"."platforms.linux-arm64"]
 checksum = "sha256:fa46ad2b3954db5d5335303d45de921613393285d9a93c140b63b40e35e9ce50"
 url = "https://github.com/google/osv-scanner/releases/download/v2.3.5/osv-scanner_linux_arm64"
+url_api = "https://api.github.com/repos/google/osv-scanner/releases/assets/380248755"
 
 [tools."aqua:google/osv-scanner"."platforms.linux-arm64".provenance.slsa]
 url = "https://github.com/google/osv-scanner/releases/download/v2.3.5/multiple.intoto.jsonl"
@@ -14,6 +15,7 @@ url = "https://github.com/google/osv-scanner/releases/download/v2.3.5/multiple.i
 [tools."aqua:google/osv-scanner"."platforms.linux-x64"]
 checksum = "sha256:bb30c580afe5e757d3e959f4afd08a4795ea505ef84c46962b9a738aa573b41b"
 url = "https://github.com/google/osv-scanner/releases/download/v2.3.5/osv-scanner_linux_amd64"
+url_api = "https://api.github.com/repos/google/osv-scanner/releases/assets/380248788"
 
 [tools."aqua:google/osv-scanner"."platforms.linux-x64".provenance.slsa]
 url = "https://github.com/google/osv-scanner/releases/download/v2.3.5/multiple.intoto.jsonl"
@@ -21,6 +23,7 @@ url = "https://github.com/google/osv-scanner/releases/download/v2.3.5/multiple.i
 [tools."aqua:google/osv-scanner"."platforms.macos-arm64"]
 checksum = "sha256:b740efe0b08fb817865e818a498997d5f042f14b8eeafb6393176ce84dd09cf6"
 url = "https://github.com/google/osv-scanner/releases/download/v2.3.5/osv-scanner_darwin_arm64"
+url_api = "https://api.github.com/repos/google/osv-scanner/releases/assets/380248752"
 
 [tools."aqua:google/osv-scanner"."platforms.macos-arm64".provenance.slsa]
 url = "https://github.com/google/osv-scanner/releases/download/v2.3.5/multiple.intoto.jsonl"
@@ -32,16 +35,19 @@ backend = "aqua:j178/prek"
 [tools."aqua:j178/prek"."platforms.linux-arm64"]
 checksum = "sha256:0cf6d013c981a56465757dc7ff0fd3a9ceace27d7f0a792f435d1be79b790236"
 url = "https://github.com/j178/prek/releases/download/v0.3.6/prek-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/j178/prek/releases/assets/374826259"
 provenance = "github-attestations"
 
 [tools."aqua:j178/prek"."platforms.linux-x64"]
 checksum = "sha256:942564ccc9c342d317294fec7b7a77aa24ec71136e3439b15cddb62e49f76899"
 url = "https://github.com/j178/prek/releases/download/v0.3.6/prek-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/j178/prek/releases/assets/374826311"
 provenance = "github-attestations"
 
 [tools."aqua:j178/prek"."platforms.macos-arm64"]
 checksum = "sha256:50535d4fb3a0fd05f137bbdae6f8ffde17615949bd282817e3aa5755dd8d8d4c"
 url = "https://github.com/j178/prek/releases/download/v0.3.6/prek-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/j178/prek/releases/assets/374826253"
 provenance = "github-attestations"
 
 [[tools.dprint]]
@@ -51,14 +57,17 @@ backend = "aqua:dprint/dprint"
 [tools.dprint."platforms.linux-arm64"]
 checksum = "sha256:e1434b394718b63d560ecaf36c748e91f06c49fe4b09ffc8c6b6e0e6833d0900"
 url = "https://github.com/dprint/dprint/releases/download/0.52.0/dprint-aarch64-unknown-linux-musl.zip"
+url_api = "https://api.github.com/repos/dprint/dprint/releases/assets/361608819"
 
 [tools.dprint."platforms.linux-x64"]
 checksum = "sha256:ff86d0b9dc28183e111e7cd7d4101fdc4e1b9be0fb84bd08f3b9a41688010aa1"
 url = "https://github.com/dprint/dprint/releases/download/0.52.0/dprint-x86_64-unknown-linux-musl.zip"
+url_api = "https://api.github.com/repos/dprint/dprint/releases/assets/361608818"
 
 [tools.dprint."platforms.macos-arm64"]
 checksum = "sha256:bb3a5be1444fcfaf2f405cbf8af7da809d055705a2ca17bd2e7edff6f2959354"
 url = "https://github.com/dprint/dprint/releases/download/0.52.0/dprint-aarch64-apple-darwin.zip"
+url_api = "https://api.github.com/repos/dprint/dprint/releases/assets/361608824"
 
 [[tools.github-cli]]
 version = "2.87.0"
@@ -67,16 +76,19 @@ backend = "aqua:cli/cli"
 [tools.github-cli."platforms.linux-arm64"]
 checksum = "sha256:7f7fbaf65baa1e438ae5b7134bff014c0122944dd2e83bb5db8088fe3888fe39"
 url = "https://github.com/cli/cli/releases/download/v2.87.0/gh_2.87.0_linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/358046964"
 provenance = "github-attestations"
 
 [tools.github-cli."platforms.linux-x64"]
 checksum = "sha256:5f461c1dc2b80483ea5617f9253d591fb427b3ecfdd69c69089e1ee6156dc234"
 url = "https://github.com/cli/cli/releases/download/v2.87.0/gh_2.87.0_linux_amd64.tar.gz"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/358046961"
 provenance = "github-attestations"
 
 [tools.github-cli."platforms.macos-arm64"]
 checksum = "sha256:b1e6e3ab764892a33a1fe464c239be393e6bbd4220804692f919c4c805b1dbbf"
 url = "https://github.com/cli/cli/releases/download/v2.87.0/gh_2.87.0_macOS_arm64.zip"
+url_api = "https://api.github.com/repos/cli/cli/releases/assets/358046978"
 provenance = "github-attestations"
 
 [[tools.jq]]
@@ -86,16 +98,19 @@ backend = "aqua:jqlang/jq"
 [tools.jq."platforms.linux-arm64"]
 checksum = "sha256:6bc62f25981328edd3cfcfe6fe51b073f2d7e7710d7ef7fcdac28d4e384fc3d4"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-arm64"
+url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/268981481"
 provenance = "github-attestations"
 
 [tools.jq."platforms.linux-x64"]
 checksum = "sha256:020468de7539ce70ef1bceaf7cde2e8c4f2ca6c3afb84642aabc5c97d9fc2a0d"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-amd64"
+url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/268981484"
 provenance = "github-attestations"
 
 [tools.jq."platforms.macos-arm64"]
 checksum = "sha256:a9fe3ea2f86dfc72f6728417521ec9067b343277152b114f4e98d8cb0e263603"
 url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-macos-arm64"
+url_api = "https://api.github.com/repos/jqlang/jq/releases/assets/268981506"
 provenance = "github-attestations"
 
 [[tools.ripgrep]]
@@ -105,14 +120,17 @@ backend = "aqua:BurntSushi/ripgrep"
 [tools.ripgrep."platforms.linux-arm64"]
 checksum = "sha256:2b661c6ef508e902f388e9098d9c4c5aca72c87b55922d94abdba830b4dc885e"
 url = "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/BurntSushi/ripgrep/releases/assets/307306472"
 
 [tools.ripgrep."platforms.linux-x64"]
 checksum = "sha256:1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599"
 url = "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/BurntSushi/ripgrep/releases/assets/307306614"
 
 [tools.ripgrep."platforms.macos-arm64"]
 checksum = "sha256:378e973289176ca0c6054054ee7f631a065874a352bf43f0fa60ef079b6ba715"
 url = "https://github.com/BurntSushi/ripgrep/releases/download/15.1.0/ripgrep-15.1.0-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/BurntSushi/ripgrep/releases/assets/307305438"
 
 [[tools.ruff]]
 version = "0.15.0"
@@ -121,14 +139,17 @@ backend = "aqua:astral-sh/ruff"
 [tools.ruff."platforms.linux-arm64"]
 checksum = "sha256:b9860c394ea814a9e9560e80bc798c53b8a3a5120ce961a2555fb563cee9f73b"
 url = "https://github.com/astral-sh/ruff/releases/download/0.15.0/ruff-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/ruff/releases/assets/350142120"
 
 [tools.ruff."platforms.linux-x64"]
 checksum = "sha256:f2bd69f091517ebc49405319a6e7818b1037e250b8d539336aa0b91c44ffa4aa"
 url = "https://github.com/astral-sh/ruff/releases/download/0.15.0/ruff-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/ruff/releases/assets/350142160"
 
 [tools.ruff."platforms.macos-arm64"]
 checksum = "sha256:093d355ac33c6b8e91e80b8497d5581c61b028c0405e265cf38fd88f9a291c5c"
 url = "https://github.com/astral-sh/ruff/releases/download/0.15.0/ruff-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/ruff/releases/assets/350142105"
 
 [[tools.ty]]
 version = "0.0.44"
@@ -137,16 +158,19 @@ backend = "aqua:astral-sh/ty"
 [tools.ty."platforms.linux-arm64"]
 checksum = "sha256:46a84ec41d2ae8892673f698a2ae31e02278203ededdce0d9229b7c4f5ac8bff"
 url = "https://github.com/astral-sh/ty/releases/download/0.0.44/ty-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/ty/releases/assets/438914473"
 provenance = "github-attestations"
 
 [tools.ty."platforms.linux-x64"]
 checksum = "sha256:618549cc5b0fd19b3ca0830a43fee4189623d7bd993bf65315f1f0ba650d944a"
 url = "https://github.com/astral-sh/ty/releases/download/0.0.44/ty-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/ty/releases/assets/438914556"
 provenance = "github-attestations"
 
 [tools.ty."platforms.macos-arm64"]
 checksum = "sha256:e796d5a91886a379d1da7c97772722a205901991d642382f75e2c27c138cfddb"
 url = "https://github.com/astral-sh/ty/releases/download/0.0.44/ty-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/ty/releases/assets/438914458"
 provenance = "github-attestations"
 
 [[tools.uv]]
@@ -156,16 +180,19 @@ backend = "aqua:astral-sh/uv"
 [tools.uv."platforms.linux-arm64"]
 checksum = "sha256:b658b56957bceea742ca14f3ef28fb3542adbcedfb8bd5bd718ae255394ccd09"
 url = "https://github.com/astral-sh/uv/releases/download/0.9.30/uv-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/uv/releases/assets/350792451"
 provenance = "github-attestations"
 
 [tools.uv."platforms.linux-x64"]
 checksum = "sha256:1caf8fe092e2005dd4c134ba515c1aa3eea3d3c143f8a1903bcb58fcdf169365"
 url = "https://github.com/astral-sh/uv/releases/download/0.9.30/uv-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/uv/releases/assets/350792501"
 provenance = "github-attestations"
 
 [tools.uv."platforms.macos-arm64"]
 checksum = "sha256:03a5d9ec7f7d588446b2ec226d13ff6300055e55365eca8f3fab39f342b0e805"
 url = "https://github.com/astral-sh/uv/releases/download/0.9.30/uv-aarch64-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/astral-sh/uv/releases/assets/350792440"
 provenance = "github-attestations"
 
 [[tools.yq]]
@@ -173,10 +200,16 @@ version = "4.44.1"
 backend = "aqua:mikefarah/yq"
 
 [tools.yq."platforms.linux-arm64"]
+checksum = "sha512:341eb2e618ccc9252f4123fa9291c64820cc5dafb826031ddd8f3e5db63db0cb034cd901fc8897f9fb24ccb3261ba4104906a3d848d6a6dd17f7917cd231c6ad"
 url = "https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_arm64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/167414621"
 
 [tools.yq."platforms.linux-x64"]
+checksum = "sha512:17afc44c559cc214e259779e101449112703ba1a5d21bcb42b4f973e5cda2cd8e6f5ec62ae51410a3dc8dfdeef150127e651e361d0933a60cfc398df0e256fb8"
 url = "https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_linux_amd64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/167414618"
 
 [tools.yq."platforms.macos-arm64"]
-url = "https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_darwin_arm64"
+checksum = "sha512:b779f240f03308c3ef599416beae71c97a9b3152b6f20eb99b9ffe47317c550a3bdcc81621340b137c5e3ef65b4ef2069accb92b9957047ba056389d16f518f0"
+url = "https://github.com/mikefarah/yq/releases/download/v4.44.1/yq_darwin_amd64"
+url_api = "https://api.github.com/repos/mikefarah/yq/releases/assets/167414605"


### PR DESCRIPTION
## Summary
- pin mise 2026.7.5 for worktree-aware config trust
- refresh tool metadata for all configured platforms
- add resolved asset API URLs and yq checksums

## Test plan
- [x] `mise run format-check`
- [x] `mise run lock-check`
- [x] `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the required mise version to 2026.7.5 for improved tooling compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->