### PR TITLE
fix: add pii replacement time to summary

### DIFF
--- a/src/nemo_safe_synthesizer/results.py
+++ b/src/nemo_safe_synthesizer/results.py
@@ -92,6 +92,7 @@ def make_nss_summary(
 def make_nss_results(
     generate_results: GenerateJobResults | pd.DataFrame,
     total_time: float | None = None,
+    pii_replacer_time: float | None = None,
     training_time: float | None = None,
     generation_time: float | None = None,
     evaluation_time: float | None = None,
@@ -106,6 +107,7 @@ def make_nss_results(
         generate_results: Generation output -- a ``GenerateJobResults`` or
             a raw ``DataFrame`` of synthetic records.
         total_time: Total wall-clock time in seconds.
+        pii_replacer_time: PII replacement phase time in seconds.
         training_time: Training phase time in seconds.
         generation_time: Generation phase time in seconds.
         evaluation_time: Evaluation phase time in seconds.
@@ -121,6 +123,7 @@ def make_nss_results(
     """
     timing = SafeSynthesizerTiming(
         total_time_sec=total_time,
+        pii_replacer_time_sec=pii_replacer_time,
         evaluation_time_sec=evaluation_time,
         training_time_sec=training_time,
         generation_time_sec=generation_time,

--- a/src/nemo_safe_synthesizer/sdk/library_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/library_builder.py
@@ -631,6 +631,7 @@ class SafeSynthesizer(ConfigBuilder):
 
         self.results = make_nss_results(
             total_time=time.monotonic() - self._total_start,
+            pii_replacer_time=self._pii_replacer_time,
             training_time=training_time,
             generation_time=generation_time,
             evaluation_time=evaluation_time,


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->
Fix a little bug where PII Replacer time is not shown in the summary. It used to be None, with the fix, it shows
<img width="254" height="179" alt="image" src="https://github.com/user-attachments/assets/42c0a831-3c61-4783-a734-98d4a94a30f3" />


## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `mise run format && mise run check` or via prek validation.
- [x] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #209 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PII replacement duration to the timing details included in Safe Synthesizer results.
  * Results now consistently report this timing information across evaluation workflows.

* **Bug Fixes**
  * Corrected an issue where PII replacement time was not included in generated result summaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->