### PR TITLE
fix: allow relaxing numeric ranges for highly numeric datasets

### DIFF
--- a/src/nemo_safe_synthesizer/config/generate.py
+++ b/src/nemo_safe_synthesizer/config/generate.py
@@ -114,6 +114,26 @@ class ValidationParameters(Parameters, BaseModel):
         ),
     ] = False
 
+    enforce_numeric_range: Annotated[
+        bool,
+        Field(
+            title="enforce_numeric_range",
+            description=(
+                "Whether generated floating-point values must fall within the "
+                "minimum/maximum observed in training. The schema records each numeric "
+                "column's exact observed range, but no structured-generation backend can "
+                "constrain a floating-point magnitude (integers and enums are enforced by "
+                "the grammar; floats are not), so these bounds act only as a post-generation "
+                "validation gate. On wide float tables the per-field rejections compound and "
+                "can invalidate nearly every otherwise well-formed record (rejected as "
+                "``Field value must be less/greater than ...``). Set to ``False`` to drop the "
+                "float range check so out-of-range floating-point values are accepted; integer "
+                "and enum constraints remain enforced. Leave ``True`` (the default) to preserve "
+                "strict range validation."
+            ),
+        ),
+    ] = True
+
 
 class StructuredGenerationParameters(Parameters, BaseModel):
     """Configuration for vLLM structured generation.

--- a/src/nemo_safe_synthesizer/config/generate.py
+++ b/src/nemo_safe_synthesizer/config/generate.py
@@ -119,17 +119,8 @@ class ValidationParameters(Parameters, BaseModel):
         Field(
             title="enforce_numeric_range",
             description=(
-                "Whether generated floating-point values must fall within the "
-                "minimum/maximum observed in training. The schema records each numeric "
-                "column's exact observed range, but no structured-generation backend can "
-                "constrain a floating-point magnitude (integers and enums are enforced by "
-                "the grammar; floats are not), so these bounds act only as a post-generation "
-                "validation gate. On wide float tables the per-field rejections compound and "
-                "can invalidate nearly every otherwise well-formed record (rejected as "
-                "``Field value must be less/greater than ...``). Set to ``False`` to drop the "
-                "float range check so out-of-range floating-point values are accepted; integer "
-                "and enum constraints remain enforced. Leave ``True`` (the default) to preserve "
-                "strict range validation."
+                "When True, reject floats outside the training-observed min/max. "
+                "Set False to skip float range checks (integers/enums still enforced)."
             ),
         ),
     ] = True

--- a/src/nemo_safe_synthesizer/data_processing/dataset.py
+++ b/src/nemo_safe_synthesizer/data_processing/dataset.py
@@ -167,6 +167,49 @@ def make_json_schema(df: pd.DataFrame, string_length_multiple: float = STRING_LE
     return schema
 
 
+def relax_numeric_bounds(schema: dict) -> dict:
+    """Return a copy of ``schema`` with float (``number``) range bounds removed.
+
+    ``make_json_schema`` records each numeric column's exact observed
+    ``minimum``/``maximum``. Neither structured-generation backend can enforce a
+    floating-point range (XGrammar and the regex builder bound integers and
+    enums but emit an unconstrained token stream for ``number``), so those bounds
+    act purely as a post-generation validation gate. On wide float tables the
+    per-field rejections compound and can reject nearly every record even though
+    the values are otherwise well-formed. Dropping the ``number`` bounds turns
+    that hard rejection into acceptance while leaving integer and enum
+    constraints -- which the grammar does enforce -- untouched.
+
+    Only ``number``-typed properties are relaxed; a property whose type list
+    includes ``integer`` keeps its (grammar-enforced, whole-number) bounds so the
+    XGrammar constraint stays valid.
+
+    Args:
+        schema: A JSON schema as produced by ``make_json_schema``.
+
+    Returns:
+        A deep-ish copy of ``schema`` with ``minimum``/``maximum`` stripped from
+        pure ``number`` properties. The input is not mutated.
+    """
+    relaxed = dict(schema)
+    properties = relaxed.get("properties")
+    if not isinstance(properties, dict):
+        return relaxed
+
+    new_properties: dict = {}
+    for name, prop in properties.items():
+        if isinstance(prop, dict):
+            types = prop.get("type")
+            types = types if isinstance(types, list) else [types]
+            # Relax only pure floats; keep integer bounds (grammar-enforced and
+            # required to be whole numbers) and enum constraints intact.
+            if "number" in types and "integer" not in types:
+                prop = {k: v for k, v in prop.items() if k not in ("minimum", "maximum")}
+        new_properties[name] = prop
+    relaxed["properties"] = new_properties
+    return relaxed
+
+
 def normalize_dataframe(df: pd.DataFrame) -> pd.DataFrame:
     """Ensure DataFrame meets standards for use in Safe Synthesizer models.
 

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -31,6 +31,7 @@ from ..config.generate import (
     resolve_structured_generation_schema_method,
     structural_tag_backend_error_message,
 )
