### PR TITLE
fix: move container registry to nvcr

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -13,7 +13,7 @@ All workflows that use `.github/actions/setup-python-env` now default to the ver
 | -------------------------------------------------- | --------------------------- | ---------------------------------------------------------------------------------------------------------- |
 | [ci-checks.yml](ci-checks.yml)                     | Push to `main`, PRs, manual | Format, typecheck, unit tests, and CPU smoke tests                                                         |
 | [gpu-tests.yml](gpu-tests.yml)                     | Nightly, manual             | GPU smoke tests (required) and E2E tests                                                                   |
-| [container-build.yml](container-build.yml)         | `v*`, manual                 | Builds the extra-driven GPU container image and publishes GHCR tags for release tags                       |
+| [container-build.yml](container-build.yml)         | `v*`, manual                 | Builds the extra-driven multi-arch GPU container image and publishes NVCR tags for release tags            |
 | [conventional-commit.yml](conventional-commit.yml) | PRs                         | Validates PR titles follow conventional commit format                                                      |
 | [docs.yml](docs.yml)                               | Push to `main` (docs paths) | Publishes `main` docs as the `latest` GitHub Pages version                                                 |
 | [release.yml](release.yml)                         | Push tags to `v*`           | Builds and publishes package to Test PyPI/PyPI, creates a GitHub release, and publishes versioned docs     |
@@ -89,8 +89,8 @@ flowchart LR
     end
 
     subgraph containers [Container Build]
-        buildContainer[Build cu129 Image]
-        publishGhcr[Publish GHCR Tags]
+        buildContainer[Build cu129 Multi-Arch Image]
+        publishNvcr[Publish NVCR Tags]
     end
 
     subgraph internalRelease [Internal Release]
@@ -105,7 +105,7 @@ flowchart LR
     tag[Tag push v[0-9]*] --> release & containers
 
     buildWheel --> publishPyPI --> ghRelease --> slackNotify
-    buildContainer --> publishGhcr
+    buildContainer --> publishNvcr
     buildWheelInt --> publishArtifactory
 
     conventional -.->|reuses| FW-CI-templates

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -34,7 +34,11 @@ permissions:
   packages: write
 
 env:
+  # Release-tag pushes publish to the NVCR staging team. Promotion to the
+  # user-facing NVCR team is a separate release step.
   REGISTRY_IMAGE: nvcr.io/aire/safe-synth-dev/safe-synthesizer
+  # GHCR stores only BuildKit cache layers for GitHub-hosted builds. It is not
+  # used as a distribution registry for Safe-Synthesizer images.
   CACHE_IMAGE: ghcr.io/nvidia-nemo/safe-synthesizer
 
 jobs:
@@ -77,10 +81,12 @@ jobs:
         if: github.event_name == 'push'
         shell: bash -e -u -o pipefail {0}
         env:
-          NVCR_TOKEN: ${{ secrets.NVCR_AIRE_SAFE_SYN_DEPLOY_KEY }}
+          # Prefer the full project secret name; keep the legacy name as a
+          # temporary fallback until the repo secret is rotated.
+          NVCR_TOKEN: ${{ secrets.NVCR_AIRE_SAFE_SYNTHESIZER_DEPLOY_KEY || secrets.NVCR_AIRE_SAFE_SYN_DEPLOY_KEY }}
         run: |
           if [[ -z "${NVCR_TOKEN}" ]]; then
-            echo "::error::Missing required secret NVCR_AIRE_SAFE_SYN_DEPLOY_KEY"
+            echo "::error::Missing required secret NVCR_AIRE_SAFE_SYNTHESIZER_DEPLOY_KEY"
             exit 1
           fi
 
@@ -90,7 +96,7 @@ jobs:
         with:
           registry: nvcr.io
           username: '$oauthtoken'
-          password: ${{ secrets.NVCR_AIRE_SAFE_SYN_DEPLOY_KEY }}
+          password: ${{ secrets.NVCR_AIRE_SAFE_SYNTHESIZER_DEPLOY_KEY || secrets.NVCR_AIRE_SAFE_SYN_DEPLOY_KEY }}
 
       - name: Log in to GHCR cache registry
         if: github.event_name == 'push'

