### PR TITLE
fix: add max_records_per_sequence when generating

### DIFF
--- a/src/nemo_safe_synthesizer/config/generate.py
+++ b/src/nemo_safe_synthesizer/config/generate.py
@@ -171,18 +171,8 @@ class StructuredGenerationParameters(Parameters, BaseModel):
         Field(
             title="max_records_per_sequence",
             description=(
-                "Upper bound on the number of records emitted per group (sequence) when "
-                "structured generation is enabled for grouped data (``group_training_examples_by``). "
-                "The grouped constraint otherwise allows unbounded record repetition inside a "
-                "group, so a model that does not voluntarily emit the closing ``eos_token`` "
-                "delimiter decodes to ``max_tokens`` and produces no parseable group -- every "
-                "completion is length-truncated and rejected as ``Group BOS and/or EOS tokens "
-                "missing``. Bounding the repetition forces the closing delimiter after at most "
-                "this many records, guaranteeing a closeable group. Leave as ``None`` (the "
-                "default) to use the largest group size observed during training "
-                "(``ModelMetadata.max_records_per_group``), which covers every trained group "
-                "with no truncation; set an explicit value only to override that. Enforced by "
-                "both the ``regex`` and ``structural_tag`` schema methods."
+                "Max records per grouped sequence under structured generation. "
+                "None uses the largest training group size. Must be None or >= 1."
             ),
         ),
     ] = None

--- a/src/nemo_safe_synthesizer/config/generate.py
+++ b/src/nemo_safe_synthesizer/config/generate.py
@@ -165,6 +165,28 @@ class StructuredGenerationParameters(Parameters, BaseModel):
         ),
     ] = False
 
+    max_records_per_sequence: Annotated[
+        int | None,
+        ValueValidator(value_func=lambda v: v is None or v >= 1),
+        Field(
+            title="max_records_per_sequence",
+            description=(
+                "Upper bound on the number of records emitted per group (sequence) when "
+                "structured generation is enabled for grouped data (``group_training_examples_by``). "
+                "The grouped constraint otherwise allows unbounded record repetition inside a "
+                "group, so a model that does not voluntarily emit the closing ``eos_token`` "
+                "delimiter decodes to ``max_tokens`` and produces no parseable group -- every "
+                "completion is length-truncated and rejected as ``Group BOS and/or EOS tokens "
+                "missing``. Bounding the repetition forces the closing delimiter after at most "
+                "this many records, guaranteeing a closeable group. Leave as ``None`` (the "
+                "default) to use the largest group size observed during training "
+                "(``ModelMetadata.max_records_per_group``), which covers every trained group "
+                "with no truncation; set an explicit value only to override that. Enforced by "
+                "both the ``regex`` and ``structural_tag`` schema methods."
+            ),
+        ),
+    ] = None
+
     @model_validator(mode="after")
     def _validate_structural_tag_backend(self) -> Self:
         if not self.enabled:

--- a/src/nemo_safe_synthesizer/data_processing/assembler.py
+++ b/src/nemo_safe_synthesizer/data_processing/assembler.py
@@ -1566,6 +1566,7 @@ class GroupedDataExampleAssembler(TrainingExampleAssembler):
                 "tokens_per_group": self.stats["tokens_per_group"],
                 "tokens_per_example": self.stats["tokens_per_example"],
                 "records_per_example": self.stats["records_per_example"],
+                "records_per_group": self.stats["records_per_group"],
                 "groups_per_example": self.stats["groups_per_example"],
             },
         )

--- a/src/nemo_safe_synthesizer/data_processing/assembler.py
+++ b/src/nemo_safe_synthesizer/data_processing/assembler.py
@@ -1405,10 +1405,13 @@ class GroupedDataExampleAssembler(TrainingExampleAssembler):
             group_indices = group_data.index.to_list()
             group = dataset.select(group_indices).remove_columns(group_by).to_dict()
             num_records = len(group["input_ids"])
-            self.stats["records_per_group"].update(num_records)
+            # Keep train/val group-size stats separate so generation bounds derived
+            # from ``records_per_group`` never incorporate holdout groups.
+            stats = self.stats_val if "is_val" in dataset.info.description else self.stats
+            stats["records_per_group"].update(num_records)
             group["input_ids"] = list(chain(*group["input_ids"]))
             group["attention_mask"] = list(chain(*group["attention_mask"]))
