### PR TITLE
fix: add a mechanism for allowing more max tokens

### DIFF
--- a/src/nemo_safe_synthesizer/config/generate.py
+++ b/src/nemo_safe_synthesizer/config/generate.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import math
 import warnings
 from collections.abc import Mapping
 from typing import Annotated, Any, ClassVar, Literal, Self
@@ -243,12 +244,12 @@ class GenerateParameters(Parameters, BaseModel):
 
     max_tokens_multiplier: Annotated[
         float,
-        ValueValidator(value_func=lambda v: v > 0),
+        ValueValidator(value_func=lambda v: math.isfinite(v) and v > 0),
         Field(
             title="max_tokens_multiplier",
             description=(
                 "Multiplier on the longest training example when sizing per-sample "
-                "max_tokens. Must be > 0. Default 1.2."
+                "max_tokens. Must be a finite value > 0. Default 1.2."
             ),
         ),
     ] = 1.2  # mirrors llm.metadata.GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER (kept a literal to avoid a config->llm import cycle)

--- a/src/nemo_safe_synthesizer/config/generate.py
+++ b/src/nemo_safe_synthesizer/config/generate.py
@@ -241,6 +241,28 @@ class GenerateParameters(Parameters, BaseModel):
         ),
     ] = 0.8
 
+    max_tokens_multiplier: Annotated[
+        float,
+        ValueValidator(value_func=lambda v: v > 0),
+        Field(
+            title="max_tokens_multiplier",
+            description=(
+                "Margin applied to the longest tokenized training example "
+                "(``max_tokens_per_example``) when sizing the per-sample generation "
+                "budget (``SamplingParams.max_tokens``). The effective budget is "
+                "``int(max_tokens_per_example * max_tokens_multiplier)``, still clamped "
+                "to the remaining context window. The default adds only a small jitter "
+                "margin, which suffices for most tables but is too tight for long, "
+                "unbounded free-text columns: a model that over-generates slightly past "
+                "the longest training example truncates mid-JSON and produces no "
+                "parseable record (``length``-dominated finish reasons, zero valid "
+                "records). Raise this (e.g. to 1.5-2.0) to give the model room to emit "
+                "the closing tokens on such datasets; there is no benefit to values that "
+                "push the budget past the context window. Must be > 0."
+            ),
+        ),
+    ] = 1.2  # mirrors llm.metadata.GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER (kept a literal to avoid a config->llm import cycle)
+
     structured_generation: StructuredGenerationParameters = Field(
         description="Structured generation parameters controlling schema-constrained output.",
         default_factory=StructuredGenerationParameters,

--- a/src/nemo_safe_synthesizer/config/generate.py
+++ b/src/nemo_safe_synthesizer/config/generate.py
@@ -247,18 +247,8 @@ class GenerateParameters(Parameters, BaseModel):
         Field(
             title="max_tokens_multiplier",
             description=(
-                "Margin applied to the longest tokenized training example "
-                "(``max_tokens_per_example``) when sizing the per-sample generation "
-                "budget (``SamplingParams.max_tokens``). The effective budget is "
-                "``int(max_tokens_per_example * max_tokens_multiplier)``, still clamped "
-                "to the remaining context window. The default adds only a small jitter "
-                "margin, which suffices for most tables but is too tight for long, "
-                "unbounded free-text columns: a model that over-generates slightly past "
-                "the longest training example truncates mid-JSON and produces no "
-                "parseable record (``length``-dominated finish reasons, zero valid "
-                "records). Raise this (e.g. to 1.5-2.0) to give the model room to emit "
-                "the closing tokens on such datasets; there is no benefit to values that "
-                "push the budget past the context window. Must be > 0."
+                "Multiplier on the longest training example when sizing per-sample "
+                "max_tokens. Must be > 0. Default 1.2."
             ),
         ),
     ] = 1.2  # mirrors llm.metadata.GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER (kept a literal to avoid a config->llm import cycle)

--- a/src/nemo_safe_synthesizer/generation/timeseries_backend.py
+++ b/src/nemo_safe_synthesizer/generation/timeseries_backend.py
@@ -921,7 +921,10 @@ class TimeseriesBackend(VllmBackend):
             top_p=self.config.generation.top_p,
             top_k=FIXED_RUNTIME_GENERATE_ARGS["top_k"],
             min_p=FIXED_RUNTIME_GENERATE_ARGS["min_p"],