--- a/.github/workflows/container-build.yml
+++ b/.github/workflows/container-build.yml
@@ -30,10 +30,12 @@ concurrency:
 
 permissions:
   contents: read
+  # Used only for the GHCR BuildKit cache. Published images go to NVCR.
   packages: write
 
 env:
-  REGISTRY_IMAGE: ghcr.io/nvidia-nemo/safe-synthesizer
+  REGISTRY_IMAGE: nvcr.io/aire/safe-synth-dev/safe-synthesizer
+  CACHE_IMAGE: ghcr.io/nvidia-nemo/safe-synthesizer
 
 jobs:
   build:
@@ -45,7 +47,7 @@ jobs:
         include:
           - variant: cu129
             extra: cu129
-            platforms: linux/amd64
+            platforms: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -63,10 +65,34 @@ jobs:
           fi
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - name: Log in to GHCR
+      - name: Check NVCR deploy key
+        if: github.event_name == 'push'
+        shell: bash -e -u -o pipefail {0}
+        env:
+          NVCR_TOKEN: ${{ secrets.NVCR_AIRE_SAFE_SYN_DEPLOY_KEY }}
+        run: |
+          if [[ -z "${NVCR_TOKEN}" ]]; then
+            echo "::error::Missing required secret NVCR_AIRE_SAFE_SYN_DEPLOY_KEY"
+            exit 1
+          fi
+
+      - name: Log in to NVCR
+        if: github.event_name == 'push'
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: nvcr.io
+          username: '$oauthtoken'
+          password: ${{ secrets.NVCR_AIRE_SAFE_SYN_DEPLOY_KEY }}
+
+      - name: Log in to GHCR cache registry
         if: github.event_name == 'push'
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
@@ -107,8 +133,8 @@ jobs:
             PACKAGE_VERSION=${{ steps.package-version.outputs.version }}
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
-          cache-from: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.variant }}
-          cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.variant }},mode=max,oci-mediatypes=true,image-manifest=true
+          cache-from: type=registry,ref=${{ env.CACHE_IMAGE }}:buildcache-${{ matrix.variant }}
+          cache-to: type=registry,ref=${{ env.CACHE_IMAGE }}:buildcache-${{ matrix.variant }},mode=max,oci-mediatypes=true,image-manifest=true
 
       - name: Build image
         if: github.event_name != 'push'

--- a/containers/README.md
+++ b/containers/README.md
@@ -113,12 +113,12 @@ CONTAINER_GPU_PLATFORM=linux/arm64 mise run container:build:gpu
 Multi-platform manifests must be pushed to a registry:
 
 ```bash
-CONTAINER_GPU_REGISTRY=ghcr.io/nvidia-nemo mise run container:build:gpu-multiarch
+CONTAINER_GPU_REGISTRY=nvcr.io/aire/safe-synth-dev mise run container:build:gpu-multiarch
 ```
 
 This builds and pushes `$(CONTAINER_GPU_REGISTRY)/$(CONTAINER_GPU_IMAGE)`.
-Confirm the selected Python extra has wheels for every requested architecture
-before enabling a platform in CI.
+The release workflow uses this same multi-platform build for `linux/amd64` and
+`linux/arm64`.
 
 ## CPU Test Image
 

--- a/docs/developer-guide/docker.md
+++ b/docs/developer-guide/docker.md
@@ -187,7 +187,10 @@ Overridable variables:
 Manual dispatch works for branch validation after this workflow exists on the
 default branch. Manual runs build the image without pushing it.
 
-The workflow pushes images only for release tag `push` events.
+The workflow pushes images only for release tag `push` events. It builds a
+multi-platform manifest for `linux/amd64` and `linux/arm64`, logs in to
+`nvcr.io` with the repo secret `NVCR_AIRE_SAFE_SYN_DEPLOY_KEY`, and publishes
+under the `aire/safe-synth-dev` team.
 
 Build cache is exported to a dedicated GHCR registry cache tag,
 `buildcache-<variant>`, only for release tag events that can push packages. The