-            self.stats["tokens_per_group"].update(len(group["input_ids"]))
+            stats["tokens_per_group"].update(len(group["input_ids"]))
             group.update({"num_records": num_records})
             yield group
 

--- a/src/nemo_safe_synthesizer/generation/regex_manager.py
+++ b/src/nemo_safe_synthesizer/generation/regex_manager.py
@@ -321,12 +321,27 @@ def _build_regex(instance: dict[str, Any], whitespace_pattern: str, **kwargs) ->
             raise NotImplementedError()
 
 
+def _resolve_max_records_per_sequence(
+    config: SafeSynthesizerParameters, default_max_records_per_group: int | None
+) -> int | None:
+    """Effective per-group record bound for grouped structured generation.
+
+    An explicit ``structured_generation.max_records_per_sequence`` override wins;
+    otherwise the training-derived default (``ModelMetadata.max_records_per_group``,
+    the largest group seen during training) is used. ``None`` leaves the per-group
+    repetition unbounded.
+    """
+    override = config.generation.structured_generation.max_records_per_sequence
+    return override if override is not None else default_max_records_per_group
+
+
 def build_json_based_regex(
     schema: dict[str, Any],
     config: SafeSynthesizerParameters,
     bos_token: str,
     eos_token: str,
     whitespace_pattern: str | None = None,
+    default_max_records_per_group: int | None = None,
 ) -> str:
     """Build a regex that constrains LLM output to valid JSONL records.
 
@@ -345,6 +360,9 @@ def build_json_based_regex(
         eos_token: End-of-sequence token (used when grouping).
         whitespace_pattern: Optional regex fragment for matching
             whitespace between JSON tokens.
+        default_max_records_per_group: Training-derived per-group record
+            bound used when ``structured_generation.max_records_per_sequence``
+            is unset. Typically ``ModelMetadata.max_records_per_group``.
 
     Returns:
         Compiled regex string suitable for vLLM's structured-output
@@ -353,14 +371,23 @@ def build_json_based_regex(
     whitespace_pattern = whitespace_pattern or ""
 
     record_regex = _build_regex(schema, whitespace_pattern)
+    max_records = _resolve_max_records_per_sequence(config, default_max_records_per_group)
 
     if config.data.group_training_examples_by is not None:
-        sequence_regex = rf"{re.escape(bos_token)}({record_regex}\n)+{re.escape(eos_token)}"
+        # Bounding the per-group record repetition forces the closing ``eos_token`` after at
+        # most ``max_records`` records. Without it the ``+`` lets a model that never emits the
+        # delimiter decode to ``max_tokens``, yielding a length-truncated, unparseable group.
+        record_repeat = rf"({record_regex}\n){{1,{max_records}}}" if max_records else rf"({record_regex}\n)+"
+        sequence_regex = rf"{re.escape(bos_token)}{record_repeat}{re.escape(eos_token)}"
     else:
         # Without grouping, the "sequence" is a single record.
         sequence_regex = record_regex
 
-    if config.generation.structured_generation.use_single_sequence and config.data.max_sequences_per_example == 1:
+    if config.data.group_training_examples_by is not None and max_records:
+        # Grouped generation produces one group per completion; a bounded single sequence
+        # (no outer repetition) guarantees a terminable, parseable group.
+        regex = sequence_regex
+    elif config.generation.structured_generation.use_single_sequence and config.data.max_sequences_per_example == 1:
         regex = sequence_regex
     else:
         regex = rf"({sequence_regex}\n)+"
@@ -383,11 +410,20 @@ def _plus_format(content: dict[str, Any]) -> dict[str, Any]:
     return {"type": "plus", "content": content}
 
 
+def _repeat_format(content: dict[str, Any], min_count: int, max_count: int) -> dict[str, Any]:
+    """Return a Structural Tag bounded-repetition format (``min``..``max`` inclusive).
+
+    ``max_count=-1`` means unbounded, matching XGrammar's ``RepeatFormat`` semantics.
+    """
+    return {"type": "repeat", "min": min_count, "max": max_count, "content": content}
+
+
 def build_json_structural_tag(
     schema: dict[str, Any],
     config: SafeSynthesizerParameters,
     bos_token: str,
     eos_token: str,
+    default_max_records_per_group: int | None = None,
 ) -> str:
     """Build an XGrammar Structural Tag for schema-constrained JSONL records.
 