+from ..data_processing.dataset import relax_numeric_bounds
 from ..defaults import DEFAULT_SAMPLING_PARAMETERS, FIXED_RUNTIME_GENERATE_ARGS
 from ..errors import InternalError, ParameterError
 from ..generation.backend import GeneratorBackend
@@ -249,6 +250,11 @@ class VllmBackend(GeneratorBackend):
         self.remote = False
         self.workdir = workdir
         self.schema = load_json(self.workdir.schema_file)
+        if not self.config.generation.validation.enforce_numeric_range:
+            # Drop float range bounds so out-of-range floating-point values are
+            # accepted instead of rejected in post-generation validation. Integer
+            # and enum constraints (which the grammar enforces) are unaffected.
+            self.schema = relax_numeric_bounds(self.schema)
         self.columns = list(self.schema["properties"].keys())
         self.prompt = utils.create_schema_prompt(
             self.columns,

--- a/tests/data_processing/test_dataset.py
+++ b/tests/data_processing/test_dataset.py
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pandas as pd
+
+from nemo_safe_synthesizer.data_processing.dataset import make_json_schema, relax_numeric_bounds
+
+
+def test_relax_numeric_bounds_strips_float_bounds():
+    schema = {
+        "type": "object",
+        "properties": {
+            "ratio": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+        },
+        "required": ["ratio"],
+    }
+    relaxed = relax_numeric_bounds(schema)
+    assert "minimum" not in relaxed["properties"]["ratio"]
+    assert "maximum" not in relaxed["properties"]["ratio"]
+    assert relaxed["properties"]["ratio"]["type"] == "number"
+
+
+def test_relax_numeric_bounds_keeps_integer_and_enum_bounds():
+    schema = {
+        "type": "object",
+        "properties": {
+            "count": {"type": "integer", "minimum": 1, "maximum": 10},
+            "category": {"enum": [1, 2, 3]},
+        },
+    }
+    relaxed = relax_numeric_bounds(schema)
+    assert relaxed["properties"]["count"] == {"type": "integer", "minimum": 1, "maximum": 10}
+    assert relaxed["properties"]["category"] == {"enum": [1, 2, 3]}
+
+
+def test_relax_numeric_bounds_handles_type_list_with_null():
+    schema = {
+        "type": "object",
+        "properties": {
+            "maybe_float": {"type": ["number", "null"], "minimum": -5.0, "maximum": 5.0},
+            "maybe_int": {"type": ["integer", "null"], "minimum": 0, "maximum": 9},
+        },
+    }
+    relaxed = relax_numeric_bounds(schema)
+    # A nullable float is still relaxed; a nullable integer keeps its bounds.
+    assert "minimum" not in relaxed["properties"]["maybe_float"]
+    assert "maximum" not in relaxed["properties"]["maybe_float"]
+    assert relaxed["properties"]["maybe_int"]["minimum"] == 0
+    assert relaxed["properties"]["maybe_int"]["maximum"] == 9
+
+
+def test_relax_numeric_bounds_does_not_mutate_input():
+    schema = {
+        "type": "object",
+        "properties": {"ratio": {"type": "number", "minimum": 0.0, "maximum": 1.0}},
+    }
+    relax_numeric_bounds(schema)
+    assert schema["properties"]["ratio"]["minimum"] == 0.0
+    assert schema["properties"]["ratio"]["maximum"] == 1.0
+
+
+def test_relax_numeric_bounds_on_make_json_schema_output():
+    df = pd.DataFrame(
+        {
+            "flt": [0.11, 0.52, 0.93, 0.34, 0.75, 0.16, 0.27, 0.68, 0.49, 0.80, 0.13, 0.94],
+            "txt": ["a", "bb", "ccc", "dd", "e", "ff", "g", "hh", "iii", "j", "kk", "l"],
+        }
+    )
+    schema = make_json_schema(df)
+    assert schema["properties"]["flt"]["type"] == "number"
+    assert "maximum" in schema["properties"]["flt"]
+
+    relaxed = relax_numeric_bounds(schema)
+    assert "minimum" not in relaxed["properties"]["flt"]
+    assert "maximum" not in relaxed["properties"]["flt"]
+    # String bounds are untouched.
+    assert relaxed["properties"]["txt"].get("maxLength") == schema["properties"]["txt"].get("maxLength")


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration option to enable or disable validation of generated floating-point values against observed numeric ranges (enabled by default).
  * When disabled, floating-point bounds are relaxed while integer limits and enum constraints remain enforced.
  * Numeric bound relaxation is applied consistently during generation schema handling, including nullable numeric fields.
* **Tests**
  * Added unit tests covering float bound stripping, preservation of integer/enum constraints, nullable behavior, input-schema immutability, and end-to-end schema integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->