-            max_tokens=self.model_metadata.generation_max_tokens_for(self._get_prompt_token_count()),
+            max_tokens=self.model_metadata.generation_max_tokens_for(
+                self._get_prompt_token_count(),
+                multiplier=self.config.generation.max_tokens_multiplier,
+            ),
             skip_special_tokens=True,
             include_stop_str_in_output=False,
             ignore_eos=False,

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -738,7 +738,10 @@ class VllmBackend(GeneratorBackend):
             top_p=self.config.generation.top_p,
             top_k=FIXED_RUNTIME_GENERATE_ARGS["top_k"],
             min_p=FIXED_RUNTIME_GENERATE_ARGS["min_p"],
-            max_tokens=self.model_metadata.generation_max_tokens_for(self._get_prompt_token_count()),
+            max_tokens=self.model_metadata.generation_max_tokens_for(
+                self._get_prompt_token_count(),
+                multiplier=self.config.generation.max_tokens_multiplier,
+            ),
             skip_special_tokens=not need_special_token_outputs,
             include_stop_str_in_output=need_special_token_outputs,
             ignore_eos=False,

--- a/src/nemo_safe_synthesizer/llm/metadata.py
+++ b/src/nemo_safe_synthesizer/llm/metadata.py
@@ -450,13 +450,13 @@ class ModelMetadata(BaseModel):
             rsf = self.rope_scaling.factor
         return int((self.base_max_seq_length or DEFAULT_MAX_SEQ_LENGTH) * rsf)
 
-    def generation_max_tokens_for(self, prompt_len: int) -> int:
+    def generation_max_tokens_for(self, prompt_len: int, multiplier: float | None = None) -> int:
         """Per-sample ``max_tokens`` ceiling, prompt-aware.
 
         Returns the smaller of:
 
-        1. ``int(max_tokens_per_example * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)``
-           when the assembler stat is populated, else ``max_seq_length``.
+        1. ``int(max_tokens_per_example * multiplier)`` when the assembler stat
+           is populated, else ``max_seq_length``.
         2. ``max_seq_length - prompt_len`` -- vLLM raises when
            ``len(prompt) + max_tokens > max_model_len``
            (`vllm#33418 <https://github.com/vllm-project/vllm/issues/33418>`_).
@@ -468,15 +468,29 @@ class ModelMetadata(BaseModel):
         clamp is a defensive belt for legacy adapters where the assembler
         stat is missing and for prompts longer than those seen in training.
 
+        The default ``multiplier`` (``GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER``)
+        adds only a small jitter margin, which is enough for most tables but
+        too tight for long, unbounded free-text columns: a model that
+        over-generates slightly past the longest training example truncates
+        mid-JSON and yields no parseable record. Callers wire the user-facing
+        ``generation.max_tokens_multiplier`` knob through here to widen the
+        budget (bounded by the context window) for such datasets.
+
         Args:
             prompt_len: Tokenized length of the prompt this sample will
                 run against. Pass ``0`` to disable the prompt clamp.
+            multiplier: Margin applied to ``max_tokens_per_example``. Defaults
+                to ``GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER`` when ``None`` so
+                non-generation callers (e.g. the training eval callback) keep
+                the legacy sizing.
 
         Returns:
             Non-negative ``max_tokens`` value safe to feed to ``SamplingParams``.
         """
+        if multiplier is None:
+            multiplier = GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER
         if self.max_tokens_per_example and self.max_tokens_per_example > 0:
-            sized = int(self.max_tokens_per_example * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)
+            sized = int(self.max_tokens_per_example * multiplier)
         else:
             sized = self.max_seq_length
         return max(0, min(sized, self.max_seq_length - prompt_len))

--- a/tests/config/test_generate.py
+++ b/tests/config/test_generate.py
@@ -231,8 +231,8 @@ class TestMaxTokensMultiplier:
         """Users can widen the budget for long free-text datasets."""
         assert GenerateParameters(max_tokens_multiplier=1.8).max_tokens_multiplier == 1.8
 
-    @pytest.mark.parametrize("value", [0, -0.5])
+    @pytest.mark.parametrize("value", [0, -0.5, float("inf"), float("-inf"), float("nan")])
     def test_rejects_non_positive(self, value: float) -> None:
-        """Non-positive multipliers are rejected by the validator."""
+        """Non-positive and non-finite multipliers are rejected by the validator."""
         with pytest.raises(ValidationError):
             GenerateParameters(max_tokens_multiplier=value)

--- a/tests/config/test_generate.py
+++ b/tests/config/test_generate.py
@@ -217,3 +217,22 @@ class TestMixedInputMigration:
         assert params.structured_generation.backend == "xgrammar"
         assert params.structured_generation.schema_method == "structural_tag"
         assert params.structured_generation.use_single_sequence is True