@@ -402,6 +438,9 @@ def build_json_structural_tag(
             structured-generation settings).
         bos_token: Beginning-of-sequence token (used when grouping).
         eos_token: End-of-sequence token (used when grouping).
+        default_max_records_per_group: Training-derived per-group record
+            bound used when ``structured_generation.max_records_per_sequence``
+            is unset. Typically ``ModelMetadata.max_records_per_group``.
 
     Returns:
         JSON string suitable for ``StructuredOutputsParams(structural_tag=...)``.
@@ -411,19 +450,30 @@ def build_json_structural_tag(
         "json_schema": schema,
     }
     record_line_format = _sequence_format([record_format, _const_string_format("\n")])
+    max_records = _resolve_max_records_per_sequence(config, default_max_records_per_group)
 
     if config.data.group_training_examples_by is not None:
+        # Bounding the per-group record repetition forces the closing eos_token after at most
+        # max_records records. The unbounded plus otherwise lets a model that never emits the
+        # delimiter decode to max_tokens, yielding a length-truncated, unparseable group.
+        record_repetition = (
+            _repeat_format(record_line_format, 1, max_records) if max_records else _plus_format(record_line_format)
+        )
         sequence_format = _sequence_format(
             [
                 _const_string_format(bos_token),
-                _plus_format(record_line_format),
+                record_repetition,
                 _const_string_format(eos_token),
             ]
         )
     else:
         sequence_format = record_format
 
-    if config.generation.structured_generation.use_single_sequence and config.data.max_sequences_per_example == 1:
+    if config.data.group_training_examples_by is not None and max_records:
+        # Grouped generation produces one group per completion; a bounded single sequence
+        # (no outer repetition) guarantees a terminable, parseable group.
+        output_format = sequence_format
+    elif config.generation.structured_generation.use_single_sequence and config.data.max_sequences_per_example == 1:
         output_format = sequence_format
     elif config.data.group_training_examples_by is not None:
         output_format = _plus_format(_sequence_format([sequence_format, _const_string_format("\n")]))

--- a/src/nemo_safe_synthesizer/generation/vllm_backend.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_backend.py
@@ -398,6 +398,7 @@ class VllmBackend(GeneratorBackend):
                 self.config,
                 bos_token=pc.bos_token,
                 eos_token=pc.eos_token,
+                default_max_records_per_group=self.model_metadata.max_records_per_group,
             )
             params["regex"] = regex
         elif schema_method == "json_schema":
@@ -413,6 +414,7 @@ class VllmBackend(GeneratorBackend):
                 self.config,
                 bos_token=pc.bos_token,
                 eos_token=pc.eos_token,
+                default_max_records_per_group=self.model_metadata.max_records_per_group,
             )
 
         return StructuredOutputsParams(**params)

--- a/src/nemo_safe_synthesizer/llm/metadata.py
+++ b/src/nemo_safe_synthesizer/llm/metadata.py
@@ -373,6 +373,14 @@ class ModelMetadata(BaseModel):
 
     tokenizer: PreTrainedTokenizerBase | None = Field(default=None, exclude=True, repr=False)
 
+    @field_validator("max_records_per_group", mode="after")
+    @classmethod
+    def validate_max_records_per_group(cls, v: int | None) -> int | None:
+        """Reject non-positive persisted bounds (``None`` or ``>= 1`` only)."""
+        if v is not None and v < 1:
+            raise ValueError("max_records_per_group must be None or >= 1")
+        return v
+
     @model_validator(mode="before")
     @classmethod
     def populate_derived_fields(cls, data: dict) -> dict:

--- a/src/nemo_safe_synthesizer/llm/metadata.py
+++ b/src/nemo_safe_synthesizer/llm/metadata.py
@@ -359,6 +359,18 @@ class ModelMetadata(BaseModel):
     fine-tuned LoRAs that fail to emit EOS on short structured outputs do
     not decode wasted tokens to the full context-window cap."""
 
+    max_records_per_group: int | None = Field(
+        default=None,
+        description="Maximum number of records in any single group observed during training.",
+    )
+    """Populated by the training backend from the grouped assembler's
+    ``records_per_group`` running statistic. Consumed as the default bound on
+    per-group record repetition in structured generation for grouped data:
+    the grammar forces the group-closing ``eos_token`` after at most this many
+    records, so a fine-tuned model that fails to emit the delimiter terminates
+    and produces a parseable group instead of decoding to the token cap.
+    ``None`` for non-grouped training (the bound does not apply)."""
+
     tokenizer: PreTrainedTokenizerBase | None = Field(default=None, exclude=True, repr=False)
 
     @model_validator(mode="before")

--- a/src/nemo_safe_synthesizer/training/huggingface_backend.py
+++ b/src/nemo_safe_synthesizer/training/huggingface_backend.py
@@ -761,6 +761,7 @@ class HuggingFaceBackend(TrainingBackend):
             self.model_metadata.initial_prefill = assembler._get_initial_prefill()  # ty: ignore[unresolved-attribute]
 
         self._propagate_max_tokens_per_example()
+        self._propagate_max_records_per_group()
 
     def _propagate_max_tokens_per_example(self) -> None:
         """Copy the assembler's ``tokens_per_example.max`` onto ``ModelMetadata``.
@@ -776,6 +777,19 @@ class HuggingFaceBackend(TrainingBackend):
         tokens_per_example = self.training_examples.stats.get("tokens_per_example")
         if tokens_per_example is not None and tokens_per_example.count > 0:
             self.model_metadata.max_tokens_per_example = int(math.ceil(tokens_per_example.max))
+
+    def _propagate_max_records_per_group(self) -> None:
+        """Copy the grouped assembler's ``records_per_group.max`` onto ``ModelMetadata``.
+
+        Only grouped runs populate this stat. It becomes the default bound on
+        per-group record repetition in structured generation: the grammar forces
+        the group-closing delimiter after at most the largest trained group, so
+        completions terminate and parse instead of decoding to the token cap.
+        No-op when the stat is absent (non-grouped) or unpopulated.
+        """
+        records_per_group = self.training_examples.stats.get("records_per_group")
+        if records_per_group is not None and records_per_group.count > 0:
+            self.model_metadata.max_records_per_group = int(math.ceil(records_per_group.max))
 
     @utils.time_function
     def train(self, **training_args: Any) -> None:

--- a/tests/data_processing/test_assembler.py
+++ b/tests/data_processing/test_assembler.py
@@ -454,10 +454,13 @@ def test_grouped_data_assembler_shorter_context_with_test_split(
     assert examples.test is not None
     assert examples.test.num_rows == 9
     assert round(examples.stats["tokens_per_record"].mean, 4) == 19.0
-    assert round(examples.stats["tokens_per_group"].mean, 4) == 219.64
+    assert round(examples.stats["tokens_per_group"].mean, 4) == 219.925
     assert round(examples.stats["tokens_per_example"].mean, 4) == 284.9189
     assert round(examples.stats["records_per_example"].mean, 4) == 12.5135
     assert round(examples.stats["groups_per_example"].mean, 4) == 1.0811
+    # Holdout groups must not inflate the training-derived generation bound.
+    assert examples.stats["records_per_group"].count == assembler.num_groups_train
+    assert assembler.stats_val["records_per_group"].count == assembler.num_groups_validation
 
 
 def test_grouped_data_assembler_dp(

--- a/tests/generation/test_regex_manager.py
+++ b/tests/generation/test_regex_manager.py
@@ -199,6 +199,70 @@ def test_build_json_structural_tag_with_groupby_single_sequence(fixture_safe_syn
     }
 
 
+def test_build_json_structural_tag_groupby_max_records_per_sequence(fixture_safe_synthesizer_config):
+    """max_records_per_sequence emits a single bounded (repeat 1..N) BOS/EOS group."""
+    fixture_safe_synthesizer_config.data.group_training_examples_by = "id"
+    fixture_safe_synthesizer_config.generation.structured_generation.max_records_per_sequence = 2
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+
+    structural_tag = json.loads(
+        build_json_structural_tag(
+            schema,
+            config=fixture_safe_synthesizer_config,
+            bos_token=BOS_TOKEN,
+            eos_token=EOS_TOKEN,
+        )
+    )
+
+    assert structural_tag["format"] == {
+        "type": "sequence",
+        "elements": [
+            {"type": "const_string", "value": BOS_TOKEN},
+            {
+                "type": "repeat",
+                "min": 1,
+                "max": 2,
+                "content": {
+                    "type": "sequence",
+                    "elements": [
+                        {"type": "json_schema", "json_schema": schema},
+                        {"type": "const_string", "value": "\n"},
+                    ],
+                },
+            },
+            {"type": "const_string", "value": EOS_TOKEN},
+        ],
+    }
+
+
+# Purpose: XGrammar round-trip for the bounded grouped Structural Tag: accepts 1..N-record
+# groups, rejects an (N+1)-record group and multi-group text (the bound forces termination).
+def test_structural_tag_groupby_max_records_per_sequence_round_trip(fixture_safe_synthesizer_config, fixture_tokenizer):
+    fixture_safe_synthesizer_config.data.group_training_examples_by = "id"
+    fixture_safe_synthesizer_config.generation.structured_generation.max_records_per_sequence = 2
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+        "required": ["name"],
+    }
+    structural_tag = build_json_structural_tag(
+        schema,
+        config=fixture_safe_synthesizer_config,
+        bos_token=BOS_TOKEN,
+        eos_token=EOS_TOKEN,
+    )
+
+    one = '<s>{"name":"alice"}\n</s>'
+    two = '<s>{"name":"alice"}\n{"name":"bob"}\n</s>'
+    three = '<s>{"name":"alice"}\n{"name":"bob"}\n{"name":"carol"}\n</s>'
+    two_groups = '<s>{"name":"alice"}\n</s>\n<s>{"name":"bob"}\n</s>'
+
+    assert structural_tag_accepts_text(one, structural_tag, fixture_tokenizer) is True
+    assert structural_tag_accepts_text(two, structural_tag, fixture_tokenizer) is True
+    assert structural_tag_accepts_text(three, structural_tag, fixture_tokenizer) is False
+    assert structural_tag_accepts_text(two_groups, structural_tag, fixture_tokenizer) is False
+
+
 # Purpose: Ensures keys with special chars (e.g., '.') are escaped and string length bounds enforced.
 # Data: Object with required key 'full.name', minLength=3, maxLength=10.
 # Asserts: Equality against expected regex and behavioral matches via re.fullmatch for valid/invalid cases.
@@ -372,6 +436,108 @@ def test_build_json_based_regex_with_groupby(fixture_safe_synthesizer_config):
 
     grouped_missing_eos = '<s>{"foo":"a"}\n'
     assert re.fullmatch(regex, grouped_missing_eos) is None
+
+
+# Purpose: max_records_per_sequence bounds grouped generation to a single, terminable group.
+# Data: enum schema, group_by="id", structured_generation.max_records_per_sequence=2.
+# Asserts: regex is a single BOS..EOS group with a {1,2}-bounded record repetition (no outer
+# repetition), accepts groups of 1-2 records, and rejects a 3-record group and multi-group text.
+def test_build_json_based_regex_groupby_max_records_per_sequence(fixture_safe_synthesizer_config):
+    fixture_safe_synthesizer_config.data.group_training_examples_by = "id"
+    fixture_safe_synthesizer_config.generation.structured_generation.max_records_per_sequence = 2
+
+    schema = {
+        "type": "object",
+        "properties": {
+            "foo": {"enum": ["a", "b", "c"]},
+        },
+        "required": ["foo"],
+    }
+
+    regex = build_json_based_regex(
+        schema, config=fixture_safe_synthesizer_config, bos_token=BOS_TOKEN, eos_token=EOS_TOKEN
+    )
+
+    assert regex == '<s>(\\{"foo":("a"|"b"|"c")\\}\\n){1,2}</s>'
+
+    one_record = '<s>{"foo":"a"}\n</s>'
+    assert re.fullmatch(regex, one_record) is not None
+
+    two_records = '<s>{"foo":"a"}\n{"foo":"b"}\n</s>'
+    assert re.fullmatch(regex, two_records) is not None
+
+    # Bound forces the closing EOS after at most 2 records.
+    three_records = '<s>{"foo":"a"}\n{"foo":"b"}\n{"foo":"c"}\n</s>'
+    assert re.fullmatch(regex, three_records) is None
+
+    # A single group per completion: no trailing/outer repetition of groups.
+    two_groups = '<s>{"foo":"a"}\n</s>\n<s>{"foo":"b"}\n</s>'
+    assert re.fullmatch(regex, two_groups) is None
+
+
+# Purpose: default_max_records_per_group (training-derived) applies when the config
+# override is unset; an explicit override takes precedence over the default.
+def test_build_json_based_regex_groupby_default_max_records_per_group(fixture_safe_synthesizer_config):
+    fixture_safe_synthesizer_config.data.group_training_examples_by = "id"
+    schema = {"type": "object", "properties": {"foo": {"enum": ["a", "b", "c"]}}, "required": ["foo"]}
+
+    # Config override unset -> training-derived default is used.
+    regex_default = build_json_based_regex(
+        schema,
+        config=fixture_safe_synthesizer_config,
+        bos_token=BOS_TOKEN,
+        eos_token=EOS_TOKEN,
+        default_max_records_per_group=3,
+    )
+    assert regex_default == '<s>(\\{"foo":("a"|"b"|"c")\\}\\n){1,3}</s>'
+
+    # Explicit override wins over the training-derived default.
+    fixture_safe_synthesizer_config.generation.structured_generation.max_records_per_sequence = 2
+    regex_override = build_json_based_regex(
+        schema,
+        config=fixture_safe_synthesizer_config,
+        bos_token=BOS_TOKEN,
+        eos_token=EOS_TOKEN,
+        default_max_records_per_group=3,
+    )
+    assert regex_override == '<s>(\\{"foo":("a"|"b"|"c")\\}\\n){1,2}</s>'
+
+
+# Purpose: structural_tag default_max_records_per_group applies when the config override
+# is unset, emitting a single bounded (repeat 1..default) BOS/EOS group.
+def test_build_json_structural_tag_groupby_default_max_records_per_group(fixture_safe_synthesizer_config):
+    fixture_safe_synthesizer_config.data.group_training_examples_by = "id"
+    schema = {"type": "object", "properties": {"name": {"type": "string"}}}
+
+    structural_tag = json.loads(
+        build_json_structural_tag(
+            schema,
+            config=fixture_safe_synthesizer_config,
+            bos_token=BOS_TOKEN,
+            eos_token=EOS_TOKEN,
+            default_max_records_per_group=3,
+        )
+    )
+
+    assert structural_tag["format"] == {
+        "type": "sequence",
+        "elements": [
+            {"type": "const_string", "value": BOS_TOKEN},
+            {
+                "type": "repeat",
+                "min": 1,
+                "max": 3,
+                "content": {
+                    "type": "sequence",
+                    "elements": [
+                        {"type": "json_schema", "json_schema": schema},
+                        {"type": "const_string", "value": "\n"},
+                    ],
+                },
+            },
+            {"type": "const_string", "value": EOS_TOKEN},
+        ],
+    }
 
 
 # Purpose: Validates integer range inference and sign handling across mixed and all-negative datasets.

--- a/tests/generation/test_vllm_backend.py
+++ b/tests/generation/test_vllm_backend.py
@@ -47,6 +47,7 @@ def mock_model_metadata(fixture_session_cache_dir):
     metadata.base_max_seq_length = 2048
     metadata.rope_scaling = None
     metadata.max_tokens_per_example = None
+    metadata.max_records_per_group = None
     metadata.generation_max_tokens_for.return_value = 2048
     return metadata
 
@@ -205,6 +206,7 @@ class TestBuildStructuredOutputParams:
                 params_with_structured_generation_regex,
                 bos_token=mock_model_metadata.prompt_config.bos_token,
                 eos_token=mock_model_metadata.prompt_config.eos_token,
+                default_max_records_per_group=mock_model_metadata.max_records_per_group,
             )
             assert result is not None
             assert result.regex == "test_regex_pattern"