@@ -198,7 +201,7 @@ Actions cache quota and slow down cache export.
 Current image name:
 
 ```text
-ghcr.io/nvidia-nemo/safe-synthesizer
+nvcr.io/aire/safe-synth-dev/safe-synthesizer
 ```
 
 On release tags, current `cu129` tags include:
@@ -206,6 +209,9 @@ On release tags, current `cu129` tags include:
 - `cu129` and `latest-cu129`
 - `<version>-cu129` and `<major>.<minor>-cu129` on `v*` tags
 - `sha-<short-sha>-cu129` for traceability
+
+Each tag points to a multi-platform manifest with `linux/amd64` and
+`linux/arm64` images.
 
 The workflow passes `PACKAGE_VERSION` into the Docker build. On release tags,
 this is the tag without the leading `v`; on non-tag builds, it is
@@ -277,7 +283,7 @@ single tag. Clients pull the correct variant automatically. Because
 directly to a registry:
 
 ```bash
-CONTAINER_GPU_REGISTRY=ghcr.io/nvidia-nemo mise run container:build:gpu-multiarch
+CONTAINER_GPU_REGISTRY=nvcr.io/aire/safe-synth-dev mise run container:build:gpu-multiarch
 ```
 
 This runs:
@@ -285,7 +291,7 @@ This runs:
 ```bash
 docker buildx build \
   --platform linux/amd64,linux/arm64 \
-  --tag ghcr.io/nvidia-nemo/nss-gpu:latest \
+  --tag nvcr.io/aire/safe-synth-dev/nss-gpu:latest \
   --target runtime --push \
   -f containers/Dockerfile.cuda .
 ```

--- a/docs/developer-guide/docker.md
+++ b/docs/developer-guide/docker.md
@@ -189,16 +189,22 @@ default branch. Manual runs build the image without pushing it.
 
 The workflow pushes images only for release tag `push` events. It builds a
 multi-platform manifest for `linux/amd64` and `linux/arm64`, logs in to
-`nvcr.io` with the repo secret `NVCR_AIRE_SAFE_SYN_DEPLOY_KEY`, and publishes
-under the `aire/safe-synth-dev` team.
+`nvcr.io` with the repo secret `NVCR_AIRE_SAFE_SYNTHESIZER_DEPLOY_KEY`, and
+publishes under the `aire/safe-synth-dev` team. The workflow also accepts the
+legacy `NVCR_AIRE_SAFE_SYN_DEPLOY_KEY` secret while the repository secret is
+rotated to the full project name. The `safe-synth-dev` team is the release
+workflow's staging namespace; promotion to the user-facing NVCR team is handled
+as a separate release step.
 
 Build cache is exported to a dedicated GHCR registry cache tag,
-`buildcache-<variant>`, only for release tag events that can push packages. The
-workflow does not use the GitHub Actions cache backend for Docker layers
-because the CUDA dependency layers are large enough to churn the default
-Actions cache quota and slow down cache export.
+`buildcache-<variant>`, only for release tag events that can push packages.
+GHCR is used only for BuildKit cache artifacts because this job runs in GitHub
+Actions; published runtime images go to NVCR. The workflow does not use the
+GitHub Actions cache backend for Docker layers because the CUDA dependency
+layers are large enough to churn the default Actions cache quota and slow down
+cache export.
 
-Current image name:
+Current workflow image name before promotion:
 
 ```text
 nvcr.io/aire/safe-synth-dev/safe-synthesizer


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
* Set up arm variant
* Push to nvcr instead of ghcr

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GPU container images are now built for both Linux AMD64 and ARM64 architectures.
  * Release-tagged images are published to the NVIDIA container registry.

* **Documentation**
  * Updated workflow diagrams and container documentation with the new registry location, image naming, release behavior, and multi-platform usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->