### PR TITLE
fix: compact training progress logs

### DIFF
--- a/src/nemo_safe_synthesizer/observability.py
+++ b/src/nemo_safe_synthesizer/observability.py
@@ -256,8 +256,8 @@ def _convert_rich_table_to_string(rich_table: Table) -> str:
 def _render_table_data_for_console(logger: logging.Logger, method_name: str, event_dict: dict) -> dict:
     """Processor that renders table data keys as Rich tables for console output.
 
-    Looks for specific keys in the event_dict (defined in TABLE_DATA_KEYS).
-    For each found key, renders the data as a Rich ASCII table and appends to the message.
+    For each table found in structured context, renders the data as a Rich ASCII
+    table and appends it to the message.
     Creates a filtered copy of extra (without table keys) for console display,
     preserving the original extra dict for JSON logging.
 
@@ -288,11 +288,12 @@ def _render_table_data_for_console(logger: logging.Logger, method_name: str, eve
         # The original 'extra' dict (with ctx) is preserved for JSON logging
         return event_dict
 
-    # Create a filtered copy of extra for console display (excluding rendered table keys)
+    # Structured context is retained for JSON but not repeated in plain output.
+    # Other extra values remain available for the compact console suffix.
     # Keep the original extra intact for JSON logging
     extra = event_dict.get("extra", {})
     if extra:
-        filtered_extra = {k: v for k, v in extra.items() if k not in rendered_keys}
+        filtered_extra = {k: v for k, v in extra.items() if k != "ctx" and k not in rendered_keys}
         if filtered_extra:
             event_dict["_extra_display"] = filtered_extra
     return event_dict

--- a/src/nemo_safe_synthesizer/training/callbacks.py
+++ b/src/nemo_safe_synthesizer/training/callbacks.py
@@ -389,7 +389,7 @@ class SafeSynthesizerWorkerCallback(TrainerCallback):
                 log_to_user["step"] = user_step
                 log_to_user[which_loss] = round(logs[which_loss], 4)
 
-                epoch = f"{state.epoch:.2%}" if state.epoch is not None else "n/a"
+                epoch = f"{state.epoch:.2f}" if state.epoch is not None else "n/a"
                 loss_label = which_loss.replace("_", " ").title()
                 message = (
                     f"Training Progress | Progress: {complete_frac:.2%} | Epoch: {epoch} | "

--- a/src/nemo_safe_synthesizer/training/callbacks.py
+++ b/src/nemo_safe_synthesizer/training/callbacks.py
@@ -293,8 +293,9 @@ class ProgressBarCallback(TrainerCallback):
 class SafeSynthesizerWorkerCallback(TrainerCallback):
     """Trainer callback that emits structured progress logs at a fixed interval.
 
-    Logs are written via the ``logger.runtime`` channel as rendered tables
-    containing epoch, step, loss, and progress fraction.
+    Logs are written via the ``logger.runtime`` channel as compact messages
+    containing epoch, step, loss, and progress fraction. The corresponding raw
+    values remain available as structured context for JSON logs.
 
     Args:
         log_interval: Minimum seconds between successive log emissions.
@@ -388,11 +389,16 @@ class SafeSynthesizerWorkerCallback(TrainerCallback):
                 log_to_user["step"] = user_step
                 log_to_user[which_loss] = round(logs[which_loss], 4)
 