@@ -254,6 +256,7 @@ class TestBuildStructuredOutputParams:
                 params_with_structured_generation_structural_tag,
                 bos_token=mock_model_metadata.prompt_config.bos_token,
                 eos_token=mock_model_metadata.prompt_config.eos_token,
+                default_max_records_per_group=mock_model_metadata.max_records_per_group,
             )
             assert result is not None
             assert result.structural_tag == '{"type":"structural_tag","format":{"type":"json_schema","json_schema":{}}}'
@@ -286,6 +289,7 @@ class TestBuildStructuredOutputParams:
                 params_with_structured_generation_auto,
                 bos_token=mock_model_metadata.prompt_config.bos_token,
                 eos_token=mock_model_metadata.prompt_config.eos_token,
+                default_max_records_per_group=mock_model_metadata.max_records_per_group,
             )
             assert result is not None
             assert result.structural_tag is not None
@@ -318,6 +322,7 @@ class TestBuildStructuredOutputParams:
                 params_with_structured_generation_auto,
                 bos_token=mock_model_metadata.prompt_config.bos_token,
                 eos_token=mock_model_metadata.prompt_config.eos_token,
+                default_max_records_per_group=mock_model_metadata.max_records_per_group,
             )
             assert result is not None
             assert result.regex == "test_regex_pattern"