+
+
+@pytest.mark.unit
+class TestMaxTokensMultiplier:
+    def test_default_matches_metadata_constant(self) -> None:
+        """The config default mirrors the metadata safety-margin constant."""
+        from nemo_safe_synthesizer.llm.metadata import GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER
+
+        assert GenerateParameters().max_tokens_multiplier == GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER
+
+    def test_accepts_widened_value(self) -> None:
+        """Users can widen the budget for long free-text datasets."""
+        assert GenerateParameters(max_tokens_multiplier=1.8).max_tokens_multiplier == 1.8
+
+    @pytest.mark.parametrize("value", [0, -0.5])
+    def test_rejects_non_positive(self, value: float) -> None:
+        """Non-positive multipliers are rejected by the validator."""
+        with pytest.raises(ValidationError):
+            GenerateParameters(max_tokens_multiplier=value)

--- a/tests/generation/test_vllm_backend.py
+++ b/tests/generation/test_vllm_backend.py
@@ -1043,8 +1043,10 @@ class TestGenerationMaxTokensPlumbing:
         assert captured["max_tokens"] == 4_200
         # Engine is not initialized in this plumbing test, so the cached
         # prompt-token count falls back to 0; the helper is still called
-        # exactly once with that value.
-        mock_model_metadata.generation_max_tokens_for.assert_called_once_with(0)
+        # exactly once with that value plus the configured budget multiplier.
+        mock_model_metadata.generation_max_tokens_for.assert_called_once_with(
+            0, multiplier=base_params.generation.max_tokens_multiplier
+        )
 
     def test_passes_cached_prompt_token_count_when_engine_initialized(
         self, base_params, mock_model_metadata, mock_schema, mock_workdir
@@ -1074,7 +1076,9 @@ class TestGenerationMaxTokensPlumbing:
             backend.generate()
 
         assert captured["max_tokens"] == 4_096
-        mock_model_metadata.generation_max_tokens_for.assert_called_once_with(37)
+        mock_model_metadata.generation_max_tokens_for.assert_called_once_with(
+            37, multiplier=base_params.generation.max_tokens_multiplier
+        )
         # Cached: a second access does not retokenize.
         assert backend._get_prompt_token_count() == 37
         fake_tokenizer.encode.assert_called_once_with(backend.prompt)

--- a/tests/llm/test_metadata.py
+++ b/tests/llm/test_metadata.py
@@ -689,6 +689,32 @@ class TestGenerationMaxTokensFor:
         # Beyond-context prompts still produce a safe value vLLM can accept.
         assert sample_model_metadata.generation_max_tokens_for(sample_model_metadata.max_seq_length + 64) == 0
 
+    def test_metadata_generation_max_tokens_for_none_multiplier_uses_default(self, sample_model_metadata):
+        """``multiplier=None`` reproduces the legacy safety-margin sizing."""
+        sample_model_metadata.max_tokens_per_example = 1000
+        expected = int(1000 * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)
+        assert sample_model_metadata.generation_max_tokens_for(10, multiplier=None) == expected
+        # Explicitly passing the default constant matches the None path.
+        assert (
+            sample_model_metadata.generation_max_tokens_for(10, multiplier=GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)
+            == expected
+        )
+
+    def test_metadata_generation_max_tokens_for_custom_multiplier_widens_budget(self, sample_model_metadata):
+        """A larger multiplier widens the stat-derived budget (the long-text fix)."""
+        sample_model_metadata.max_tokens_per_example = 1000
+        # 1000 * 1.8 = 1800, still within the 2048 window given a small prompt.
+        assert sample_model_metadata.generation_max_tokens_for(10, multiplier=1.8) == 1800
+
+    def test_metadata_generation_max_tokens_for_custom_multiplier_still_clamped_to_window(self, sample_model_metadata):
+        """The prompt/window clamp still binds even with an aggressive multiplier."""
+        assert sample_model_metadata.max_seq_length == 2048
+        sample_model_metadata.max_tokens_per_example = 1500  # * 4.0 = 6000, far past the window
+        prompt_len = 48
+        assert sample_model_metadata.generation_max_tokens_for(prompt_len, multiplier=4.0) == (
+            sample_model_metadata.max_seq_length - prompt_len
+        )
+
     def test_metadata_max_tokens_per_example_round_trips_through_metadata_json(self, sample_model_metadata):
         """``max_tokens_per_example`` persists through save → load."""
         sample_model_metadata.max_tokens_per_example = 1500


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `max_tokens_multiplier` to control the per-request generation token budget, defaulting to **1.2**.
  * Enforced validation to allow only finite values strictly **greater than 0**.
* **Bug Fixes**
  * Improved consistency of max-token budgeting across generation backends by applying the configured multiplier while keeping existing context-window clamping behavior.
* **Tests**
  * Added unit tests for the new multiplier field (default, valid/invalid values including non-finite cases) and for multiplier behavior (including clamping).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->