### PR TITLE
feat(config): add strict config validation

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -150,6 +150,8 @@ jobs:
         run: mise run build-wheel
 
       - name: Verify clean end-user wheel install
+        env:
+          CONTAINER_CMD: docker
         run: mise run release:verify-wheel
 
   unit-test:

--- a/docs/developer-guide/configuration_management.md
+++ b/docs/developer-guide/configuration_management.md
@@ -91,14 +91,19 @@ The shared `pydantic_model_config` sets `arbitrary_types_allowed`,
 `protected_namespaces=()`, and `json_schema_mode_override="validation"`.
 
 `SafeSynthesizerParameters.unknown_fields` controls Pydantic's recursive
-unknown-field policy at raw-input boundaries. The default, `"reject"`, maps to
-`extra="forbid"`; `"ignore"` maps to `extra="ignore"` for version-skew
-compatibility. Sparse patch compilation and SDK raw-mapping builders use the
-same effective setting. Complete inputs use the field default when it is
-omitted; partial patches inherit the existing configuration's policy. Reject
-mode preserves unknown keys until Pydantic reports them, while ignore mode
-filters them during normalization. Retaining undeclared fields with
-`extra="allow"` is unsupported because Safe Synthesizer cannot act on them.
+unknown-field policy at raw-input boundaries:
+
+- `"reject"` is the default and maps to `extra="forbid"`. Normalization
+  preserves unknown keys until Pydantic reports them.
+- `"ignore"` maps to `extra="ignore"` for compatibility with stale
+  configurations and notebooks or mismatched client and service versions.
+  Normalization filters unknown keys.
+- `extra="allow"` is unsupported because Safe Synthesizer cannot act on
+  undeclared fields.
+
+Sparse patch compilation and SDK raw-mapping builders use the same effective
+setting. Complete inputs use the field default when it is omitted; partial
+patches inherit the existing configuration's policy.
 
 ## Adding a Config Field
 

--- a/docs/developer-guide/configuration_management.md
+++ b/docs/developer-guide/configuration_management.md
@@ -93,8 +93,9 @@ The shared `pydantic_model_config` sets `arbitrary_types_allowed`,
 `SafeSynthesizerParameters.strict_config` separately controls Pydantic's
 recursive unknown-field policy at raw-input boundaries. The default is to pass
 `extra="forbid"`; `strict_config: false` passes `extra="ignore"`. Sparse patch
-compilation and SDK raw-mapping builders must use the same effective setting so
-they do not discard unknown keys before top-level validation can inspect them.
+compilation and SDK raw-mapping builders must use the same effective setting.
+Strict mode preserves unknown keys until Pydantic rejects them; non-strict mode
+filters unknown keys while normalizing the input.
 
 ## Adding a Config Field
 

--- a/docs/developer-guide/configuration_management.md
+++ b/docs/developer-guide/configuration_management.md
@@ -90,6 +90,12 @@ The shared `pydantic_model_config` sets `arbitrary_types_allowed`,
 `validation_error_cause`, `from_attributes`, `validate_default`,
 `protected_namespaces=()`, and `json_schema_mode_override="validation"`.
 
+`SafeSynthesizerParameters.strict_config` separately controls Pydantic's
+recursive unknown-field policy at raw-input boundaries. The default is to pass
+`extra="forbid"`; `strict_config: false` passes `extra="ignore"`. Sparse patch
+compilation and SDK raw-mapping builders must use the same effective setting so
+they do not discard unknown keys before top-level validation can inspect them.
+
 ## Adding a Config Field
 
 Add the field to the relevant parameter model. The CLI option is generated

--- a/docs/developer-guide/configuration_management.md
+++ b/docs/developer-guide/configuration_management.md
@@ -90,12 +90,15 @@ The shared `pydantic_model_config` sets `arbitrary_types_allowed`,
 `validation_error_cause`, `from_attributes`, `validate_default`,
 `protected_namespaces=()`, and `json_schema_mode_override="validation"`.
 
-`SafeSynthesizerParameters.strict_config` separately controls Pydantic's
-recursive unknown-field policy at raw-input boundaries. The default is to pass
-`extra="forbid"`; `strict_config: false` passes `extra="ignore"`. Sparse patch
-compilation and SDK raw-mapping builders must use the same effective setting.
-Strict mode preserves unknown keys until Pydantic rejects them; non-strict mode
-filters unknown keys while normalizing the input.
+`SafeSynthesizerParameters.unknown_fields` controls Pydantic's recursive
+unknown-field policy at raw-input boundaries. The default, `"reject"`, maps to
+`extra="forbid"`; `"ignore"` maps to `extra="ignore"` for version-skew
+compatibility. Sparse patch compilation and SDK raw-mapping builders use the
+same effective setting. Complete inputs use the field default when it is
+omitted; partial patches inherit the existing configuration's policy. Reject
+mode preserves unknown keys until Pydantic reports them, while ignore mode
+filters them during normalization. Retaining undeclared fields with
+`extra="allow"` is unsupported because Safe Synthesizer cannot act on them.
 
 ## Adding a Config Field
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -147,10 +147,12 @@ an atomic leaf raise an error.
 ### Resume-Time Overrides
 
 When generation resumes from a saved training run, runtime configuration may
-override only `generation`, `evaluation`, and `emit_telemetry`. Telemetry is
-overridden only when the runtime input explicitly sets it. Saved `training`,
-`data`, `privacy`, PII replacement, time-series, and preflight settings remain
-unchanged.
+override only `generation`, `evaluation`, `emit_telemetry`, and `strict_config`.
+Telemetry and strictness are overridden only when the runtime input explicitly
+sets them. An explicit `strict_config: false` is applied while loading the saved
+configuration, allowing legacy fields to be ignored when client and service
+versions differ. Saved `training`, `data`, `privacy`, PII replacement,
+time-series, and preflight settings remain unchanged.
 
 ---
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -26,19 +26,21 @@ This catches misspelled sections and parameters before a run starts, for
 example `evaluate` instead of `evaluation` or `training.epoch` when no such
 training parameter exists.
 
-Set `strict_config: false` at the top level only when a configuration must pass
-between mismatched client and service versions that may not recognize the same
-fields:
+Set `unknown_fields: ignore` at the top level only when a configuration must
+pass between mismatched client and service versions that may not recognize the
+same fields:
 
 ```yaml
-strict_config: false
+unknown_fields: ignore
 training:
   batch_size: 4
 ```
 
-The setting applies to the same configuration input in which it appears and is
-preserved in serialized configurations. It controls unknown keys only; normal
-Pydantic value validation and type coercion are unchanged.
+The default is `unknown_fields: reject`. The setting applies to the same
+configuration input in which it appears and is preserved in serialized
+configurations. It controls unknown keys only; normal Pydantic value validation
+and type coercion are unchanged. Undeclared fields cannot be retained because
+Safe Synthesizer would not act on them.
 
 ### Examples
 