+                epoch = f"{state.epoch:.2%}" if state.epoch is not None else "n/a"
+                loss_label = which_loss.replace("_", " ").title()
+                message = (
+                    f"Training Progress | Progress: {complete_frac:.2%} | Epoch: {epoch} | "
+                    f"Step: {user_step} | {loss_label}: {logs[which_loss]:.2f}"
+                )
                 logger.runtime.info(
-                    "",
+                    message,
                     extra={
                         "ctx": {
-                            "render_table": True,
                             "tabular_data": log_to_user,
                             "title": "Training Progress",
                         }

--- a/tests/observability/test_observability.py
+++ b/tests/observability/test_observability.py
@@ -357,8 +357,8 @@ class TestRenderTableDataForConsole:
         assert "key1" in result["extra"]["ctx"]
         assert "value1" == result["extra"]["ctx"]["key1"]
 
-    def test_creates_filtered_extra_display(self, mock_logger):
-        """Test that _extra_display is created without table keys."""
+    def test_creates_filtered_extra_display_without_ctx(self, mock_logger):
+        """Plain output keeps ordinary extras without repeating structured context."""
         event_dict = {
             "event": "test",
             "extra": {
@@ -370,8 +370,8 @@ class TestRenderTableDataForConsole:
         result = _render_table_data_for_console(mock_logger, "info", event_dict)
 
         assert "_extra_display" in result
-        assert "other_key" in result["_extra_display"]
-        assert "count" not in result["_extra_display"]
+        assert result["_extra_display"] == {"other_key": "other_value"}
+        assert result["extra"]["ctx"] == {"count": 100}
 
     def test_handles_empty_event_dict(self, mock_logger):
         """Test handling of event dict without table data."""

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -95,7 +95,7 @@ def test_worker_callback_logs_compact_structured_progress(monkeypatch):
     )
 
     log_info.assert_called_once_with(
-        "Training Progress | Progress: 20.00% | Epoch: 20.00% | Step: 8 | Loss: 0.12",
+        "Training Progress | Progress: 20.00% | Epoch: 0.20 | Step: 8 | Loss: 0.12",
         extra={
             "ctx": {
                 "tabular_data": {"progress": 0.2, "epoch": 0.2, "step": 8, "loss": 0.1235},

--- a/tests/training/test_callbacks.py
+++ b/tests/training/test_callbacks.py
@@ -11,7 +11,8 @@ import torch
 from nemo_safe_synthesizer.data_processing.record_utils import ParsedRecord
 from nemo_safe_synthesizer.generation.processors import ParsedResponse, TabularDataProcessor
 from nemo_safe_synthesizer.llm.metadata import ModelMetadata
-from nemo_safe_synthesizer.training.callbacks import InferenceEvalCallback
+from nemo_safe_synthesizer.training import callbacks as callbacks_module
+from nemo_safe_synthesizer.training.callbacks import InferenceEvalCallback, SafeSynthesizerWorkerCallback
 
 
 @pytest.fixture
@@ -78,6 +79,30 @@ def _invoke_on_evaluate(
         tokenizer=tokenizer,
     )
     return state, control
+
+
+def test_worker_callback_logs_compact_structured_progress(monkeypatch):
+    """Training progress uses a compact message without flattening JSON metrics."""
+    log_info = MagicMock()
+    monkeypatch.setattr(callbacks_module.logger.runtime, "info", log_info)
+    state = MagicMock(is_local_process_zero=True, global_step=2, max_steps=10, epoch=0.2)
+
+    SafeSynthesizerWorkerCallback().on_log(
+        args=MagicMock(gradient_accumulation_steps=4),
+        state=state,
+        control=MagicMock(),
+        logs={"loss": 0.123456},
+    )
+
+    log_info.assert_called_once_with(
+        "Training Progress | Progress: 20.00% | Epoch: 20.00% | Step: 8 | Loss: 0.12",
+        extra={
+            "ctx": {
+                "tabular_data": {"progress": 0.2, "epoch": 0.2, "step": 8, "loss": 0.1235},
+                "title": "Training Progress",
+            }
+        },
+    )
 
 
 class TestInferenceEvalCallbackMaxNewTokens:


### PR DESCRIPTION
## Summary
- render training progress as a compact one-line message in plain logs
- preserve structured context for JSON output without duplicating it in the console suffix

## Output examples

Before:

```text
2026-05-28T16:28:20.263 | Nemo Safe Synthesizer | runtime | info | callbacks.py: SafeSynthesizerWorkerCallback.on_log: 391

  Training Progress
+-------------------+
| Metric   | Value  |
|----------+--------|
| Progress | 80.95% |
| Epoch    | 81.60% |
| Step     | 408    |
| Loss     | 0.22   |
+-------------------+
```

After:

```text
2026-05-28T16:28:20.263 | Nemo Safe Synthesizer | runtime | info | callbacks.py: SafeSynthesizerWorkerCallback.on_log: 398
Training Progress | Progress: 80.95% | Epoch: 0.81 | Step: 408 | Loss: 0.22
```

## Test plan
- [x] `uv run --no-sync pytest tests/observability/test_observability.py tests/training/test_callbacks.py -n0 -q`
- [x] `mise run check`

Closes #537

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Training progress logs are now emitted as concise, single-line runtime messages (progress, epoch, step, and loss) instead of table-formatted output.
  * Structured context is preserved for JSON logging, while `"ctx"` is excluded from plain/console “extra” payloads to avoid duplicate display.
  * Updated console table-rendering documentation/behavior to clearly render table data from structured context and append the rendered result to the log message.
* **Tests**
  * Added/updated coverage for compact progress logging and improved assertions for the “without ctx” console behavior while confirming `extra.ctx` remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->