### PR TITLE
feat(cli): add version flag

### DIFF
--- a/docs/user-guide/getting-started.md
+++ b/docs/user-guide/getting-started.md
@@ -139,6 +139,7 @@ indexes outside PyPI. You must pass the extra index URLs shown below.
 After installing, activate your Python virtual environment and confirm the CLI is available:
 
 ```bash
+safe-synthesizer --version
 safe-synthesizer --help
 ```
 
@@ -153,6 +154,7 @@ Usage: safe-synthesizer [OPTIONS] COMMAND [ARGS]...
   modify a config file.
 
 Options:
+  --version  Show the version and exit.
   --help  Show this message and exit.
 
 Commands:

--- a/docs/user-guide/running.md
+++ b/docs/user-guide/running.md
@@ -182,6 +182,12 @@ for the full override precedence rules.
 
 ## CLI Commands
 
+Print the installed version and exit:
+
+```bash
+safe-synthesizer --version
+```
+
 ```bash
 safe-synthesizer --help
 ```

--- a/src/nemo_safe_synthesizer/__init__.py
+++ b/src/nemo_safe_synthesizer/__init__.py
@@ -2,3 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from __future__ import annotations
+
+from .package_info import __version__
+
+__all__ = ["__version__"]

--- a/src/nemo_safe_synthesizer/cli/cli.py
+++ b/src/nemo_safe_synthesizer/cli/cli.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 
 import click
 
+from ..package_info import __version__
 from .artifacts import artifacts
 from .config import config
 from .run import run
 
 
 @click.group()
+@click.version_option(version=__version__, prog_name="safe-synthesizer")
 def cli() -> None:
     """NeMo Safe Synthesizer command-line interface.
     This application is used to run the Safe Synthesizer pipeline.

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -6,7 +6,9 @@ import re
 
 from click.testing import CliRunner
 
+from nemo_safe_synthesizer import __version__
 from nemo_safe_synthesizer.cli.cli import cli
+from nemo_safe_synthesizer.package_info import __version__ as package_info_version
 from nemo_safe_synthesizer.utils import merge_dicts
 
 
@@ -14,6 +16,17 @@ def strip_ansi_codes(text: str) -> str:
     """Remove ANSI escape codes from text."""
     ansi_escape = re.compile(r"\x1b\[[0-9;]*m")
     return ansi_escape.sub("", text)
+
+
+def test_version_option():
+    result = CliRunner().invoke(cli, ["--version"])
+
+    assert result.exit_code == 0
+    assert result.output == f"safe-synthesizer, version {__version__}\n"
+
+
+def test_version_is_exposed_from_package_root():
+    assert __version__ == package_info_version
 
 
 def test_merge_dicts():


### PR DESCRIPTION
## Summary
- Add `safe-synthesizer --version` backed by installed package metadata.
- Expose the same version from the package root and document the CLI flag.

## Test plan
- [x] `uv run --no-sync pytest tests/cli -v -n0`
- [x] `mise run format-check`
- [x] `mise run typecheck`

Closes #606

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `safe-synthesizer --version` command to display the installed version and exit.
  * Exposed the package version through the public API.

* **Documentation**
  * Updated CLI usage examples and command reference with the new version option.

* **Tests**
  * Added coverage verifying version output and consistency across the CLI and package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->