@@ -128,6 +130,13 @@ retain the current lower-precedence configuration values:
 synthesizer.with_generate({"temperature": 0.8}, num_records=2000)
 ```
 
+Set an SDK-wide compatibility policy when constructing the builder so it
+applies before any raw section mapping is validated:
+
+```python
+synthesizer = SafeSynthesizer(unknown_fields="ignore")
+```
+
 A mapping is a branch only when its schema field is another Pydantic model.
 Mapping-valued leaf fields, such as free-form dictionaries, are replaced as one
 atomic value rather than recursively merged.
@@ -138,21 +147,22 @@ so an in-place mutation such as
 `source.validation.group_by_fix_unordered_records = True` is captured when that
 model is used as a patch input. Unrelated defaults remain implicit.
 
-Raw mapping sources follow the effective top-level `strict_config` setting.
-They reject unknown extra keys by default and ignore them when strict config
-validation is disabled. After a name has been resolved to a canonical path,
+Raw mapping sources follow the effective top-level `unknown_fields` setting.
+They reject unknown extra keys by default and discard them when the policy is
+`ignore`. After a name has been resolved to a canonical path,
 however, that path remains strict: unknown paths and paths that descend through
 an atomic leaf raise an error.
 
 ### Resume-Time Overrides
 
 When generation resumes from a saved training run, runtime configuration may
-override only `generation`, `evaluation`, `emit_telemetry`, and `strict_config`.
-Telemetry and strictness are overridden only when the runtime input explicitly
-sets them. An explicit `strict_config: false` is applied while loading the saved
-configuration, allowing legacy fields to be ignored when client and service
-versions differ. Saved `training`, `data`, `privacy`, PII replacement,
-time-series, and preflight settings remain unchanged.
+override only `generation`, `evaluation`, `emit_telemetry`, and
+`unknown_fields`. Telemetry and the unknown-field policy are overridden only
+when the runtime input explicitly sets them. An explicit
+`unknown_fields: ignore` is applied while loading the saved configuration,
+allowing legacy fields to be discarded when client and service versions differ.
+Saved `training`, `data`, `privacy`, PII replacement, time-series, and preflight
+settings remain unchanged.
 
 ---
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -19,6 +19,27 @@ Exactly what avenues of configuration are available, and thus how precedence is 
 Each layer only overrides what it explicitly sets -- everything else falls
 through to the next layer.
 
+### Unknown Configuration Keys
+
+Safe Synthesizer rejects unknown configuration keys recursively by default.
+This catches misspelled sections and parameters before a run starts, for
+example `evaluate` instead of `evaluation` or `training.epoch` when no such
+training parameter exists.
+
+Set `strict_config: false` at the top level only when a configuration must pass
+between mismatched client and service versions that may not recognize the same
+fields:
+
+```yaml
+strict_config: false
+training:
+  batch_size: 4
+```
+
+The setting applies to the same configuration input in which it appears and is
+preserved in serialized configurations. It controls unknown keys only; normal
+Pydantic value validation and type coercion are unchanged.
+
 ### Examples
 
 Start from model defaults, override one field via CLI:
@@ -117,10 +138,11 @@ so an in-place mutation such as
 `source.validation.group_by_fix_unordered_records = True` is captured when that
 model is used as a patch input. Unrelated defaults remain implicit.
 
-Raw mapping sources retain the established behavior of ignoring unknown extra
-keys. After a name has been resolved to a canonical path, however, that path is
-strict: unknown paths and paths that descend through an atomic leaf raise an
-error.
+Raw mapping sources follow the effective top-level `strict_config` setting.
+They reject unknown extra keys by default and ignore them when strict config
+validation is disabled. After a name has been resolved to a canonical path,
+however, that path remains strict: unknown paths and paths that descend through
+an atomic leaf raise an error.
 
 ### Resume-Time Overrides
 

--- a/src/nemo_safe_synthesizer/config/job.py
+++ b/src/nemo_safe_synthesizer/config/job.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from .base import NSSBaseModel
 from .parameters import (
@@ -29,3 +29,11 @@ class SafeSynthesizerJobConfig(NSSBaseModel):
         description="Name of platform secret containing the HuggingFace token. "
         "Must exist in the same workspace as the job.",
     )
+
+    @field_validator("config", mode="before")
+    @classmethod
+    def _validate_config_with_its_unknown_field_policy(cls, value: object) -> object:
+        """Preserve dynamic strictness when parameters are nested in a service payload."""
+        if isinstance(value, SafeSynthesizerParameters):
+            return value
+        return SafeSynthesizerParameters.model_validate(value)

--- a/src/nemo_safe_synthesizer/config/job.py
+++ b/src/nemo_safe_synthesizer/config/job.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from .base import NSSBaseModel
 from .parameters import (
@@ -29,11 +29,3 @@ class SafeSynthesizerJobConfig(NSSBaseModel):
         description="Name of platform secret containing the HuggingFace token. "
         "Must exist in the same workspace as the job.",
     )
-
-    @field_validator("config", mode="before")
-    @classmethod
-    def _validate_config_with_its_unknown_field_policy(cls, value: object) -> object:
-        """Preserve dynamic strictness when parameters are nested in a service payload."""
-        if isinstance(value, SafeSynthesizerParameters):
-            return value
-        return SafeSynthesizerParameters.model_validate(value)

--- a/src/nemo_safe_synthesizer/config/parameters.py
+++ b/src/nemo_safe_synthesizer/config/parameters.py
@@ -133,9 +133,9 @@ class SafeSynthesizerParameters(Parameters):
             extra=type(self)._extra_behavior(data),
         )
 
-    # Preserve Pydantic's normal model-validation path: this initializer only
-    # selects the extras policy for direct ``Model(...)`` construction.
-    setattr(__init__, "__pydantic_base_init__", True)
+    # Pydantic marks its own BaseModel initializer this way so the model
+    # metaclass does not treat this equivalent initializer as a custom one.
+    cast(Any, __init__).__pydantic_base_init__ = True
 
     @classmethod
     @override
@@ -154,7 +154,7 @@ class SafeSynthesizerParameters(Parameters):
         return super().model_validate(
             obj,
             strict=strict,
-            extra=extra or cls._extra_behavior(obj),
+            extra=extra if extra is not None else cls._extra_behavior(obj),
             from_attributes=from_attributes,
             context=context,
             by_alias=by_alias,
@@ -321,13 +321,13 @@ class SafeSynthesizerParameters(Parameters):
         return base.combine(override).apply()
 
     def with_runtime_overrides(self, runtime: SafeSynthesizerParameters) -> "SafeSynthesizerParameters":
-        """Apply resume-time generation/evaluation/telemetry overrides onto a copy of self.
+        """Apply supported resume-time overrides onto a copy of self.
 
         ``self`` is the saved training-run config. Only explicitly-set
         ``generation`` and ``evaluation`` fields from ``runtime`` are merged in,
-        plus ``emit_telemetry`` when the caller set it. Training, data, privacy,
-        and other sections are preserved so training provenance survives a
-        generate-only resume.
+        plus ``emit_telemetry`` and ``strict_config`` when the caller set them.
+        Training, data, privacy, and other sections are preserved so training
+        provenance survives a generate-only resume.
 
         Args:
             runtime: Config carrying resume-time CLI/SDK overrides. Typically

--- a/src/nemo_safe_synthesizer/config/parameters.py
+++ b/src/nemo_safe_synthesizer/config/parameters.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Mapping
-from typing import Self, TypeAlias
+from typing import Any, ClassVar, Literal, Self, TypeAlias, cast
 
-from pydantic import Field, model_validator
+from pydantic import Field, TypeAdapter, model_validator
 from typing_extensions import override
 
 from ..configurator.parameter_paths import (
@@ -35,6 +35,9 @@ __all__ = ["ConfigPatch", "SafeSynthesizerParameters"]
 
 
 logger = get_logger(__name__)
+
+
+_ExtraBehavior = Literal["ignore", "forbid"]
 
 
 class SafeSynthesizerParameters(Parameters):
@@ -92,6 +95,71 @@ class SafeSynthesizerParameters(Parameters):
             "Defaults from NEMO_TELEMETRY_ENABLED when unset."
         ),
     )
+
+    strict_config: bool = Field(
+        default=True,
+        description=(
+            "Whether unknown configuration keys are rejected recursively. "
+            "Disable only when compatibility across mismatched client and service versions is required."
+        ),
+    )
+
+    _strict_config_adapter: ClassVar[TypeAdapter[bool]] = TypeAdapter(bool)
+
+    @classmethod
+    def _strict_config_enabled(cls, value: object = True) -> bool:
+        """Validate and resolve the user-facing unknown-field policy flag."""
+        return cls._strict_config_adapter.validate_python(value)
+
+    @classmethod
+    def _strict_config_from_mapping(cls, source: Mapping[str, object], *, default: bool = True) -> bool:
+        return cls._strict_config_enabled(source.get("strict_config", default))
+
+    @classmethod
+    def _extra_behavior(cls, source: object, *, default: bool = True) -> _ExtraBehavior:
+        if isinstance(source, SafeSynthesizerParameters):
+            enabled = source.strict_config
+        elif isinstance(source, Mapping):
+            enabled = cls._strict_config_from_mapping(cast(Mapping[str, object], source), default=default)
+        else:
+            enabled = default
+        return "forbid" if enabled else "ignore"
+
+    def __init__(self, /, **data: Any) -> None:
+        """Validate constructor input with the input's recursive unknown-field policy."""
+        self.__pydantic_validator__.validate_python(
+            data,
+            self_instance=self,
+            extra=type(self)._extra_behavior(data),
+        )
+
+    # Preserve Pydantic's normal model-validation path: this initializer only
+    # selects the extras policy for direct ``Model(...)`` construction.
+    setattr(__init__, "__pydantic_base_init__", True)
+
+    @classmethod
+    @override
+    def model_validate(
+        cls,
+        obj: Any,
+        *,
+        strict: bool | None = None,
+        extra: Literal["allow", "ignore", "forbid"] | None = None,
+        from_attributes: bool | None = None,
+        context: Any | None = None,
+        by_alias: bool | None = None,
+        by_name: bool | None = None,
+    ) -> Self:
+        """Validate input using ``strict_config`` as the recursive extras policy."""
+        return super().model_validate(
+            obj,
+            strict=strict,
+            extra=extra or cls._extra_behavior(obj),
+            from_attributes=from_attributes,
+            context=context,
+            by_alias=by_alias,
+            by_name=by_name,
+        )
 
     @model_validator(mode="after")
     def _validate_and_resolve_data_params(self) -> Self:
@@ -194,11 +262,36 @@ class SafeSynthesizerParameters(Parameters):
         return CompiledConfigPatch.from_paths(cls, assignments).apply()
 
     @classmethod
+    @override
+    def from_config_source(
+        cls,
+        source: Parameters | Mapping[str, object] | None = None,
+        *,
+        unknown_fields: Literal["ignore", "reject"] | None = None,
+        **kwargs: object,
+    ) -> Self:
+        """Normalize a source using its effective ``strict_config`` policy."""
+        if unknown_fields is None:
+            if isinstance(source, Mapping):
+                enabled = (
+                    cls._strict_config_enabled(kwargs["strict_config"])
+                    if "strict_config" in kwargs
+                    else cls._strict_config_from_mapping(cast(Mapping[str, object], source))
+                )
+            elif isinstance(source, SafeSynthesizerParameters):
+                enabled = source.strict_config
+            else:
+                enabled = cls._strict_config_enabled(kwargs.get("strict_config", True))
+            unknown_fields = "reject" if enabled else "ignore"
+        return cast(Self, super().from_config_source(source, unknown_fields=unknown_fields, **kwargs))
+
+    @classmethod
     def from_config_patch(cls, patch: ConfigPatch) -> Self:
         """Validate a sparse top-level config patch as a full configuration."""
         normalized = ParameterSchema.from_model(cls).normalize_aliases(patch)
+        unknown_fields = "reject" if cls._strict_config_from_mapping(normalized) else "ignore"
         return CompiledConfigPatch.from_mapping(
-            cls, normalized, origin="config patch", precedence=0, unknown_fields="ignore"
+            cls, normalized, origin="config patch", precedence=0, unknown_fields=unknown_fields
         ).apply()
 
     def with_config_patch(self, patch: ConfigPatch) -> Self:
@@ -217,8 +310,13 @@ class SafeSynthesizerParameters(Parameters):
             unknown_fields="reject",
         )
         normalized = ParameterSchema.from_model(model_type).normalize_aliases(patch)
+        strict_config = model_type._strict_config_from_mapping(normalized, default=self.strict_config)
         override = CompiledConfigPatch.from_mapping(
-            model_type, normalized, origin="config patch", precedence=1, unknown_fields="ignore"
+            model_type,
+            normalized,
+            origin="config patch",
+            precedence=1,
+            unknown_fields="reject" if strict_config else "ignore",
         )
         return base.combine(override).apply()
 
@@ -251,6 +349,8 @@ class SafeSynthesizerParameters(Parameters):
         _add_section("evaluation", runtime.evaluation)
         if "emit_telemetry" in runtime.model_fields_set:
             updates["emit_telemetry"] = runtime.emit_telemetry
+        if "strict_config" in runtime.model_fields_set:
+            updates["strict_config"] = runtime.strict_config
         patch = CompiledConfigPatch.from_mapping(
             type(self),
             updates,

--- a/src/nemo_safe_synthesizer/config/parameters.py
+++ b/src/nemo_safe_synthesizer/config/parameters.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Mapping
-from typing import Any, ClassVar, Literal, Self, TypeAlias, cast
+from typing import Self, TypeAlias, cast
 
-from pydantic import Field, TypeAdapter, model_validator
+from pydantic import Field, model_validator
 from typing_extensions import override
 
 from ..configurator.parameter_paths import (
@@ -28,6 +28,12 @@ from .replace_pii import PiiReplacerConfig
 from .time_series import TimeSeriesParameters
 from .training import TrainingHyperparams
 from .types import AUTO_STR
+from .unknown_fields import (
+    DEFAULT_UNKNOWN_FIELDS,
+    UnknownFieldBehavior,
+    normalize_unknown_fields,
+    validate_unknown_fields,
+)
 
 ConfigPatch: TypeAlias = Mapping[str, object]
 
@@ -35,9 +41,6 @@ __all__ = ["ConfigPatch", "SafeSynthesizerParameters"]
 
 
 logger = get_logger(__name__)
-
-
-_ExtraBehavior = Literal["ignore", "forbid"]
 
 
 class SafeSynthesizerParameters(Parameters):
@@ -96,70 +99,33 @@ class SafeSynthesizerParameters(Parameters):
         ),
     )
 
-    strict_config: bool = Field(
-        default=True,
+    unknown_fields: UnknownFieldBehavior = Field(
+        default=DEFAULT_UNKNOWN_FIELDS,
         description=(
-            "Whether unknown configuration keys are rejected recursively. "
-            "Disable only when compatibility across mismatched client and service versions is required."
+            "How unknown configuration keys are handled recursively. "
+            "Use 'ignore' only for compatibility across mismatched client and service versions."
         ),
     )
 
-    _strict_config_adapter: ClassVar[TypeAdapter[bool]] = TypeAdapter(bool)
-
     @classmethod
-    def _strict_config_enabled(cls, value: object = True) -> bool:
-        """Validate and resolve the user-facing unknown-field policy flag."""
-        return cls._strict_config_adapter.validate_python(value)
+    def _unknown_fields_from_input(cls, source: object) -> UnknownFieldBehavior:
+        """Resolve the policy declared by a complete configuration input."""
+        if isinstance(source, cls):
+            return source.unknown_fields
+        if isinstance(source, Mapping):
+            mapping = cast(Mapping[str, object], source)
+            return validate_unknown_fields(mapping.get("unknown_fields", DEFAULT_UNKNOWN_FIELDS))
+        return DEFAULT_UNKNOWN_FIELDS
 
+    @model_validator(mode="before")
     @classmethod
-    def _strict_config_from_mapping(cls, source: Mapping[str, object], *, default: bool = True) -> bool:
-        return cls._strict_config_enabled(source.get("strict_config", default))
-
-    @classmethod
-    def _extra_behavior(cls, source: object, *, default: bool = True) -> _ExtraBehavior:
-        if isinstance(source, SafeSynthesizerParameters):
-            enabled = source.strict_config
-        elif isinstance(source, Mapping):
-            enabled = cls._strict_config_from_mapping(cast(Mapping[str, object], source), default=default)
-        else:
-            enabled = default
-        return "forbid" if enabled else "ignore"
-
-    def __init__(self, /, **data: Any) -> None:
-        """Validate constructor input with the input's recursive unknown-field policy."""
-        self.__pydantic_validator__.validate_python(
-            data,
-            self_instance=self,
-            extra=type(self)._extra_behavior(data),
-        )
-
-    # Pydantic marks its own BaseModel initializer this way so the model
-    # metaclass does not treat this equivalent initializer as a custom one.
-    cast(Any, __init__).__pydantic_base_init__ = True
-
-    @classmethod
-    @override
-    def model_validate(
-        cls,
-        obj: Any,
-        *,
-        strict: bool | None = None,
-        extra: Literal["allow", "ignore", "forbid"] | None = None,
-        from_attributes: bool | None = None,
-        context: Any | None = None,
-        by_alias: bool | None = None,
-        by_name: bool | None = None,
-    ) -> Self:
-        """Validate input using ``strict_config`` as the recursive extras policy."""
-        return super().model_validate(
-            obj,
-            strict=strict,
-            extra=extra if extra is not None else cls._extra_behavior(obj),
-            from_attributes=from_attributes,
-            context=context,
-            by_alias=by_alias,
-            by_name=by_name,
-        )
+    def _normalize_unknown_field_policy(cls, value: object) -> object:
+        """Apply the declared policy before the model tree is validated."""
+        if not isinstance(value, Mapping):
+            return value
+        mapping = cast(Mapping[str, object], value)
+        unknown_fields = cls._unknown_fields_from_input(mapping)
+        return normalize_unknown_fields(cls, mapping, unknown_fields)
 
     @model_validator(mode="after")
     def _validate_and_resolve_data_params(self) -> Self:
@@ -266,30 +232,27 @@ class SafeSynthesizerParameters(Parameters):
     def from_config_source(
         cls,
         source: Parameters | Mapping[str, object] | None = None,
-        *,
-        unknown_fields: Literal["ignore", "reject"] | None = None,
         **kwargs: object,
     ) -> Self:
-        """Normalize a source using its effective ``strict_config`` policy."""
-        if unknown_fields is None:
-            if isinstance(source, Mapping):
-                enabled = (
-                    cls._strict_config_enabled(kwargs["strict_config"])
-                    if "strict_config" in kwargs
-                    else cls._strict_config_from_mapping(cast(Mapping[str, object], source))
-                )
-            elif isinstance(source, SafeSynthesizerParameters):
-                enabled = source.strict_config
-            else:
-                enabled = cls._strict_config_enabled(kwargs.get("strict_config", True))
-            unknown_fields = "reject" if enabled else "ignore"
-        return cast(Self, super().from_config_source(source, unknown_fields=unknown_fields, **kwargs))
+        """Normalize a source using its effective unknown-field policy."""
+        if "unknown_fields" in kwargs:
+            unknown_field_behavior = validate_unknown_fields(kwargs["unknown_fields"])
+        else:
+            unknown_field_behavior = cls._unknown_fields_from_input(source)
+        return cast(
+            Self,
+            super().from_config_source(
+                source,
+                unknown_field_behavior=unknown_field_behavior,
+                **kwargs,
+            ),
+        )
 
     @classmethod
     def from_config_patch(cls, patch: ConfigPatch) -> Self:
         """Validate a sparse top-level config patch as a full configuration."""
         normalized = ParameterSchema.from_model(cls).normalize_aliases(patch)
-        unknown_fields = "reject" if cls._strict_config_from_mapping(normalized) else "ignore"
+        unknown_fields = cls._unknown_fields_from_input(normalized)
         return CompiledConfigPatch.from_mapping(
             cls, normalized, origin="config patch", precedence=0, unknown_fields=unknown_fields
         ).apply()
@@ -310,13 +273,17 @@ class SafeSynthesizerParameters(Parameters):
             unknown_fields="reject",
         )
         normalized = ParameterSchema.from_model(model_type).normalize_aliases(patch)
-        strict_config = model_type._strict_config_from_mapping(normalized, default=self.strict_config)
+        unknown_fields = (
+            validate_unknown_fields(normalized["unknown_fields"])
+            if "unknown_fields" in normalized
+            else self.unknown_fields
+        )
         override = CompiledConfigPatch.from_mapping(
             model_type,
             normalized,
             origin="config patch",
             precedence=1,
-            unknown_fields="reject" if strict_config else "ignore",
+            unknown_fields=unknown_fields,
         )
         return base.combine(override).apply()
 
@@ -325,7 +292,7 @@ class SafeSynthesizerParameters(Parameters):
 
         ``self`` is the saved training-run config. Only explicitly-set
         ``generation`` and ``evaluation`` fields from ``runtime`` are merged in,
-        plus ``emit_telemetry`` and ``strict_config`` when the caller set them.
+        plus ``emit_telemetry`` and ``unknown_fields`` when the caller set them.
         Training, data, privacy, and other sections are preserved so training
         provenance survives a generate-only resume.
 
@@ -349,8 +316,8 @@ class SafeSynthesizerParameters(Parameters):
         _add_section("evaluation", runtime.evaluation)
         if "emit_telemetry" in runtime.model_fields_set:
             updates["emit_telemetry"] = runtime.emit_telemetry
-        if "strict_config" in runtime.model_fields_set:
-            updates["strict_config"] = runtime.strict_config
+        if "unknown_fields" in runtime.model_fields_set:
+            updates["unknown_fields"] = runtime.unknown_fields
         patch = CompiledConfigPatch.from_mapping(
             type(self),
             updates,

--- a/src/nemo_safe_synthesizer/config/parameters.py
+++ b/src/nemo_safe_synthesizer/config/parameters.py
@@ -103,7 +103,8 @@ class SafeSynthesizerParameters(Parameters):
         default=DEFAULT_UNKNOWN_FIELDS,
         description=(
             "How unknown configuration keys are handled recursively. "
-            "Use 'ignore' only for compatibility across mismatched client and service versions."
+            "Use 'ignore' only for compatibility with stale configurations and notebooks "
+            "or mismatched client and service versions."
         ),
     )
 

--- a/src/nemo_safe_synthesizer/config/patch.py
+++ b/src/nemo_safe_synthesizer/config/patch.py
@@ -8,16 +8,16 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Generic, Literal, TypeAlias, TypeVar, cast
+from typing import Generic, TypeVar, cast
 
 from pydantic import BaseModel
 
 from ..configurator.parameter_paths import ParameterPath, format_parameter_path
 from ..configurator.pydantic_compat import nested_model_type
 from ..errors import ParameterError
+from .unknown_fields import UnknownFieldBehavior
 
 ModelT = TypeVar("ModelT", bound=BaseModel)
-UnknownFieldBehavior: TypeAlias = Literal["ignore", "reject"]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/nemo_safe_synthesizer/config/unknown_fields.py
+++ b/src/nemo_safe_synthesizer/config/unknown_fields.py
@@ -98,8 +98,7 @@ def _normalize_annotation(
 
     if origin in (dict, Mapping) and len(args) == 2 and isinstance(value, Mapping):
         return {
-            key: _normalize_annotation(args[1], item, unknown_fields, (*path, str(key)))
-            for key, item in value.items()
+            key: _normalize_annotation(args[1], item, unknown_fields, (*path, str(key))) for key, item in value.items()
         }
 
     return value

--- a/src/nemo_safe_synthesizer/config/unknown_fields.py
+++ b/src/nemo_safe_synthesizer/config/unknown_fields.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unknown-field policy shared by configuration input boundaries."""
+
+from __future__ import annotations
+
+import types
+from collections.abc import Mapping, Sequence
+from typing import Annotated, Literal, TypeAlias, Union, cast, get_args, get_origin
+
+from pydantic import BaseModel, TypeAdapter
+
+from ..errors import ParameterError
+
+UnknownFieldBehavior: TypeAlias = Literal["ignore", "reject"]
+
+DEFAULT_UNKNOWN_FIELDS: UnknownFieldBehavior = "reject"
+
+_UNKNOWN_FIELDS_ADAPTER: TypeAdapter[UnknownFieldBehavior] = TypeAdapter(UnknownFieldBehavior)
+
+
+def validate_unknown_fields(value: object) -> UnknownFieldBehavior:
+    """Validate one user-facing unknown-field policy value."""
+    return _UNKNOWN_FIELDS_ADAPTER.validate_python(value)
+
+
+def normalize_unknown_fields(
+    model_type: type[BaseModel],
+    source: Mapping[str, object],
+    unknown_fields: UnknownFieldBehavior,
+) -> dict[str, object]:
+    """Recursively reject or remove fields absent from a Pydantic model tree."""
+    return _normalize_model_mapping(model_type, source, unknown_fields, ())
+
+
+def _normalize_model_mapping(
+    model_type: type[BaseModel],
+    source: Mapping[str, object],
+    unknown_fields: UnknownFieldBehavior,
+    path: tuple[str, ...],
+) -> dict[str, object]:
+    normalized: dict[str, object] = {}
+    for name, value in source.items():
+        field = model_type.model_fields.get(name)
+        if field is None:
+            if unknown_fields == "reject":
+                location = ".".join((*path, name))
+                raise ParameterError(f"Unknown configuration field {location!r}.")
+            continue
+        normalized[name] = _normalize_annotation(field.annotation, value, unknown_fields, (*path, name))
+    return normalized
+
+
+def _normalize_annotation(
+    annotation: object,
+    value: object,
+    unknown_fields: UnknownFieldBehavior,
+    path: tuple[str, ...],
+) -> object:
+    while get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        if isinstance(value, Mapping):
+            return _normalize_model_mapping(
+                annotation,
+                cast(Mapping[str, object], value),
+                unknown_fields,
+                path,
+            )
+        return value
+
+    origin = get_origin(annotation)
+    args = get_args(annotation)
+    if origin in (types.UnionType, Union):
+        candidates = tuple(item for item in args if item is not type(None))
+        model_candidates = tuple(item for item in candidates if _annotation_contains_model(item))
+        if len(model_candidates) == 1:
+            return _normalize_annotation(model_candidates[0], value, unknown_fields, path)
+        return value
+
+    if origin in (list, set, frozenset, Sequence) and args and isinstance(value, Sequence):
+        if isinstance(value, (str, bytes, bytearray)):
+            return value
+        items = (
+            _normalize_annotation(args[0], item, unknown_fields, (*path, str(index)))
+            for index, item in enumerate(value)
+        )
+        return type(value)(items)
+
+    if origin is tuple and args and isinstance(value, tuple):
+        item_annotations = args if args[-1:] != (Ellipsis,) else (args[0],) * len(value)
+        return tuple(
+            _normalize_annotation(item_annotations[index], item, unknown_fields, (*path, str(index)))
+            for index, item in enumerate(value)
+        )
+
+    if origin in (dict, Mapping) and len(args) == 2 and isinstance(value, Mapping):
+        return {
+            key: _normalize_annotation(args[1], item, unknown_fields, (*path, str(key)))
+            for key, item in value.items()
+        }
+
+    return value
+
+
+def _annotation_contains_model(annotation: object) -> bool:
+    while get_origin(annotation) is Annotated:
+        annotation = get_args(annotation)[0]
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return True
+    return any(_annotation_contains_model(item) for item in get_args(annotation) if item is not Ellipsis)

--- a/src/nemo_safe_synthesizer/configurator/parameters.py
+++ b/src/nemo_safe_synthesizer/configurator/parameters.py
@@ -31,7 +31,8 @@ from pydantic import (
 from ..config.base import (
     pydantic_model_config,
 )
-from ..config.patch import CompiledConfigPatch, PatchAssignment, UnknownFieldBehavior
+from ..config.patch import CompiledConfigPatch, PatchAssignment
+from ..config.unknown_fields import UnknownFieldBehavior
 from ..errors import ParameterError
 from .parameter import (
     DataT,
@@ -79,18 +80,18 @@ class Parameters(BaseModel, metaclass=ABCMeta):
         cls,
         source: Self | Mapping[str, object] | None = None,
         *,
-        unknown_fields: UnknownFieldBehavior = "ignore",
+        unknown_field_behavior: UnknownFieldBehavior = "ignore",
         **kwargs: object,
     ) -> Self:
         """Normalize one sparse config source plus higher-precedence keyword values.
 
         ``source`` may be ``None``, an instance of exactly ``cls``, or a raw
         mapping. Declared compatibility aliases are normalized for raw mappings
-        and keyword overrides. ``unknown_fields`` controls whether unknown raw
-        mapping keys are ignored or rejected. Keyword overrides accept top-level
-        fields and canonical dotted paths, but reject inferred bare nested names
-        with an actionable path suggestion. A different Pydantic model type is
-        rejected rather than adapted.
+        and keyword overrides. ``unknown_field_behavior`` controls whether
+        unknown raw mapping keys are ignored or rejected. Keyword overrides
+        accept top-level fields and canonical dotted paths, but reject inferred
+        bare nested names with an actionable path suggestion. A different
+        Pydantic model type is rejected rather than adapted.
         """
         schema = ParameterSchema.from_model(cls)
         match source:
@@ -113,7 +114,7 @@ class Parameters(BaseModel, metaclass=ABCMeta):
                     schema.normalize_aliases(cast(Mapping[str, object], mapping)),
                     origin="mapping config",
                     precedence=0,
-                    unknown_fields=unknown_fields,
+                    unknown_fields=unknown_field_behavior,
                 )
             case _:
                 raise TypeError(f"Unsupported config type: {type(source)}")

--- a/src/nemo_safe_synthesizer/configurator/parameters.py
+++ b/src/nemo_safe_synthesizer/configurator/parameters.py
@@ -31,7 +31,7 @@ from pydantic import (
 from ..config.base import (
     pydantic_model_config,
 )
-from ..config.patch import CompiledConfigPatch, PatchAssignment
+from ..config.patch import CompiledConfigPatch, PatchAssignment, UnknownFieldBehavior
 from ..errors import ParameterError
 from .parameter import (
     DataT,
@@ -75,16 +75,22 @@ class Parameters(BaseModel, metaclass=ABCMeta):
         return patch.apply_to_full_model(self)
 
     @classmethod
-    def from_config_source(cls, source: Self | Mapping[str, object] | None = None, **kwargs: object) -> Self:
+    def from_config_source(
+        cls,
+        source: Self | Mapping[str, object] | None = None,
+        *,
+        unknown_fields: UnknownFieldBehavior = "ignore",
+        **kwargs: object,
+    ) -> Self:
         """Normalize one sparse config source plus higher-precedence keyword values.
 
         ``source`` may be ``None``, an instance of exactly ``cls``, or a raw
         mapping. Declared compatibility aliases are normalized for raw mappings
-        and keyword overrides. Unknown mapping keys retain Pydantic's
-        extra-ignore behavior. Keyword overrides accept top-level fields and
-        canonical dotted paths, but reject inferred bare nested names with an
-        actionable path suggestion. A different Pydantic model type is rejected
-        rather than adapted.
+        and keyword overrides. ``unknown_fields`` controls whether unknown raw
+        mapping keys are ignored or rejected. Keyword overrides accept top-level
+        fields and canonical dotted paths, but reject inferred bare nested names
+        with an actionable path suggestion. A different Pydantic model type is
+        rejected rather than adapted.
         """
         schema = ParameterSchema.from_model(cls)
         match source:
@@ -107,7 +113,7 @@ class Parameters(BaseModel, metaclass=ABCMeta):
                     schema.normalize_aliases(cast(Mapping[str, object], mapping)),
                     origin="mapping config",
                     precedence=0,
-                    unknown_fields="ignore",
+                    unknown_fields=unknown_fields,
                 )
             case _:
                 raise TypeError(f"Unsupported config type: {type(source)}")

--- a/src/nemo_safe_synthesizer/sdk/config_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/config_builder.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Self, TypeAlias
+from typing import Literal, Self, TypeAlias
 
 import pandas as pd
 
@@ -54,6 +54,7 @@ class ConfigBuilder:
     def __init__(self, config: SafeSynthesizerParameters | None = None) -> None:
         self._nss_config = config.model_copy(deep=True) if config is not None else None
         if self._nss_config is not None:
+            self._strict_config = self._nss_config.strict_config
             self._emit_telemetry_config = self._nss_config.emit_telemetry
             self._evaluation_config = self._nss_config.evaluation
             self._replace_pii_config = self._nss_config.replace_pii
@@ -64,6 +65,7 @@ class ConfigBuilder:
             self._data_config = self._nss_config.data
             self._time_series_config = self._nss_config.time_series
         else:
+            self._strict_config = True
             self._data_config: DataParameters = DataParameters()
             self._evaluation_config: EvaluationParameters = EvaluationParameters()
             self._generation_config: GenerateParameters = GenerateParameters()
@@ -77,6 +79,15 @@ class ConfigBuilder:
         self._data_source: DataSource | None = None
         self._classify_model_provider: str | None = None
         self._hf_token_secret: str | None = None
+
+    @property
+    def _unknown_fields(self) -> Literal["ignore", "reject"]:
+        return "reject" if self._strict_config else "ignore"
+
+    def with_strict_config(self, enabled: bool) -> Self:
+        """Control whether SDK raw mapping inputs reject unknown keys."""
+        self._strict_config = enabled
+        return self
 
     def with_data_source(self, df_source: DataSource) -> Self:
         """Set the data source for synthetic data generation.
@@ -100,7 +111,7 @@ class ConfigBuilder:
         Returns:
             This builder instance with data processing settings applied.
         """
-        self._data_config = DataParameters.from_config_source(config, **kwargs)
+        self._data_config = DataParameters.from_config_source(config, unknown_fields=self._unknown_fields, **kwargs)
         return self
 
     def with_train(self, config: TrainingHyperparams | RawConfig | None = None, **kwargs: object) -> Self:
@@ -113,7 +124,9 @@ class ConfigBuilder:
         Returns:
             This builder instance with training hyperparameters applied.
         """
-        self._training_config = TrainingHyperparams.from_config_source(config, **kwargs)
+        self._training_config = TrainingHyperparams.from_config_source(
+            config, unknown_fields=self._unknown_fields, **kwargs
+        )
         return self
 
     def with_generate(self, config: GenerateParameters | RawConfig | None = None, **kwargs: object) -> Self:
@@ -126,7 +139,9 @@ class ConfigBuilder:
         Returns:
             This builder instance with generation settings applied.
         """
-        self._generation_config = GenerateParameters.from_config_source(config, **kwargs)
+        self._generation_config = GenerateParameters.from_config_source(
+            config, unknown_fields=self._unknown_fields, **kwargs
+        )
         return self
 
     def with_time_series(self, config: TimeSeriesParameters | RawConfig | None = None, **kwargs: object) -> Self:
@@ -139,7 +154,9 @@ class ConfigBuilder:
         Returns:
             This builder instance with time-series synthesis settings applied.
         """
-        self._time_series_config = TimeSeriesParameters.from_config_source(config, **kwargs)
+        self._time_series_config = TimeSeriesParameters.from_config_source(
+            config, unknown_fields=self._unknown_fields, **kwargs
+        )
         return self
 
     def with_differential_privacy(
@@ -154,7 +171,9 @@ class ConfigBuilder:
         Returns:
             This builder instance with differential privacy settings applied.
         """
-        self._privacy_config = DifferentialPrivacyHyperparams.from_config_source(config, **kwargs)
+        self._privacy_config = DifferentialPrivacyHyperparams.from_config_source(
+            config, unknown_fields=self._unknown_fields, **kwargs
+        )
         return self
 
     def with_replace_pii(
@@ -200,9 +219,11 @@ class ConfigBuilder:
 
         match config:
             case PiiReplacerConfig() | Mapping() as values:
-                cfg = PiiReplacerConfig.from_config_source(values, **kwargs)
+                cfg = PiiReplacerConfig.from_config_source(values, unknown_fields=self._unknown_fields, **kwargs)
             case None:
-                cfg = PiiReplacerConfig.from_config_source(PiiReplacerConfig.get_default_config(), **kwargs)
+                cfg = PiiReplacerConfig.from_config_source(
+                    PiiReplacerConfig.get_default_config(), unknown_fields=self._unknown_fields, **kwargs
+                )
             case _:
                 raise ValueError(f"Config must be a PiiReplacerConfig, raw mapping, or None, got {config!r}")
 
@@ -219,7 +240,9 @@ class ConfigBuilder:
         Returns:
             This builder instance with evaluation settings applied.
         """
-        self._evaluation_config = EvaluationParameters.from_config_source(config, **kwargs)
+        self._evaluation_config = EvaluationParameters.from_config_source(
+            config, unknown_fields=self._unknown_fields, **kwargs
+        )
         return self
 
     def resolve(self) -> Self:
@@ -253,6 +276,7 @@ class ConfigBuilder:
             replace_pii=self._replace_pii_config,
             preflight=self._preflight_config,
             emit_telemetry=self._emit_telemetry_config,
+            strict_config=self._strict_config,
         )
 
         # Inject classify_model_provider into PII replacer config if set

--- a/src/nemo_safe_synthesizer/sdk/config_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/config_builder.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Literal, Self, TypeAlias
+from typing import Self, TypeAlias
 
 import pandas as pd
 
@@ -20,6 +20,11 @@ from ..config import (
     SafeSynthesizerParameters,
     TimeSeriesParameters,
     TrainingHyperparams,
+)
+from ..config.unknown_fields import (
+    DEFAULT_UNKNOWN_FIELDS,
+    UnknownFieldBehavior,
+    validate_unknown_fields,
 )
 from ..observability import get_logger
 from ..telemetry import _telemetry_enabled
@@ -49,13 +54,19 @@ class ConfigBuilder:
         config: Optional pre-built parameters.  When supplied, the
             individual ``_*_config`` attributes are seeded from its
             sections.
+        unknown_fields: Optional SDK-wide override for raw mapping validation.
+            Set it at construction time so every section uses the same policy.
     """
 
-    def __init__(self, config: SafeSynthesizerParameters | None = None) -> None:
+    def __init__(
+        self,
+        config: SafeSynthesizerParameters | None = None,
+        *,
+        unknown_fields: UnknownFieldBehavior | None = None,
+    ) -> None:
         self._nss_config = config.model_copy(deep=True) if config is not None else None
-        self._strict_config_explicit = config is not None and "strict_config" in config.model_fields_set
+        self._unknown_fields_override = validate_unknown_fields(unknown_fields) if unknown_fields is not None else None
         if self._nss_config is not None:
-            self._strict_config = self._nss_config.strict_config
             self._emit_telemetry_config = self._nss_config.emit_telemetry
             self._evaluation_config = self._nss_config.evaluation
             self._replace_pii_config = self._nss_config.replace_pii
@@ -66,7 +77,6 @@ class ConfigBuilder:
             self._data_config = self._nss_config.data
             self._time_series_config = self._nss_config.time_series
         else:
-            self._strict_config = True
             self._data_config: DataParameters = DataParameters()
             self._evaluation_config: EvaluationParameters = EvaluationParameters()
             self._generation_config: GenerateParameters = GenerateParameters()
@@ -82,14 +92,12 @@ class ConfigBuilder:
         self._hf_token_secret: str | None = None
 
     @property
-    def _unknown_fields(self) -> Literal["ignore", "reject"]:
-        return "reject" if self._strict_config else "ignore"
-
-    def with_strict_config(self, enabled: bool) -> Self:
-        """Control whether SDK raw mapping inputs reject unknown keys."""
-        self._strict_config = enabled
-        self._strict_config_explicit = True
-        return self
+    def _effective_unknown_fields(self) -> UnknownFieldBehavior:
+        if self._unknown_fields_override is not None:
+            return self._unknown_fields_override
+        if self._nss_config is not None:
+            return self._nss_config.unknown_fields
+        return DEFAULT_UNKNOWN_FIELDS
 
     def with_data_source(self, df_source: DataSource) -> Self:
         """Set the data source for synthetic data generation.
@@ -113,7 +121,11 @@ class ConfigBuilder:
         Returns:
             This builder instance with data processing settings applied.
         """
-        self._data_config = DataParameters.from_config_source(config, unknown_fields=self._unknown_fields, **kwargs)
+        self._data_config = DataParameters.from_config_source(
+            config,
+            unknown_field_behavior=self._effective_unknown_fields,
+            **kwargs,
+        )
         return self
 
     def with_train(self, config: TrainingHyperparams | RawConfig | None = None, **kwargs: object) -> Self:
@@ -127,7 +139,9 @@ class ConfigBuilder:
             This builder instance with training hyperparameters applied.
         """
         self._training_config = TrainingHyperparams.from_config_source(
-            config, unknown_fields=self._unknown_fields, **kwargs
+            config,
+            unknown_field_behavior=self._effective_unknown_fields,
+            **kwargs,
         )
         return self
 
@@ -142,7 +156,9 @@ class ConfigBuilder:
             This builder instance with generation settings applied.
         """
         self._generation_config = GenerateParameters.from_config_source(
-            config, unknown_fields=self._unknown_fields, **kwargs
+            config,
+            unknown_field_behavior=self._effective_unknown_fields,
+            **kwargs,
         )
         return self
 
@@ -157,7 +173,9 @@ class ConfigBuilder:
             This builder instance with time-series synthesis settings applied.
         """
         self._time_series_config = TimeSeriesParameters.from_config_source(
-            config, unknown_fields=self._unknown_fields, **kwargs
+            config,
+            unknown_field_behavior=self._effective_unknown_fields,
+            **kwargs,
         )
         return self
 
@@ -174,7 +192,9 @@ class ConfigBuilder:
             This builder instance with differential privacy settings applied.
         """
         self._privacy_config = DifferentialPrivacyHyperparams.from_config_source(
-            config, unknown_fields=self._unknown_fields, **kwargs
+            config,
+            unknown_field_behavior=self._effective_unknown_fields,
+            **kwargs,
         )
         return self
 
@@ -221,10 +241,16 @@ class ConfigBuilder:
 
         match config:
             case PiiReplacerConfig() | Mapping() as values:
-                cfg = PiiReplacerConfig.from_config_source(values, unknown_fields=self._unknown_fields, **kwargs)
+                cfg = PiiReplacerConfig.from_config_source(
+                    values,
+                    unknown_field_behavior=self._effective_unknown_fields,
+                    **kwargs,
+                )
             case None:
                 cfg = PiiReplacerConfig.from_config_source(
-                    PiiReplacerConfig.get_default_config(), unknown_fields=self._unknown_fields, **kwargs
+                    PiiReplacerConfig.get_default_config(),
+                    unknown_field_behavior=self._effective_unknown_fields,
+                    **kwargs,
                 )
             case _:
                 raise ValueError(f"Config must be a PiiReplacerConfig, raw mapping, or None, got {config!r}")
@@ -243,7 +269,9 @@ class ConfigBuilder:
             This builder instance with evaluation settings applied.
         """
         self._evaluation_config = EvaluationParameters.from_config_source(
-            config, unknown_fields=self._unknown_fields, **kwargs
+            config,
+            unknown_field_behavior=self._effective_unknown_fields,
+            **kwargs,
         )
         return self
 
@@ -268,18 +296,19 @@ class ConfigBuilder:
         then injects ``_classify_model_provider`` into PII configuration when
         requested.
         """
-        self._nss_config = SafeSynthesizerParameters(
-            data=self._data_config,
-            evaluation=self._evaluation_config,
-            training=self._training_config,
-            generation=self._generation_config,
-            privacy=self._privacy_config,
-            time_series=self._time_series_config,
-            replace_pii=self._replace_pii_config,
-            preflight=self._preflight_config,
-            emit_telemetry=self._emit_telemetry_config,
-            strict_config=self._strict_config,
-        )
+        config_values: dict[str, object] = {
+            "data": self._data_config,
+            "evaluation": self._evaluation_config,
+            "training": self._training_config,
+            "generation": self._generation_config,
+            "privacy": self._privacy_config,
+            "time_series": self._time_series_config,
+            "replace_pii": self._replace_pii_config,
+            "preflight": self._preflight_config,
+            "emit_telemetry": self._emit_telemetry_config,
+            "unknown_fields": self._effective_unknown_fields,
+        }
+        self._nss_config = SafeSynthesizerParameters.model_validate(config_values)
 
         # Inject classify_model_provider into PII replacer config if set
         if self._classify_model_provider and self._nss_config.replace_pii:

--- a/src/nemo_safe_synthesizer/sdk/config_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/config_builder.py
@@ -53,6 +53,7 @@ class ConfigBuilder:
 
     def __init__(self, config: SafeSynthesizerParameters | None = None) -> None:
         self._nss_config = config.model_copy(deep=True) if config is not None else None
+        self._strict_config_explicit = config is not None and "strict_config" in config.model_fields_set
         if self._nss_config is not None:
             self._strict_config = self._nss_config.strict_config
             self._emit_telemetry_config = self._nss_config.emit_telemetry
@@ -87,6 +88,7 @@ class ConfigBuilder:
     def with_strict_config(self, enabled: bool) -> Self:
         """Control whether SDK raw mapping inputs reject unknown keys."""
         self._strict_config = enabled
+        self._strict_config_explicit = True
         return self
 
     def with_data_source(self, df_source: DataSource) -> Self:

--- a/src/nemo_safe_synthesizer/sdk/library_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/library_builder.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pandas as pd
+
 from datasets import Dataset
 
 from ..cli.artifact_structure import Workdir
@@ -297,6 +298,7 @@ class SafeSynthesizer(ConfigBuilder):
         if runtime_config is not None:
             saved_config = saved_config.with_runtime_overrides(runtime_config)
         self._nss_config = saved_config
+        self._strict_config = self._nss_config.strict_config
         self._generation_config = self._nss_config.generation
         self._evaluation_config = self._nss_config.evaluation
         self._emit_telemetry_config = self._nss_config.emit_telemetry

--- a/src/nemo_safe_synthesizer/sdk/library_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/library_builder.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from collections.abc import Iterator
@@ -276,9 +277,11 @@ class SafeSynthesizer(ConfigBuilder):
         Loads the configuration from the source run directory's config file.
         When resuming from a trained model for generation, the source paths
         point to the parent workdir that contains the trained adapter.
-        Optional ``runtime_config`` values for generation and evaluation are
-        applied after loading the saved training-run config so resume-time CLI
-        overrides work without mutating the persisted train config.
+        Optional ``runtime_config`` values for generation, evaluation,
+        telemetry, and strict config validation are applied without mutating
+        the persisted train config. An explicitly set ``strict_config`` also
+        controls validation of the saved config itself so legacy fields can be
+        ignored for version-skew compatibility.
 
         Always prefers cached train/test splits from the training run to ensure
         evaluation metrics are consistent and privacy guarantees are maintained.
@@ -292,12 +295,22 @@ class SafeSynthesizer(ConfigBuilder):
         # Use source paths which point to parent workdir when resuming for generation
         config_file = self._workdir.source_config
 
-        saved_config = SafeSynthesizerParameters.from_json(config_file)
+        with config_file.open() as file:
+            saved_config_input = json.load(file)
+        strict_config_override: bool | None = None
+        if runtime_config is not None and "strict_config" in runtime_config.model_fields_set:
+            strict_config_override = runtime_config.strict_config
+        elif self._strict_config_explicit:
+            strict_config_override = self._strict_config
+        if strict_config_override is not None and isinstance(saved_config_input, dict):
+            saved_config_input["strict_config"] = strict_config_override
+        saved_config = SafeSynthesizerParameters.model_validate(saved_config_input)
         _warn_for_saved_default_drift(saved_config)
         if runtime_config is not None:
             saved_config = saved_config.with_runtime_overrides(runtime_config)
         self._nss_config = saved_config
         self._strict_config = self._nss_config.strict_config
+        self._strict_config_explicit = "strict_config" in self._nss_config.model_fields_set
         self._generation_config = self._nss_config.generation
         self._evaluation_config = self._nss_config.evaluation
         self._emit_telemetry_config = self._nss_config.emit_telemetry

--- a/src/nemo_safe_synthesizer/sdk/library_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/library_builder.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import json
 import os
 import time
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -20,6 +20,7 @@ from ..config import (
     SafeSynthesizerParameters,
 )
 from ..config.autoconfig import AutoConfigResolver
+from ..config.unknown_fields import UnknownFieldBehavior, normalize_unknown_fields
 from ..configurator.parameters import Parameters
 from ..errors import ParameterError
 from ..evaluation.evaluator import Evaluator
@@ -213,8 +214,9 @@ class SafeSynthesizer(ConfigBuilder):
         save_path: Path | str | None = None,
         emit_telemetry: bool | None = None,
         deployment_type: DeploymentTypeEnum | None = None,
+        unknown_fields: UnknownFieldBehavior | None = None,
     ):
-        super().__init__(config=config)
+        super().__init__(config=config, unknown_fields=unknown_fields)
         self._workdir = workdir
         if self._workdir is None:
             # Create a default workdir when none provided
@@ -278,10 +280,10 @@ class SafeSynthesizer(ConfigBuilder):
         When resuming from a trained model for generation, the source paths
         point to the parent workdir that contains the trained adapter.
         Optional ``runtime_config`` values for generation, evaluation,
-        telemetry, and strict config validation are applied without mutating
-        the persisted train config. An explicitly set ``strict_config`` also
-        controls validation of the saved config itself so legacy fields can be
-        ignored for version-skew compatibility.
+        telemetry, and the unknown-field policy are applied without mutating
+        the persisted train config. An explicitly set ``unknown_fields`` policy
+        also controls validation of the saved config itself so legacy fields
+        can be ignored for version-skew compatibility.
 
         Always prefers cached train/test splits from the training run to ensure
         evaluation metrics are consistent and privacy guarantees are maintained.
@@ -297,20 +299,28 @@ class SafeSynthesizer(ConfigBuilder):
 
         with config_file.open() as file:
             saved_config_input = json.load(file)
-        strict_config_override: bool | None = None
-        if runtime_config is not None and "strict_config" in runtime_config.model_fields_set:
-            strict_config_override = runtime_config.strict_config
-        elif self._strict_config_explicit:
-            strict_config_override = self._strict_config
-        if strict_config_override is not None and isinstance(saved_config_input, dict):
-            saved_config_input["strict_config"] = strict_config_override
-        saved_config = SafeSynthesizerParameters.model_validate(saved_config_input)
+        unknown_fields_override = self._unknown_fields_override
+        if runtime_config is not None and "unknown_fields" in runtime_config.model_fields_set:
+            unknown_fields_override = runtime_config.unknown_fields
+        if unknown_fields_override is None:
+            saved_config = SafeSynthesizerParameters.model_validate(saved_config_input)
+        else:
+            normalized_input = (
+                normalize_unknown_fields(
+                    SafeSynthesizerParameters,
+                    saved_config_input,
+                    unknown_fields_override,
+                )
+                if isinstance(saved_config_input, Mapping)
+                else saved_config_input
+            )
+            saved_config = SafeSynthesizerParameters.model_validate(normalized_input)
+            saved_config = saved_config.with_config_patch({"unknown_fields": unknown_fields_override})
         _warn_for_saved_default_drift(saved_config)
         if runtime_config is not None:
             saved_config = saved_config.with_runtime_overrides(runtime_config)
         self._nss_config = saved_config
-        self._strict_config = self._nss_config.strict_config
-        self._strict_config_explicit = "strict_config" in self._nss_config.model_fields_set
+        self._unknown_fields_override = None
         self._generation_config = self._nss_config.generation
         self._evaluation_config = self._nss_config.evaluation
         self._emit_telemetry_config = self._nss_config.emit_telemetry

--- a/src/nemo_safe_synthesizer/sdk/library_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/library_builder.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pandas as pd
-
 from datasets import Dataset
 
 from ..cli.artifact_structure import Workdir

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -142,3 +142,4 @@ class TestConfigValidateErrorPathExitCodes:
 
         assert result.exit_code == 0
         assert '"unknown_fields": "ignore"' in result.output
+        assert '"epoch"' not in result.output

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -124,3 +124,21 @@ class TestConfigValidateErrorPathExitCodes:
         )
 
         assert result.exit_code == 0
+
+    def test_validate_rejects_unknown_keys_by_default(self, cli_runner: CliRunner, tmp_path: Path):
+        config_path = tmp_path / "unknown.yaml"
+        config_path.write_text("training:\n  epoch: 2\n")
+
+        result = cli_runner.invoke(config, ["validate", "--config", str(config_path)])
+
+        assert result.exit_code != 0
+        assert "epoch" in result.output
+
+    def test_validate_allows_unknown_keys_when_non_strict(self, cli_runner: CliRunner, tmp_path: Path):
+        config_path = tmp_path / "unknown.yaml"
+        config_path.write_text("strict_config: false\ntraining:\n  epoch: 2\n")
+
+        result = cli_runner.invoke(config, ["validate", "--config", str(config_path)])
+
+        assert result.exit_code == 0
+        assert '"strict_config": false' in result.output

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -134,11 +134,11 @@ class TestConfigValidateErrorPathExitCodes:
         assert result.exit_code != 0
         assert "epoch" in result.output
 
-    def test_validate_allows_unknown_keys_when_non_strict(self, cli_runner: CliRunner, tmp_path: Path):
+    def test_validate_allows_unknown_keys_with_ignore_policy(self, cli_runner: CliRunner, tmp_path: Path):
         config_path = tmp_path / "unknown.yaml"
-        config_path.write_text("strict_config: false\ntraining:\n  epoch: 2\n")
+        config_path.write_text("unknown_fields: ignore\ntraining:\n  epoch: 2\n")
 
         result = cli_runner.invoke(config, ["validate", "--config", str(config_path)])
 
         assert result.exit_code == 0
-        assert '"strict_config": false' in result.output
+        assert '"unknown_fields": "ignore"' in result.output

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -375,11 +375,11 @@ generation:
     @pytest.mark.parametrize(
         ("config_contents", "overrides", "expected"),
         [
-            (None, {"unknown": True}, {}),
+            (None, {"strict_config": False, "unknown": True}, {"strict_config": False}),
             (
-                "generation:\n  num_records: 77\n",
+                "strict_config: false\ngeneration:\n  num_records: 77\n",
                 {"generation": {"unknown": True}},
-                {"generation": {"num_records": 77}},
+                {"generation": {"num_records": 77}, "strict_config": False},
             ),
         ],
     )

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -375,11 +375,11 @@ generation:
     @pytest.mark.parametrize(
         ("config_contents", "overrides", "expected"),
         [
-            (None, {"strict_config": False, "unknown": True}, {"strict_config": False}),
+            (None, {"unknown_fields": "ignore", "unknown": True}, {"unknown_fields": "ignore"}),
             (
-                "strict_config: false\ngeneration:\n  num_records: 77\n",
+                "unknown_fields: ignore\ngeneration:\n  num_records: 77\n",
                 {"generation": {"unknown": True}},
-                {"generation": {"num_records": 77}, "strict_config": False},
+                {"generation": {"num_records": 77}, "unknown_fields": "ignore"},
             ),
         ],
     )

--- a/tests/config/test_parameters.py
+++ b/tests/config/test_parameters.py
@@ -695,7 +695,7 @@ def _runtime_nested_validation() -> SafeSynthesizerParameters:
 
 
 class TestWithRuntimeOverrides:
-    """Tests for resume-time generation/evaluation/telemetry override merging."""
+    """Tests for supported resume-time override merging."""
 
     @pytest.mark.parametrize(
         ("make_runtime", "expected"),
@@ -748,6 +748,11 @@ class TestWithRuntimeOverrides:
                 lambda: SafeSynthesizerParameters.model_validate({"emit_telemetry": True}),
                 {"emit_telemetry": True},
                 id="telemetry-set-applied",
+            ),
+            pytest.param(
+                lambda: SafeSynthesizerParameters.model_validate({"strict_config": False}),
+                {"strict_config": False},
+                id="strict-config-set-applied",
             ),
         ],
     )

--- a/tests/config/test_parameters.py
+++ b/tests/config/test_parameters.py
@@ -114,8 +114,10 @@ def test_model_validate_accepts_an_existing_config():
 
 
 def test_model_validate_non_mapping_input_uses_default_unknown_field_policy():
-    with pytest.raises(ValidationError, match="valid dictionary or object"):
+    with pytest.raises(ValidationError) as exc_info:
         SafeSynthesizerParameters.model_validate(None)
+
+    assert exc_info.value.errors()[0]["type"] == "model_attributes_type"
 
 
 def test_from_yaml_str_absent_key_enables_pii():

--- a/tests/config/test_parameters.py
+++ b/tests/config/test_parameters.py
@@ -8,7 +8,7 @@ from typing import ClassVar, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pydantic import Field, ValidationError, model_validator
+from pydantic import BaseModel, Field, ValidationError, model_validator
 
 from nemo_safe_synthesizer.config.generate import GenerateParameters, StructuredGenerationParameters
 from nemo_safe_synthesizer.config.job import SafeSynthesizerJobConfig
@@ -108,12 +108,12 @@ def test_model_validate_null_disables_pii():
 
 
 def test_model_validate_accepts_an_existing_config():
-    config = SafeSynthesizerParameters(strict_config=False)
+    config = SafeSynthesizerParameters(unknown_fields="ignore")
 
     assert SafeSynthesizerParameters.model_validate(config) is config
 
 
-def test_model_validate_non_mapping_input_uses_default_strictness():
+def test_model_validate_non_mapping_input_uses_default_unknown_field_policy():
     with pytest.raises(ValidationError, match="valid dictionary or object"):
         SafeSynthesizerParameters.model_validate(None)
 
@@ -128,11 +128,11 @@ def test_from_yaml_str_null_disables_pii():
     assert c.replace_pii is None
 
 
-def test_old_yaml_with_enable_replace_pii_requires_non_strict_mode():
+def test_old_yaml_with_enable_replace_pii_requires_ignore_policy():
     with pytest.raises(ValidationError, match="enable_replace_pii"):
         SafeSynthesizerParameters.model_validate({"enable_replace_pii": True})
 
-    c = SafeSynthesizerParameters.model_validate({"strict_config": False, "enable_replace_pii": True})
+    c = SafeSynthesizerParameters.model_validate({"unknown_fields": "ignore", "enable_replace_pii": True})
     assert c.replace_pii is not None
 
 
@@ -259,24 +259,28 @@ def test_from_config_patch_validates_sparse_config():
     assert config.replace_pii is None
 
 
-def test_from_config_source_keyword_strictness_takes_precedence_over_mapping():
+def test_from_config_source_keyword_policy_takes_precedence_over_mapping():
     relaxed = SafeSynthesizerParameters.from_config_source(
-        {"strict_config": True, "unknown": True}, strict_config=False
+        {"unknown_fields": "reject", "unknown": True},
+        unknown_fields="ignore",
     )
-    assert relaxed.strict_config is False
+    assert relaxed.unknown_fields == "ignore"
 
     with pytest.raises(ParameterError, match="unknown"):
-        SafeSynthesizerParameters.from_config_source({"strict_config": False, "unknown": True}, strict_config=True)
+        SafeSynthesizerParameters.from_config_source(
+            {"unknown_fields": "ignore", "unknown": True},
+            unknown_fields="reject",
+        )
 
 
-def test_from_config_source_preserves_strictness_from_an_existing_config():
-    source = SafeSynthesizerParameters(strict_config=False)
+def test_from_config_source_preserves_policy_from_an_existing_config():
+    source = SafeSynthesizerParameters(unknown_fields="ignore")
 
-    assert SafeSynthesizerParameters.from_config_source(source).strict_config is False
+    assert SafeSynthesizerParameters.from_config_source(source).unknown_fields == "ignore"
 
 
-def test_from_config_source_resolves_strictness_without_a_source_mapping():
-    assert SafeSynthesizerParameters.from_config_source(strict_config=False).strict_config is False
+def test_from_config_source_resolves_policy_without_a_source_mapping():
+    assert SafeSynthesizerParameters.from_config_source(unknown_fields="ignore").unknown_fields == "ignore"
 
 
 @pytest.mark.parametrize(
@@ -294,10 +298,10 @@ def test_from_config_patch_rejects_unknown_mapping_keys_by_default(patch: dict[s
 @pytest.mark.parametrize(
     ("patch", "expected"),
     [
-        ({"strict_config": False, "unknown": True}, {"strict_config": False}),
+        ({"unknown_fields": "ignore", "unknown": True}, {"unknown_fields": "ignore"}),
         (
-            {"strict_config": False, "generation": {"unknown": True}},
-            {"strict_config": False, "generation": {}},
+            {"unknown_fields": "ignore", "generation": {"unknown": True}},
+            {"unknown_fields": "ignore", "generation": {}},
         ),
     ],
 )
@@ -310,23 +314,23 @@ def test_from_config_patch_ignores_unknown_mapping_keys_when_non_strict(
 
 
 def test_with_config_patch_ignores_unknown_mapping_keys_and_preserves_sparse_base():
-    config = SafeSynthesizerParameters.model_validate({"strict_config": False, "generation": {"num_records": 77}})
+    config = SafeSynthesizerParameters.model_validate({"unknown_fields": "ignore", "generation": {"num_records": 77}})
 
     merged = config.with_config_patch({"unknown": True, "generation": {"unknown": True, "temperature": 0.7}})
 
     assert merged.model_dump(exclude_unset=True) == {
         "generation": {"num_records": 77, "temperature": 0.7},
-        "strict_config": False,
+        "unknown_fields": "ignore",
     }
 
 
-def test_with_config_patch_uses_patch_strictness_for_sibling_keys():
+def test_with_config_patch_uses_patch_policy_for_sibling_keys():
     strict = SafeSynthesizerParameters()
-    relaxed = strict.with_config_patch({"strict_config": False, "unknown": True})
-    assert relaxed.strict_config is False
+    relaxed = strict.with_config_patch({"unknown_fields": "ignore", "unknown": True})
+    assert relaxed.unknown_fields == "ignore"
 
     with pytest.raises(ParameterError, match="unknown"):
-        relaxed.with_config_patch({"strict_config": True, "unknown": True})
+        relaxed.with_config_patch({"unknown_fields": "reject", "unknown": True})
 
 
 @pytest.mark.parametrize(
@@ -337,19 +341,31 @@ def test_with_config_patch_uses_patch_strictness_for_sibling_keys():
     ],
 )
 def test_unknown_fields_are_rejected_recursively_by_default(data: dict[str, object]):
-    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+    with pytest.raises(ValidationError, match="Unknown configuration field"):
         SafeSynthesizerParameters.model_validate(data)
 
 
-def test_unknown_fields_are_ignored_recursively_when_non_strict():
+def test_unknown_fields_are_ignored_recursively_with_ignore_policy():
     config = SafeSynthesizerParameters.model_validate(
-        {"strict_config": False, "evaluate": {}, "training": {"epoch": 1}}
+        {"unknown_fields": "ignore", "evaluate": {}, "training": {"epoch": 1}}
     )
 
-    assert config.strict_config is False
+    assert config.unknown_fields == "ignore"
 
 
-def test_strict_config_reaches_models_inside_collections():
+def test_constructor_applies_unknown_field_policy_recursively():
+    with pytest.raises(ValidationError, match="training.epoch"):
+        SafeSynthesizerParameters(training={"epoch": 1})  # ty: ignore[invalid-argument-type]
+
+    config = SafeSynthesizerParameters(
+        unknown_fields="ignore",
+        training={"epoch": 1},  # ty: ignore[invalid-argument-type]
+    )
+    assert config.unknown_fields == "ignore"
+    assert not hasattr(config.training, "epoch")
+
+
+def test_unknown_field_policy_reaches_models_inside_collections():
     raw = SafeSynthesizerParameters().model_dump()
     assert isinstance(raw["replace_pii"], dict)
     raw["replace_pii"]["steps"][0]["unknown"] = True  # type: ignore[index]
@@ -357,22 +373,44 @@ def test_strict_config_reaches_models_inside_collections():
     with pytest.raises(ValidationError, match="unknown"):
         SafeSynthesizerParameters.model_validate(raw)
 
-    raw["strict_config"] = False
-    assert SafeSynthesizerParameters.model_validate(raw).strict_config is False
+    raw["unknown_fields"] = "ignore"
+    assert SafeSynthesizerParameters.model_validate(raw).unknown_fields == "ignore"
 
 
-def test_service_job_config_preserves_dynamic_strictness():
+def test_service_job_config_preserves_dynamic_unknown_field_policy():
     payload: dict[str, object] = {"data_source": "dataset", "config": {"training": {"epoch": 1}}}
     with pytest.raises(ValidationError, match="epoch"):
         SafeSynthesizerJobConfig.model_validate(payload)
 
-    payload["config"] = {"strict_config": False, "training": {"epoch": 1}}
+    payload["config"] = {"unknown_fields": "ignore", "training": {"epoch": 1}}
     job = SafeSynthesizerJobConfig.model_validate(payload)
-    assert job.config.strict_config is False
+    assert job.config.unknown_fields == "ignore"
 
-    config = SafeSynthesizerParameters(strict_config=False)
+    config = SafeSynthesizerParameters(unknown_fields="ignore")
     job = SafeSynthesizerJobConfig.model_validate({"data_source": "dataset", "config": config})
     assert job.config is config
+
+
+def test_arbitrary_wrapper_preserves_dynamic_unknown_field_policy():
+    class Wrapper(BaseModel):
+        config: SafeSynthesizerParameters
+
+    with pytest.raises(ValidationError, match="epoch"):
+        Wrapper.model_validate({"config": {"training": {"epoch": 1}}})
+
+    wrapped = Wrapper.model_validate({"config": {"unknown_fields": "ignore", "training": {"epoch": 1}}})
+    assert wrapped.config.unknown_fields == "ignore"
+    assert not hasattr(wrapped.config.training, "epoch")
+
+
+def test_model_validate_does_not_allow_a_third_unknown_field_policy():
+    with pytest.raises(ValidationError, match="unknown"):
+        SafeSynthesizerParameters.model_validate({"unknown": 1}, extra="allow")
+
+
+def test_unknown_field_policy_rejects_unsupported_value():
+    with pytest.raises(ValidationError, match="Input should be 'ignore' or 'reject'"):
+        SafeSynthesizerParameters.model_validate({"unknown_fields": "allow"})
 
 
 def test_with_config_patch_keeps_validator_and_factory_defaults_implicit():
@@ -750,9 +788,9 @@ class TestWithRuntimeOverrides:
                 id="telemetry-set-applied",
             ),
             pytest.param(
-                lambda: SafeSynthesizerParameters.model_validate({"strict_config": False}),
-                {"strict_config": False},
-                id="strict-config-set-applied",
+                lambda: SafeSynthesizerParameters.model_validate({"unknown_fields": "ignore"}),
+                {"unknown_fields": "ignore"},
+                id="unknown-fields-set-applied",
             ),
         ],
     )

--- a/tests/config/test_parameters.py
+++ b/tests/config/test_parameters.py
@@ -107,6 +107,17 @@ def test_model_validate_null_disables_pii():
     assert SafeSynthesizerParameters.model_validate({"replace_pii": None}).replace_pii is None
 
 
+def test_model_validate_accepts_an_existing_config():
+    config = SafeSynthesizerParameters(strict_config=False)
+
+    assert SafeSynthesizerParameters.model_validate(config) is config
+
+
+def test_model_validate_non_mapping_input_uses_default_strictness():
+    with pytest.raises(ValidationError, match="valid dictionary or object"):
+        SafeSynthesizerParameters.model_validate(None)
+
+
 def test_from_yaml_str_absent_key_enables_pii():
     c = SafeSynthesizerParameters.from_yaml_str("training:\n  batch_size: 4\n")
     assert c.replace_pii is not None
@@ -258,6 +269,16 @@ def test_from_config_source_keyword_strictness_takes_precedence_over_mapping():
         SafeSynthesizerParameters.from_config_source({"strict_config": False, "unknown": True}, strict_config=True)
 
 
+def test_from_config_source_preserves_strictness_from_an_existing_config():
+    source = SafeSynthesizerParameters(strict_config=False)
+
+    assert SafeSynthesizerParameters.from_config_source(source).strict_config is False
+
+
+def test_from_config_source_resolves_strictness_without_a_source_mapping():
+    assert SafeSynthesizerParameters.from_config_source(strict_config=False).strict_config is False
+
+
 @pytest.mark.parametrize(
     "patch",
     [
@@ -348,6 +369,10 @@ def test_service_job_config_preserves_dynamic_strictness():
     payload["config"] = {"strict_config": False, "training": {"epoch": 1}}
     job = SafeSynthesizerJobConfig.model_validate(payload)
     assert job.config.strict_config is False
+
+    config = SafeSynthesizerParameters(strict_config=False)
+    job = SafeSynthesizerJobConfig.model_validate({"data_source": "dataset", "config": config})
+    assert job.config is config
 
 
 def test_with_config_patch_keeps_validator_and_factory_defaults_implicit():

--- a/tests/config/test_parameters.py
+++ b/tests/config/test_parameters.py
@@ -11,6 +11,7 @@ import pytest
 from pydantic import Field, ValidationError, model_validator
 
 from nemo_safe_synthesizer.config.generate import GenerateParameters, StructuredGenerationParameters
+from nemo_safe_synthesizer.config.job import SafeSynthesizerJobConfig
 from nemo_safe_synthesizer.config.parameters import SafeSynthesizerParameters
 from nemo_safe_synthesizer.config.replace_pii import PiiReplacerConfig, StepDefinition
 from nemo_safe_synthesizer.config.training import QuantizationScheme
@@ -116,11 +117,11 @@ def test_from_yaml_str_null_disables_pii():
     assert c.replace_pii is None
 
 
-def test_old_yaml_with_enable_replace_pii_loads_cleanly():
-    # Migration: configs written before this change had enable_replace_pii: true
-    # and no replace_pii key. The extra field must be silently ignored and
-    # default_factory must fire so PII stays on.
-    c = SafeSynthesizerParameters.model_validate({"enable_replace_pii": True})
+def test_old_yaml_with_enable_replace_pii_requires_non_strict_mode():
+    with pytest.raises(ValidationError, match="enable_replace_pii"):
+        SafeSynthesizerParameters.model_validate({"enable_replace_pii": True})
+
+    c = SafeSynthesizerParameters.model_validate({"strict_config": False, "enable_replace_pii": True})
     assert c.replace_pii is not None
 
 
@@ -247,25 +248,106 @@ def test_from_config_patch_validates_sparse_config():
     assert config.replace_pii is None
 
 
+def test_from_config_source_keyword_strictness_takes_precedence_over_mapping():
+    relaxed = SafeSynthesizerParameters.from_config_source(
+        {"strict_config": True, "unknown": True}, strict_config=False
+    )
+    assert relaxed.strict_config is False
+
+    with pytest.raises(ParameterError, match="unknown"):
+        SafeSynthesizerParameters.from_config_source({"strict_config": False, "unknown": True}, strict_config=True)
+
+
+@pytest.mark.parametrize(
+    "patch",
+    [
+        {"unknown": True},
+        {"generation": {"unknown": True}},
+    ],
+)
+def test_from_config_patch_rejects_unknown_mapping_keys_by_default(patch: dict[str, object]):
+    with pytest.raises(ParameterError, match="unknown"):
+        SafeSynthesizerParameters.from_config_patch(patch)
+
+
 @pytest.mark.parametrize(
     ("patch", "expected"),
     [
-        ({"unknown": True}, {}),
-        ({"generation": {"unknown": True}}, {"generation": {}}),
+        ({"strict_config": False, "unknown": True}, {"strict_config": False}),
+        (
+            {"strict_config": False, "generation": {"unknown": True}},
+            {"strict_config": False, "generation": {}},
+        ),
     ],
 )
-def test_from_config_patch_ignores_unknown_mapping_keys(patch: dict[str, object], expected: dict[str, object]):
+def test_from_config_patch_ignores_unknown_mapping_keys_when_non_strict(
+    patch: dict[str, object], expected: dict[str, object]
+):
     config = SafeSynthesizerParameters.from_config_patch(patch)
 
     assert config.model_dump(exclude_unset=True) == expected
 
 
 def test_with_config_patch_ignores_unknown_mapping_keys_and_preserves_sparse_base():
-    config = SafeSynthesizerParameters.model_validate({"generation": {"num_records": 77}})
+    config = SafeSynthesizerParameters.model_validate({"strict_config": False, "generation": {"num_records": 77}})
 
     merged = config.with_config_patch({"unknown": True, "generation": {"unknown": True, "temperature": 0.7}})
 
-    assert merged.model_dump(exclude_unset=True) == {"generation": {"num_records": 77, "temperature": 0.7}}
+    assert merged.model_dump(exclude_unset=True) == {
+        "generation": {"num_records": 77, "temperature": 0.7},
+        "strict_config": False,
+    }
+
+
+def test_with_config_patch_uses_patch_strictness_for_sibling_keys():
+    strict = SafeSynthesizerParameters()
+    relaxed = strict.with_config_patch({"strict_config": False, "unknown": True})
+    assert relaxed.strict_config is False
+
+    with pytest.raises(ParameterError, match="unknown"):
+        relaxed.with_config_patch({"strict_config": True, "unknown": True})
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"evaluate": {}},
+        {"training": {"epoch": 1}},
+    ],
+)
+def test_unknown_fields_are_rejected_recursively_by_default(data: dict[str, object]):
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        SafeSynthesizerParameters.model_validate(data)
+
+
+def test_unknown_fields_are_ignored_recursively_when_non_strict():
+    config = SafeSynthesizerParameters.model_validate(
+        {"strict_config": False, "evaluate": {}, "training": {"epoch": 1}}
+    )
+
+    assert config.strict_config is False
+
+
+def test_strict_config_reaches_models_inside_collections():
+    raw = SafeSynthesizerParameters().model_dump()
+    assert isinstance(raw["replace_pii"], dict)
+    raw["replace_pii"]["steps"][0]["unknown"] = True  # type: ignore[index]
+
+    with pytest.raises(ValidationError, match="unknown"):
+        SafeSynthesizerParameters.model_validate(raw)
+
+    raw["strict_config"] = False
+    assert SafeSynthesizerParameters.model_validate(raw).strict_config is False
+
+
+def test_service_job_config_preserves_dynamic_strictness():
+    payload: dict[str, object] = {"data_source": "dataset", "config": {"training": {"epoch": 1}}}
+    with pytest.raises(ValidationError, match="epoch"):
+        SafeSynthesizerJobConfig.model_validate(payload)
+
+    payload["config"] = {"strict_config": False, "training": {"epoch": 1}}
+    job = SafeSynthesizerJobConfig.model_validate(payload)
+    assert job.config.strict_config is False
 
 
 def test_with_config_patch_keeps_validator_and_factory_defaults_implicit():

--- a/tests/sdk/test_config_builder.py
+++ b/tests/sdk/test_config_builder.py
@@ -91,18 +91,25 @@ def test_builder_rejects_unknown_raw_mapping_keys_by_default():
         ConfigBuilder().with_train({"epoch": 1})
 
 
-def test_builder_non_strict_mode_ignores_unknown_raw_mapping_keys():
-    builder = ConfigBuilder().with_strict_config(False).with_train({"epoch": 1})
+def test_builder_ignore_policy_ignores_unknown_raw_mapping_keys():
+    builder = ConfigBuilder(unknown_fields="ignore").with_train({"epoch": 1})
 
-    assert builder._strict_config is False
+    assert builder._effective_unknown_fields == "ignore"
     assert builder._training_config == TrainingHyperparams()
 
 
-def test_builder_resolves_and_preserves_strict_config():
-    builder = ConfigBuilder().with_strict_config(False).with_data_source(pd.DataFrame({"value": [1]})).resolve()
+def test_builder_resolves_and_preserves_unknown_field_policy():
+    builder = ConfigBuilder(unknown_fields="ignore").with_data_source(pd.DataFrame({"value": [1]})).resolve()
 
     assert builder._nss_config is not None
-    assert builder._nss_config.strict_config is False
+    assert builder._nss_config.unknown_fields == "ignore"
+
+
+def test_builder_constructor_policy_overrides_seed_config_for_raw_mappings():
+    seed = SafeSynthesizerParameters(unknown_fields="ignore")
+
+    with pytest.raises(ParameterError, match="epoch"):
+        ConfigBuilder(seed, unknown_fields="reject").with_train({"epoch": 1})
 
 
 def test_with_generate_validates_raw_config_with_kwargs():

--- a/tests/sdk/test_config_builder.py
+++ b/tests/sdk/test_config_builder.py
@@ -92,10 +92,10 @@ def test_builder_rejects_unknown_raw_mapping_keys_by_default():
 
 
 def test_builder_ignore_policy_ignores_unknown_raw_mapping_keys():
-    builder = ConfigBuilder(unknown_fields="ignore").with_train({"epoch": 1})
+    builder = ConfigBuilder(unknown_fields="ignore").with_train({"batch_size": 32, "epoch": 1})
 
     assert builder._effective_unknown_fields == "ignore"
-    assert builder._training_config == TrainingHyperparams()
+    assert builder._training_config == TrainingHyperparams(batch_size=32)
 
 
 def test_builder_resolves_and_preserves_unknown_field_policy():

--- a/tests/sdk/test_config_builder.py
+++ b/tests/sdk/test_config_builder.py
@@ -86,6 +86,25 @@ def test_builder_methods_reject_wrong_typed_model(method_name: str):
         getattr(ConfigBuilder(), method_name)(config=wrong)
 
 
+def test_builder_rejects_unknown_raw_mapping_keys_by_default():
+    with pytest.raises(ParameterError, match="epoch"):
+        ConfigBuilder().with_train({"epoch": 1})
+
+
+def test_builder_non_strict_mode_ignores_unknown_raw_mapping_keys():
+    builder = ConfigBuilder().with_strict_config(False).with_train({"epoch": 1})
+
+    assert builder._strict_config is False
+    assert builder._training_config == TrainingHyperparams()
+
+
+def test_builder_resolves_and_preserves_strict_config():
+    builder = ConfigBuilder().with_strict_config(False).with_data_source(pd.DataFrame({"value": [1]})).resolve()
+
+    assert builder._nss_config is not None
+    assert builder._nss_config.strict_config is False
+
+
 def test_with_generate_validates_raw_config_with_kwargs():
     with pytest.raises(ValidationError, match="patience"):
         ConfigBuilder().with_generate(config={"num_records": 10}, patience=0)

--- a/tests/sdk/test_process_data.py
+++ b/tests/sdk/test_process_data.py
@@ -505,34 +505,39 @@ class TestLoadFromSavePath:
         with pytest.raises(ValidationError, match="epoch"):
             builder.load_from_save_path()
 
-    @pytest.mark.parametrize("use_runtime_config", [False, True], ids=["builder-policy", "runtime-policy"])
+    @pytest.mark.parametrize("policy_source", ["saved", "builder", "runtime"])
     @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
     def test_load_can_ignore_unknown_legacy_saved_fields(
         self,
         mock_metadata_cls,
-        use_runtime_config,
+        policy_source,
         tmp_path,
         fixture_sample_patient_dataframe,
         fixture_sample_patient_redacted_dataframe,
     ):
-        """An explicit non-strict resume policy applies before saved-config validation."""
+        """A persisted or overriding non-strict policy applies during saved-config validation."""
         workdir, _, _ = self._prepare_workdir(
             tmp_path,
             fixture_sample_patient_dataframe,
             fixture_sample_patient_redacted_dataframe,
         )
         saved_config = SafeSynthesizerParameters().model_dump(mode="json")
-        saved_config.pop("strict_config")
+        if policy_source == "saved":
+            saved_config["strict_config"] = False
+        else:
+            saved_config.pop("strict_config")
         saved_config["training"]["epoch"] = 1
         workdir.config.write_text(json.dumps(saved_config))
         mock_metadata_cls.from_metadata_json.return_value = MagicMock()
 
-        runtime_config = SafeSynthesizerParameters.model_validate({"strict_config": False})
-        builder = SafeSynthesizer(config=runtime_config if use_runtime_config else None, workdir=workdir)
-        if not use_runtime_config:
+        runtime_config = (
+            SafeSynthesizerParameters.model_validate({"strict_config": False}) if policy_source == "runtime" else None
+        )
+        builder = SafeSynthesizer(config=runtime_config, workdir=workdir)
+        if policy_source == "builder":
             builder.with_strict_config(False)
 
-        builder.load_from_save_path(runtime_config=runtime_config if use_runtime_config else None)
+        builder.load_from_save_path(runtime_config=runtime_config)
 
         assert builder._nss_config is not None
         assert builder._nss_config.strict_config is False

--- a/tests/sdk/test_process_data.py
+++ b/tests/sdk/test_process_data.py
@@ -12,11 +12,13 @@ tests verify the separation, persistence, and round-trip through
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
+from pydantic import ValidationError
 
 from nemo_safe_synthesizer.cli.artifact_structure import Workdir
 from nemo_safe_synthesizer.config import SafeSynthesizerParameters
@@ -477,6 +479,64 @@ class TestLoadFromSavePath:
         assert builder._training_df is None  # generation-evaluation resume path doesn't need the transformed df
         assert builder._original_training_df is not None
         pd.testing.assert_frame_equal(builder._original_training_df, train_split)
+
+    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    def test_load_rejects_unknown_legacy_saved_fields_by_default(
+        self,
+        mock_metadata_cls,
+        tmp_path,
+        fixture_sample_patient_dataframe,
+        fixture_sample_patient_redacted_dataframe,
+    ):
+        """Saved configs retain strict validation when no resume opt-out is set."""
+        workdir, _, _ = self._prepare_workdir(
+            tmp_path,
+            fixture_sample_patient_dataframe,
+            fixture_sample_patient_redacted_dataframe,
+        )
+        saved_config = SafeSynthesizerParameters().model_dump(mode="json")
+        saved_config.pop("strict_config")
+        saved_config["training"]["epoch"] = 1
+        workdir.config.write_text(json.dumps(saved_config))
+        mock_metadata_cls.from_metadata_json.return_value = MagicMock()
+
+        builder = SafeSynthesizer(config=SafeSynthesizerParameters(), workdir=workdir)
+
+        with pytest.raises(ValidationError, match="epoch"):
+            builder.load_from_save_path()
+
+    @pytest.mark.parametrize("use_runtime_config", [False, True], ids=["builder-policy", "runtime-policy"])
+    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    def test_load_can_ignore_unknown_legacy_saved_fields(
+        self,
+        mock_metadata_cls,
+        use_runtime_config,
+        tmp_path,
+        fixture_sample_patient_dataframe,
+        fixture_sample_patient_redacted_dataframe,
+    ):
+        """An explicit non-strict resume policy applies before saved-config validation."""
+        workdir, _, _ = self._prepare_workdir(
+            tmp_path,
+            fixture_sample_patient_dataframe,
+            fixture_sample_patient_redacted_dataframe,
+        )
+        saved_config = SafeSynthesizerParameters().model_dump(mode="json")
+        saved_config.pop("strict_config")
+        saved_config["training"]["epoch"] = 1
+        workdir.config.write_text(json.dumps(saved_config))
+        mock_metadata_cls.from_metadata_json.return_value = MagicMock()
+
+        runtime_config = SafeSynthesizerParameters.model_validate({"strict_config": False})
+        builder = SafeSynthesizer(config=runtime_config if use_runtime_config else None, workdir=workdir)
+        if not use_runtime_config:
+            builder.with_strict_config(False)
+
+        builder.load_from_save_path(runtime_config=runtime_config if use_runtime_config else None)
+
+        assert builder._nss_config is not None
+        assert builder._nss_config.strict_config is False
+        assert not hasattr(builder._nss_config.training, "epoch")
 
     @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
     def test_load_applies_runtime_generation_and_evaluation_config(

--- a/tests/sdk/test_process_data.py
+++ b/tests/sdk/test_process_data.py
@@ -495,7 +495,7 @@ class TestLoadFromSavePath:
             fixture_sample_patient_redacted_dataframe,
         )
         saved_config = SafeSynthesizerParameters().model_dump(mode="json")
-        saved_config.pop("strict_config")
+        saved_config.pop("unknown_fields")
         saved_config["training"]["epoch"] = 1
         workdir.config.write_text(json.dumps(saved_config))
         mock_metadata_cls.from_metadata_json.return_value = MagicMock()
@@ -515,7 +515,7 @@ class TestLoadFromSavePath:
         fixture_sample_patient_dataframe,
         fixture_sample_patient_redacted_dataframe,
     ):
-        """A persisted or overriding non-strict policy applies during saved-config validation."""
+        """A persisted or overriding ignore policy applies during saved-config validation."""
         workdir, _, _ = self._prepare_workdir(
             tmp_path,
             fixture_sample_patient_dataframe,
@@ -523,24 +523,28 @@ class TestLoadFromSavePath:
         )
         saved_config = SafeSynthesizerParameters().model_dump(mode="json")
         if policy_source == "saved":
-            saved_config["strict_config"] = False
+            saved_config["unknown_fields"] = "ignore"
         else:
-            saved_config.pop("strict_config")
+            saved_config.pop("unknown_fields")
         saved_config["training"]["epoch"] = 1
         workdir.config.write_text(json.dumps(saved_config))
         mock_metadata_cls.from_metadata_json.return_value = MagicMock()
 
         runtime_config = (
-            SafeSynthesizerParameters.model_validate({"strict_config": False}) if policy_source == "runtime" else None
+            SafeSynthesizerParameters.model_validate({"unknown_fields": "ignore"})
+            if policy_source == "runtime"
+            else None
         )
-        builder = SafeSynthesizer(config=runtime_config, workdir=workdir)
-        if policy_source == "builder":
-            builder.with_strict_config(False)
+        builder = SafeSynthesizer(
+            config=runtime_config,
+            workdir=workdir,
+            unknown_fields="ignore" if policy_source == "builder" else None,
+        )
 
         builder.load_from_save_path(runtime_config=runtime_config)
 
         assert builder._nss_config is not None
-        assert builder._nss_config.strict_config is False
+        assert builder._nss_config.unknown_fields == "ignore"
         assert not hasattr(builder._nss_config.training, "epoch")
 
     @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")


### PR DESCRIPTION
## Summary
- add `unknown_fields: reject | ignore` to reject unknown configuration keys recursively by default, with an explicit compatibility mode for stale configs, notebooks, and version-skewed clients or services
- apply the effective policy consistently across direct validation, config files, sparse patches, SDK builders, service payloads, and resume-time loading and overrides
- remove private Pydantic initializer shortcuts, document complete-input versus patch inheritance, and add regression coverage for recursive filtering and preservation
- use Docker for the end-user wheel check on GitHub runners to avoid the incompatible Podman 5.8.4 and `crun` combination

## Test plan
- [x] `mise run format-check`
- [x] targeted typechecking for changed Python files
- [x] affected config, SDK, and CLI tests (145 passed)

Closes #448