--- a/tests/llm/test_metadata.py
+++ b/tests/llm/test_metadata.py
@@ -705,6 +705,41 @@ class TestGenerationMaxTokensFor:
         # prompt_len=0 reproduces the old prompt-agnostic budget for round-trip parity.
         assert reloaded.generation_max_tokens_for(0) == int(1500 * GENERATION_MAX_TOKENS_SAFETY_MULTIPLIER)
 
+    def test_metadata_max_records_per_group_accepts_none_or_positive(
+        self, sample_prompt_config, mock_autoconfig_obj, sample_workdir
+    ):
+        """``None`` and values ``>= 1`` are valid persisted bounds."""
+        none_meta = ModelMetadata(
+            model_name_or_path="test-model",
+            prompt_config=sample_prompt_config,
+            autoconfig=mock_autoconfig_obj,
+            workdir=sample_workdir,
+            max_records_per_group=None,
+        )
+        assert none_meta.max_records_per_group is None
+        positive_meta = ModelMetadata(
+            model_name_or_path="test-model",
+            prompt_config=sample_prompt_config,
+            autoconfig=mock_autoconfig_obj,
+            workdir=sample_workdir,
+            max_records_per_group=3,
+        )
+        assert positive_meta.max_records_per_group == 3
+
+    @pytest.mark.parametrize("value", [0, -1])
+    def test_metadata_max_records_per_group_rejects_non_positive(
+        self, sample_prompt_config, mock_autoconfig_obj, sample_workdir, value
+    ):
+        """Non-positive persisted bounds fail validation."""
+        with pytest.raises(ValidationError, match="max_records_per_group"):
+            ModelMetadata(
+                model_name_or_path="test-model",
+                prompt_config=sample_prompt_config,
+                autoconfig=mock_autoconfig_obj,
+                workdir=sample_workdir,
+                max_records_per_group=value,
+            )
+
     def test_qwen2_rope_parameters_round_trip_through_metadata_json(self, sample_prompt_config, sample_workdir):
         """Native Qwen2 RoPE parameters survive the saved artifact metadata."""
         autoconfig = Qwen2Config()


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `max_records_per_sequence` to cap how many records are generated per grouped sequence.
  - Grouped structured generation now supports bounded, parseable termination for both regex and structural-tag outputs.
  - The per-group bound can be derived automatically from training statistics when not explicitly set, with clear precedence.

- **Bug Fixes**
  - Group sizing statistics used for bounds now respect train vs. validation/holdout separation.

- **Tests**
  - Added regression tests covering bound enforcement, precedence behavior, and accept/reject round-trip scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->