### PR TITLE
chore: persist train/test/transformed_training csvs before preflight check

### DIFF
--- a/src/nemo_safe_synthesizer/sdk/library_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/library_builder.py
@@ -427,6 +427,24 @@ class SafeSynthesizer(ConfigBuilder):
             # We explicitly do not replace PII in the test set so that the
             # privacy metrics are valid.
 
+        # Persist the train/test splits now -- before the full preflight run
+        # below -- so that a preflight failure (e.g. group_exceeds_context)
+        # still leaves the processed datasets on disk for inspection. Skipped on
+        # the ``--validate`` path (``check_only``), which intentionally elides
+        # CSV writes.
+        if not check_only:
+            assert self._workdir is not None
+            self._workdir.ensure_directories()
+            # ``training.csv`` is the canonical persisted original training
+            # split -- reloaded by load_from_save_path and used for evaluation.
+            self._original_training_df.to_csv(self._workdir.dataset.training, index=False)
+            if not self._training_df.equals(self._original_training_df):
+                # The transformed (e.g. PII-replaced) training data is saved for
+                # inspection only -- we don't need it in generation or evaluation.
+                self._training_df.to_csv(self._workdir.dataset.transformed_training, index=False)
+            if self._test_df is not None:
+                self._test_df.to_csv(self._workdir.dataset.test, index=False)
+
         # Only create new metadata if not already loaded (e.g., from load_from_save_path)
         metadata_for_preflight = self._llm_metadata
         if metadata_for_preflight is None:
@@ -474,19 +492,6 @@ class SafeSynthesizer(ConfigBuilder):
             return self
 
         self._data_processed = True
-
-        # Always persist the original training split -- this is the version
-        # reloaded by load_from_save_path and used for evaluation metrics.
-        assert self._workdir is not None
-        self._workdir.ensure_directories()
-        # ``training.csv`` is the canonical persisted original training split.
-        self._original_training_df.to_csv(self._workdir.dataset.training, index=False)
-        if not self._training_df.equals(self._original_training_df):
-            # The transformed (e.g. PII-replaced) training data is saved for
-            # inspection only -- we don't need it in the generation or evaluation phase.
-            self._training_df.to_csv(self._workdir.dataset.transformed_training, index=False)
-        if self._test_df is not None:
-            self._test_df.to_csv(self._workdir.dataset.test, index=False)
         return self
 
     @traced("SafeSynthesizer.train", category=LogCategory.RUNTIME)


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->
A quick adjustment to the order of operations around preflight:
Current behavior:
train/test split -> PII replacement -> preflight check -> persisting train/test/transformed_train
New behavior: 
train/test split -> PII replacement -> persisting train/test/transformed_train -> preflight check

This is so that if preflight fails, we have the transformed training split to inspect. This happened to me because a faulty PII replacement prototype altered the shape of the input data significantly, thus failing the preflight. I suspect this would happen less frequently for main, but maybe it doesn't hurt to have? I'm open to closing this PR if we think this is not worth the while.

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Processed training and test datasets are now saved before validation completes, making them available for inspection even when validation encounters an error.
  * Validation-only checks no longer write processed datasets or transformed training data to disk.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->