### PR TITLE
fix: evaluation and logging output

### DIFF
--- a/docs/user-guide/environment.md
+++ b/docs/user-guide/environment.md
@@ -47,7 +47,7 @@ Grouped by the `Category` column -- `nss`-native settings first, then
 | `NSS_DATASET_REGISTRY` | nss | `--dataset-registry` | CLI | -- | Dataset registry YAML path or URL | [Running -- Dataset Registry](running.md#dataset-registry) |
 | `NSS_WANDB_MODE` | nss | `--wandb-mode` | WandB | `disabled` | WandB run mode | Alias for `WANDB_MODE` |
 | `NSS_WANDB_PROJECT` | nss | `--wandb-project` | WandB | -- | WandB project name | Alias for `WANDB_PROJECT` |
-| `NSS_WANDB_UPLOAD_EVALUATION_REPORT` | nss | `--wandb-upload-evaluation-report` / `--no-wandb-upload-evaluation-report` | WandB | `true` | Upload final evaluation HTML and artifact | Set to `false` to retain only scalar W&B output |
+| `NSS_WANDB_UPLOAD_EVALUATION_REPORT` | nss | `--wandb-upload-evaluation-report` / `--no-wandb-upload-evaluation-report` | WandB | `true` | Upload final evaluation HTML and artifact | Set to `false` to skip HTML and artifact publishing; summary metrics and the scorecard remain enabled |
 | `NSS_INFERENCE_ENDPOINT` | nss | `--inference-endpoint-url` | PII column classifier | NVIDIA integrate URL | OpenAI-compatible endpoint for column classification | [PII appendix](#pii-ner-and-column-classification) |
 | `NSS_INFERENCE_KEY` | nss | `--inference-api-key` | PII column classifier | -- | API key for `NSS_INFERENCE_ENDPOINT` | Required for LLM column classification |
 | `NSS_INFERENCE_MODEL` | nss | `--inference-model-id` | PII column classifier | `qwen/qwen3-next-80b-a3b-instruct` | Model ID sent to the inference endpoint | [PII appendix](#pii-ner-and-column-classification) |

--- a/docs/user-guide/environment.md
+++ b/docs/user-guide/environment.md
@@ -47,7 +47,7 @@ Grouped by the `Category` column -- `nss`-native settings first, then
 | `NSS_DATASET_REGISTRY` | nss | `--dataset-registry` | CLI | -- | Dataset registry YAML path or URL | [Running -- Dataset Registry](running.md#dataset-registry) |
 | `NSS_WANDB_MODE` | nss | `--wandb-mode` | WandB | `disabled` | WandB run mode | Alias for `WANDB_MODE` |
 | `NSS_WANDB_PROJECT` | nss | `--wandb-project` | WandB | -- | WandB project name | Alias for `WANDB_PROJECT` |
-| `NSS_WANDB_UPLOAD_EVALUATION_REPORT` | nss | `--wandb-upload-evaluation-report` | WandB | `false` | Upload final evaluation HTML and artifact | May disclose distribution labels |
+| `NSS_WANDB_UPLOAD_EVALUATION_REPORT` | nss | `--wandb-upload-evaluation-report` / `--no-wandb-upload-evaluation-report` | WandB | `true` | Upload final evaluation HTML and artifact | Set to `false` to retain only scalar W&B output |
 | `NSS_INFERENCE_ENDPOINT` | nss | `--inference-endpoint-url` | PII column classifier | NVIDIA integrate URL | OpenAI-compatible endpoint for column classification | [PII appendix](#pii-ner-and-column-classification) |
 | `NSS_INFERENCE_KEY` | nss | `--inference-api-key` | PII column classifier | -- | API key for `NSS_INFERENCE_ENDPOINT` | Required for LLM column classification |
 | `NSS_INFERENCE_MODEL` | nss | `--inference-model-id` | PII column classifier | `qwen/qwen3-next-80b-a3b-instruct` | Model ID sent to the inference endpoint | [PII appendix](#pii-ner-and-column-classification) |

--- a/docs/user-guide/environment.md
+++ b/docs/user-guide/environment.md
@@ -47,6 +47,7 @@ Grouped by the `Category` column -- `nss`-native settings first, then
 | `NSS_DATASET_REGISTRY` | nss | `--dataset-registry` | CLI | -- | Dataset registry YAML path or URL | [Running -- Dataset Registry](running.md#dataset-registry) |
 | `NSS_WANDB_MODE` | nss | `--wandb-mode` | WandB | `disabled` | WandB run mode | Alias for `WANDB_MODE` |
 | `NSS_WANDB_PROJECT` | nss | `--wandb-project` | WandB | -- | WandB project name | Alias for `WANDB_PROJECT` |
+| `NSS_WANDB_UPLOAD_EVALUATION_REPORT` | nss | `--wandb-upload-evaluation-report` | WandB | `false` | Upload final evaluation HTML and artifact | May disclose distribution labels |
 | `NSS_INFERENCE_ENDPOINT` | nss | `--inference-endpoint-url` | PII column classifier | NVIDIA integrate URL | OpenAI-compatible endpoint for column classification | [PII appendix](#pii-ner-and-column-classification) |
 | `NSS_INFERENCE_KEY` | nss | `--inference-api-key` | PII column classifier | -- | API key for `NSS_INFERENCE_ENDPOINT` | Required for LLM column classification |
 | `NSS_INFERENCE_MODEL` | nss | `--inference-model-id` | PII column classifier | `qwen/qwen3-next-80b-a3b-instruct` | Model ID sent to the inference endpoint | [PII appendix](#pii-ner-and-column-classification) |

--- a/docs/user-guide/running.md
+++ b/docs/user-guide/running.md
@@ -218,6 +218,7 @@ all others have defaults or are optional.
 | `--log-color` / `--no-log-color` | `NSS_LOG_COLOR` | auto | Colorize console output (auto-detected from TTY) |
 | `--wandb-mode` | `NSS_WANDB_MODE` | `disabled` | WandB mode (`online`, `offline`, `disabled`) |
 | `--wandb-project` | `NSS_WANDB_PROJECT` | -- | WandB project name |
+| `--wandb-upload-evaluation-report` | `NSS_WANDB_UPLOAD_EVALUATION_REPORT` | `false` | Opt in to uploading evaluation HTML and artifact |
 | `--dataset-registry` | `NSS_DATASET_REGISTRY` | -- | Dataset registry YAML path/URL |
 | `-v` / `-vv` | -- | -- | Verbose logging (`-v` debug, `-vv` debug + dependencies) |
 
@@ -1351,6 +1352,28 @@ config file.
 
     These environment variables are read by the CLI only. SDK users must
     call `wandb.init(...)` explicitly.
+
+#### Evaluation scorecard and report upload
+
+For CLI-managed runs, final scalar `eval/*`, `gen/*`, timing, failure, and
+vLLM-completion values update the W&B run summary rather than creating history
+points. Existing training curves remain W&B history. After results are saved,
+the CLI publishes an `evaluation/scorecard` table panel containing final
+`eval/*` values.
+
+The HTML evaluation report can disclose distribution labels and other details
+derived from your source data. It is therefore not uploaded by default. To opt
+in to the `evaluation/report` panel and the `evaluation-report` artifact, pass:
+
+```bash
+safe-synthesizer run --wandb-mode online --wandb-upload-evaluation-report ...
+```
+
+or set `NSS_WANDB_UPLOAD_EVALUATION_REPORT=true`. When enabled, the artifact
+is named `safe-synthesizer-evaluation-report-<run-id>` and may contain
+`evaluation_report.html` and `evaluation_metrics.json` when those files are
+available. SDK callers retain scalar `log_wandb()` behavior and do not upload
+evaluation media automatically.
 
 For parameter precedence (CLI flags vs environment variables vs YAML), see
 [Environment Variables -- Precedence](environment.md#precedence).

--- a/docs/user-guide/running.md
+++ b/docs/user-guide/running.md
@@ -218,7 +218,7 @@ all others have defaults or are optional.
 | `--log-color` / `--no-log-color` | `NSS_LOG_COLOR` | auto | Colorize console output (auto-detected from TTY) |
 | `--wandb-mode` | `NSS_WANDB_MODE` | `disabled` | WandB mode (`online`, `offline`, `disabled`) |
 | `--wandb-project` | `NSS_WANDB_PROJECT` | -- | WandB project name |
-| `--wandb-upload-evaluation-report` | `NSS_WANDB_UPLOAD_EVALUATION_REPORT` | `false` | Opt in to uploading evaluation HTML and artifact |
+| `--wandb-upload-evaluation-report` / `--no-wandb-upload-evaluation-report` | `NSS_WANDB_UPLOAD_EVALUATION_REPORT` | `true` | Control evaluation HTML and artifact publication |
 | `--dataset-registry` | `NSS_DATASET_REGISTRY` | -- | Dataset registry YAML path/URL |
 | `-v` / `-vv` | -- | -- | Verbose logging (`-v` debug, `-vv` debug + dependencies) |
 
@@ -1361,15 +1361,17 @@ points. Existing training curves remain W&B history. After results are saved,
 the CLI publishes an `evaluation/scorecard` table panel containing final
 `eval/*` values.
 
-The HTML evaluation report can disclose distribution labels and other details
-derived from your source data. It is therefore not uploaded by default. To opt
-in to the `evaluation/report` panel and the `evaluation-report` artifact, pass:
+When W&B is active, the CLI publishes the HTML evaluation report to the
+user-configured project as the `evaluation/report` panel and the
+`evaluation-report` artifact. To retain only scalar W&B output, pass:
 
-```bash
-safe-synthesizer run --wandb-mode online --wandb-upload-evaluation-report ...
-```
+    safe-synthesizer run \
+      --config config.yaml \
+      --data-source data.csv \
+      --wandb-mode online \
+      --no-wandb-upload-evaluation-report
 
-or set `NSS_WANDB_UPLOAD_EVALUATION_REPORT=true`. When enabled, the artifact
+or set `NSS_WANDB_UPLOAD_EVALUATION_REPORT=false`. When enabled, the artifact
 is named `safe-synthesizer-evaluation-report-<run-id>` and may contain
 `evaluation_report.html` and `evaluation_metrics.json` when those files are
 available. SDK callers retain scalar `log_wandb()` behavior and do not upload

--- a/docs/user-guide/running.md
+++ b/docs/user-guide/running.md
@@ -218,7 +218,7 @@ all others have defaults or are optional.
 | `--log-color` / `--no-log-color` | `NSS_LOG_COLOR` | auto | Colorize console output (auto-detected from TTY) |
 | `--wandb-mode` | `NSS_WANDB_MODE` | `disabled` | WandB mode (`online`, `offline`, `disabled`) |
 | `--wandb-project` | `NSS_WANDB_PROJECT` | -- | WandB project name |
-| `--wandb-upload-evaluation-report` / `--no-wandb-upload-evaluation-report` | `NSS_WANDB_UPLOAD_EVALUATION_REPORT` | `true` | Control evaluation HTML and artifact publication |
+| `--wandb-upload-evaluation-report` / `--no-wandb-upload-evaluation-report` | `NSS_WANDB_UPLOAD_EVALUATION_REPORT` | `true` | Control evaluation HTML and artifact publishing |
 | `--dataset-registry` | `NSS_DATASET_REGISTRY` | -- | Dataset registry YAML path/URL |
 | `-v` / `-vv` | -- | -- | Verbose logging (`-v` debug, `-vv` debug + dependencies) |
 
@@ -1363,7 +1363,8 @@ the CLI publishes an `evaluation/scorecard` table panel containing final
 
 When W&B is active, the CLI publishes the HTML evaluation report to the
 user-configured project as the `evaluation/report` panel and the
-`evaluation-report` artifact. To retain only scalar W&B output, pass:
+`evaluation-report` artifact. To skip the HTML report panel and evaluation-report
+artifact while retaining summary metrics and the evaluation scorecard, pass:
 
     safe-synthesizer run \
       --config config.yaml \

--- a/src/nemo_safe_synthesizer/cli/run.py
+++ b/src/nemo_safe_synthesizer/cli/run.py
@@ -65,7 +65,8 @@ def common_run_options(f: Callable[..., object]) -> Callable[..., object]:
             "--wandb-upload-evaluation-report/--no-wandb-upload-evaluation-report",
             default=None,
             help="Upload the final evaluation HTML report and artifact to WandB. "
-            "Can also be set via NSS_WANDB_UPLOAD_EVALUATION_REPORT. [default: no-wandb-upload-evaluation-report]",
+            "Use --no-wandb-upload-evaluation-report to retain only scalar W&B output. "
+            "Can also be set via NSS_WANDB_UPLOAD_EVALUATION_REPORT. [default: wandb-upload-evaluation-report]",
         )
     )
     options.append(

--- a/src/nemo_safe_synthesizer/cli/run.py
+++ b/src/nemo_safe_synthesizer/cli/run.py
@@ -28,6 +28,7 @@ from .utils import (
     PathT,
     common_setup,
 )
+from .wandb_setup import publish_evaluation_report
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -57,6 +58,14 @@ def common_run_options(f: Callable[..., object]) -> Callable[..., object]:
             required=False,
             help="Dataset name, URL, or path to CSV dataset. "
             "For 'run generate', this is optional if a cached dataset exists in the workdir.",
+        )
+    )
+    options.append(
+        click.option(
+            "--wandb-upload-evaluation-report/--no-wandb-upload-evaluation-report",
+            default=None,
+            help="Upload the final evaluation HTML report and artifact to WandB. "
+            "Can also be set via NSS_WANDB_UPLOAD_EVALUATION_REPORT. [default: no-wandb-upload-evaluation-report]",
         )
     )
     options.append(
@@ -445,6 +454,7 @@ def run(
                 nss.results.summary.log_summary(run_logger)
                 nss.results.summary.timing.log_timing(run_logger)
                 nss.results.summary.log_wandb()
+                publish_evaluation_report(workdir, nss.results.summary, settings.wandb_upload_evaluation_report)
             finally:
                 if hasattr(nss, "generator") and nss.generator is not None:
                     nss.generator.teardown()
@@ -583,6 +593,7 @@ def run_generate(
             nss.results.summary.timing.log_timing(run_logger)
             run_logger.info(f"Generation complete. Results saved to: {final_output_file}")
             nss.results.summary.log_wandb()
+            publish_evaluation_report(workdir, nss.results.summary, settings.wandb_upload_evaluation_report)
         except KeyboardInterrupt:
             _emit_nss_telemetry(nss, TaskStatusEnum.CANCELED)
             raise

--- a/src/nemo_safe_synthesizer/cli/run.py
+++ b/src/nemo_safe_synthesizer/cli/run.py
@@ -65,7 +65,8 @@ def common_run_options(f: Callable[..., object]) -> Callable[..., object]:
             "--wandb-upload-evaluation-report/--no-wandb-upload-evaluation-report",
             default=None,
             help="Upload the final evaluation HTML report and artifact to WandB. "
-            "Use --no-wandb-upload-evaluation-report to retain only scalar W&B output. "
+            "Use --no-wandb-upload-evaluation-report to skip report HTML and artifact publishing while retaining "
+            "summary metrics and the evaluation scorecard. "
             "Can also be set via NSS_WANDB_UPLOAD_EVALUATION_REPORT. [default: wandb-upload-evaluation-report]",
         )
     )

--- a/src/nemo_safe_synthesizer/cli/run.py
+++ b/src/nemo_safe_synthesizer/cli/run.py
@@ -423,7 +423,7 @@ def run(
     )
 
     try:
-        run_logger.warning("Nemo Safe Synthesizer starting")
+        run_logger.info("Nemo Safe Synthesizer starting")
         run_logger.debug("running with: ", extra={"config": config.model_dump()})
 
         with traced_user("SafeSynthesizer"):

--- a/src/nemo_safe_synthesizer/cli/run.py
+++ b/src/nemo_safe_synthesizer/cli/run.py
@@ -67,7 +67,7 @@ def common_run_options(f: Callable[..., object]) -> Callable[..., object]:
             help="Upload the final evaluation HTML report and artifact to WandB. "
             "Use --no-wandb-upload-evaluation-report to skip report HTML and artifact publishing while retaining "
             "summary metrics and the evaluation scorecard. "
-            "Can also be set via NSS_WANDB_UPLOAD_EVALUATION_REPORT. [default: wandb-upload-evaluation-report]",
+            "Can also be set via NSS_WANDB_UPLOAD_EVALUATION_REPORT. [default: --wandb-upload-evaluation-report]",
         )
     )
     options.append(

--- a/src/nemo_safe_synthesizer/cli/settings.py
+++ b/src/nemo_safe_synthesizer/cli/settings.py
@@ -149,7 +149,7 @@ class CLISettings(BaseSettings):
     """WandB project name override."""
 
     wandb_upload_evaluation_report: bool = Field(
-        default=False,
+        default=True,
         validation_alias=AliasChoices("wandb_upload_evaluation_report", "NSS_WANDB_UPLOAD_EVALUATION_REPORT"),
         description="Whether the CLI uploads the final evaluation HTML report and artifact to WandB.",
     )

--- a/src/nemo_safe_synthesizer/cli/settings.py
+++ b/src/nemo_safe_synthesizer/cli/settings.py
@@ -148,6 +148,13 @@ class CLISettings(BaseSettings):
     )
     """WandB project name override."""
 
+    wandb_upload_evaluation_report: bool = Field(
+        default=False,
+        validation_alias=AliasChoices("wandb_upload_evaluation_report", "NSS_WANDB_UPLOAD_EVALUATION_REPORT"),
+        description="Whether the CLI uploads the final evaluation HTML report and artifact to WandB.",
+    )
+    """Whether the CLI uploads the final evaluation HTML report and artifact to WandB."""
+
     synthesis_overrides: dict[str, Any] = Field(
         default_factory=dict,
         description="Nested dict of SafeSynthesizerParameters overrides from CLI",

--- a/src/nemo_safe_synthesizer/cli/wandb_setup.py
+++ b/src/nemo_safe_synthesizer/cli/wandb_setup.py
@@ -26,6 +26,9 @@ from .artifact_structure import Workdir
 logger = get_logger(__name__)
 
 _EVALUATION_PUBLICATION_FINGERPRINT_KEY = "_nss_evaluation_publication_fingerprint"
+_EVALUATION_SCORECARD_FINGERPRINT_KEY = "_nss_evaluation_scorecard_fingerprint"
+_EVALUATION_REPORT_FINGERPRINT_KEY = "_nss_evaluation_report_fingerprint"
+_EVALUATION_ARTIFACT_FINGERPRINT_KEY = "_nss_evaluation_artifact_fingerprint"
 
 
 def resolve_wandb_run_id(id_or_path: str) -> str:
@@ -164,49 +167,73 @@ def publish_evaluation_report(
     metrics_bytes = _read_optional_file(metrics_path, "metrics") if upload_report else None
     fingerprint = _evaluation_publication_fingerprint(eval_metrics, upload_report, report_bytes, metrics_bytes)
 
-    try:
-        if run.summary.get(_EVALUATION_PUBLICATION_FINGERPRINT_KEY) == fingerprint:
-            return
-    except Exception as exc:  # noqa: BLE001 -- publication remains best-effort
-        logger.warning(f"Failed to read W&B evaluation publication marker: {exc}")
+    if _publication_marker_matches(run.summary, _EVALUATION_PUBLICATION_FINGERPRINT_KEY, fingerprint):
+        return
 
     publication_succeeded = True
-    try:
-        run.log(
-            {
-                "evaluation/scorecard": wandb.Table(
-                    columns=["metric", "value"],
-                    data=[[key, value] for key, value in eval_metrics.items()],
-                )
-            }
-        )
-    except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
-        logger.warning(f"Failed to publish W&B evaluation scorecard: {exc}")
-        publication_succeeded = False
+    scorecard_fingerprint = _fingerprint_payload({"eval_metrics": eval_metrics})
+    if not _publication_marker_matches(run.summary, _EVALUATION_SCORECARD_FINGERPRINT_KEY, scorecard_fingerprint):
+        try:
+            run.log(
+                {
+                    "evaluation/scorecard": wandb.Table(
+                        columns=["metric", "value"],
+                        data=[[key, value] for key, value in eval_metrics.items()],
+                    )
+                }
+            )
+            publication_succeeded &= _record_publication_marker(
+                run.summary,
+                _EVALUATION_SCORECARD_FINGERPRINT_KEY,
+                scorecard_fingerprint,
+            )
+        except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
+            logger.warning(f"Failed to publish W&B evaluation scorecard: {exc}")
+            publication_succeeded = False
 
-    report_sha256: str | None = None
+    report_sha256 = hashlib.sha256(report_bytes).hexdigest() if report_bytes is not None else None
     report_uploaded = False
     if upload_report and report_bytes is not None:
-        try:
-            report_html = report_bytes.decode("utf-8")
-            run.log({"evaluation/report": wandb.Html(report_html, inject=False)})
-            report_sha256 = hashlib.sha256(report_bytes).hexdigest()
+        report_fingerprint = _fingerprint_payload({"report_sha256": report_sha256})
+        if _publication_marker_matches(run.summary, _EVALUATION_REPORT_FINGERPRINT_KEY, report_fingerprint):
             report_uploaded = True
-        except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
-            logger.warning(f"Failed to publish W&B evaluation report: {exc}")
-            publication_succeeded = False
+        else:
+            try:
+                report_html = report_bytes.decode("utf-8")
+                run.log({"evaluation/report": wandb.Html(report_html, inject=False)})
+                report_uploaded = True
+                publication_succeeded &= _record_publication_marker(
+                    run.summary,
+                    _EVALUATION_REPORT_FINGERPRINT_KEY,
+                    report_fingerprint,
+                )
+            except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
+                logger.warning(f"Failed to publish W&B evaluation report: {exc}")
+                publication_succeeded = False
 
     if upload_report and (report_bytes is not None or metrics_bytes is not None):
-        try:
-            artifact = wandb.Artifact(f"safe-synthesizer-evaluation-report-{run.id}", type="evaluation-report")
-            if report_bytes is not None:
-                artifact.add_file(str(report_path), name="evaluation_report.html")
-            if metrics_bytes is not None:
-                artifact.add_file(str(metrics_path), name="evaluation_metrics.json")
-            run.log_artifact(artifact)
-        except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
-            logger.warning(f"Failed to publish W&B evaluation report artifact: {exc}")
-            publication_succeeded = False
+        artifact_fingerprint = _fingerprint_payload(
+            {
+                "report_sha256": report_sha256,
+                "metrics_sha256": hashlib.sha256(metrics_bytes).hexdigest() if metrics_bytes is not None else None,
+            }
+        )
+        if not _publication_marker_matches(run.summary, _EVALUATION_ARTIFACT_FINGERPRINT_KEY, artifact_fingerprint):
+            try:
+                artifact = wandb.Artifact(f"safe-synthesizer-evaluation-report-{run.id}", type="evaluation-report")
+                if report_bytes is not None:
+                    artifact.add_file(str(report_path), name="evaluation_report.html")
+                if metrics_bytes is not None:
+                    artifact.add_file(str(metrics_path), name="evaluation_metrics.json")
+                run.log_artifact(artifact)
+                publication_succeeded &= _record_publication_marker(
+                    run.summary,
+                    _EVALUATION_ARTIFACT_FINGERPRINT_KEY,
+                    artifact_fingerprint,
+                )
+            except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
+                logger.warning(f"Failed to publish W&B evaluation report artifact: {exc}")
+                publication_succeeded = False
 
     try:
         publication_summary = {
@@ -239,13 +266,38 @@ def _evaluation_publication_fingerprint(
     metrics_bytes: bytes | None,
 ) -> str:
     """Return a stable marker for the exact CLI evaluation publication payload."""
-    payload = {
-        "eval_metrics": eval_metrics,
-        "upload_report": upload_report,
-        "report_sha256": hashlib.sha256(report_bytes).hexdigest() if report_bytes is not None else None,
-        "metrics_sha256": hashlib.sha256(metrics_bytes).hexdigest() if metrics_bytes is not None else None,
-    }
+    return _fingerprint_payload(
+        {
+            "eval_metrics": eval_metrics,
+            "upload_report": upload_report,
+            "report_sha256": hashlib.sha256(report_bytes).hexdigest() if report_bytes is not None else None,
+            "metrics_sha256": hashlib.sha256(metrics_bytes).hexdigest() if metrics_bytes is not None else None,
+        }
+    )
+
+
+def _fingerprint_payload(payload: dict[str, object]) -> str:
+    """Return a stable SHA-256 marker for a JSON-serializable payload."""
     return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+
+def _publication_marker_matches(summary: Any, key: str, fingerprint: str) -> bool:
+    """Return whether a best-effort W&B publication marker matches."""
+    try:
+        return summary.get(key) == fingerprint
+    except Exception as exc:  # noqa: BLE001 -- publication remains best-effort
+        logger.warning(f"Failed to read W&B evaluation publication marker {key}: {exc}")
+        return False
+
+
+def _record_publication_marker(summary: Any, key: str, fingerprint: str) -> bool:
+    """Persist a best-effort W&B publication marker after an operation succeeds."""
+    try:
+        summary.update({key: fingerprint})
+        return True
+    except Exception as exc:  # noqa: BLE001 -- publication remains best-effort
+        logger.warning(f"Failed to update W&B evaluation publication marker {key}: {exc}")
+        return False
 
 
 def update_wandb_config(

--- a/src/nemo_safe_synthesizer/cli/wandb_setup.py
+++ b/src/nemo_safe_synthesizer/cli/wandb_setup.py
@@ -11,13 +11,16 @@ from __future__ import annotations
 
 import hashlib
 import json
+from collections.abc import Callable
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
-import wandb
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings
+
+import wandb
 
 from ..config import SafeSynthesizerParameters, SafeSynthesizerSummary
 from ..observability import get_logger
@@ -29,6 +32,36 @@ _EVALUATION_PUBLISHING_FINGERPRINT_KEY = "_nss_evaluation_publishing_fingerprint
 _EVALUATION_SCORECARD_FINGERPRINT_KEY = "_nss_evaluation_scorecard_fingerprint"
 _EVALUATION_REPORT_FINGERPRINT_KEY = "_nss_evaluation_report_fingerprint"
 _EVALUATION_ARTIFACT_FINGERPRINT_KEY = "_nss_evaluation_artifact_fingerprint"
+
+
+@dataclass(frozen=True)
+class _PublishingOutcome:
+    """Result of one idempotent W&B publishing operation."""
+
+    published: bool
+    recorded: bool
+
+
+@dataclass(frozen=True)
+class _EvaluationPublishingPayload:
+    """Local evaluation data prepared for W&B publishing."""
+
+    eval_metrics: dict[str, float | int | None]
+    report_path: Path
+    metrics_path: Path
+    report_bytes: bytes | None
+    metrics_bytes: bytes | None
+    report_sha256: str | None
+    metrics_sha256: str | None
+    fingerprint: str
+
+
+@dataclass(frozen=True)
+class _PublishedReportState:
+    """Durable state of the latest report known to exist in W&B."""
+
+    uploaded: bool
+    sha256: str | None
 
 
 def resolve_wandb_run_id(id_or_path: str) -> str:
@@ -160,91 +193,202 @@ def publish_evaluation_report(
     run = wandb.run
     if run is None:
         return
+    payload = _prepare_evaluation_publishing_payload(workdir, summary, upload_report)
+
+    if _publishing_marker_matches(run.summary, _EVALUATION_PUBLISHING_FINGERPRINT_KEY, payload.fingerprint):
+        return
+
+    previous_report_state = _read_published_report_state(run.summary)
+    scorecard_outcome = _publish_evaluation_scorecard(run, payload.eval_metrics)
+    report_outcome = _publish_evaluation_report_panel(run, payload)
+    artifact_outcome = _publish_evaluation_artifact(run, payload)
+    report_state = _updated_report_state(previous_report_state, report_outcome, payload.report_sha256)
+    publishing_recorded = all(outcome.recorded for outcome in (scorecard_outcome, report_outcome, artifact_outcome))
+    _update_evaluation_publishing_summary(
+        run.summary,
+        report_state=report_state,
+        publishing_fingerprint=payload.fingerprint if publishing_recorded else None,
+    )
+
+
+def _prepare_evaluation_publishing_payload(
+    workdir: Workdir,
+    summary: SafeSynthesizerSummary,
+    upload_report: bool,
+) -> _EvaluationPublishingPayload:
+    """Read and fingerprint the local evaluation data selected for publishing."""
     eval_metrics = {key: value for key, value in summary._wandb_metrics().items() if key.startswith("eval/")}
     report_path = workdir.evaluation_report
     metrics_path = workdir.evaluation_metrics
     report_bytes = _read_optional_file(report_path, "report") if upload_report else None
     metrics_bytes = _read_optional_file(metrics_path, "metrics") if upload_report else None
-    fingerprint = _evaluation_publishing_fingerprint(eval_metrics, upload_report, report_bytes, metrics_bytes)
+    report_sha256 = _optional_sha256(report_bytes)
+    metrics_sha256 = _optional_sha256(metrics_bytes)
+    fingerprint = _fingerprint_payload(
+        {
+            "eval_metrics": eval_metrics,
+            "upload_report": upload_report,
+            "report_sha256": report_sha256,
+            "metrics_sha256": metrics_sha256,
+        }
+    )
+    return _EvaluationPublishingPayload(
+        eval_metrics=eval_metrics,
+        report_path=report_path,
+        metrics_path=metrics_path,
+        report_bytes=report_bytes,
+        metrics_bytes=metrics_bytes,
+        report_sha256=report_sha256,
+        metrics_sha256=metrics_sha256,
+        fingerprint=fingerprint,
+    )
 
-    if _publishing_marker_matches(run.summary, _EVALUATION_PUBLISHING_FINGERPRINT_KEY, fingerprint):
-        return
 
-    publishing_succeeded = True
-    scorecard_fingerprint = _fingerprint_payload({"eval_metrics": eval_metrics})
-    if not _publishing_marker_matches(run.summary, _EVALUATION_SCORECARD_FINGERPRINT_KEY, scorecard_fingerprint):
-        try:
-            run.log(
-                {
-                    "evaluation/scorecard": wandb.Table(
-                        columns=["metric", "value"],
-                        data=[[key, value] for key, value in eval_metrics.items()],
-                    )
-                }
+def _publish_evaluation_scorecard(
+    run: Any,
+    eval_metrics: dict[str, float | int | None],
+) -> _PublishingOutcome:
+    """Publish the scorecard once for the current evaluation metrics."""
+    fingerprint = _fingerprint_payload({"eval_metrics": eval_metrics})
+    return _publish_once(
+        run.summary,
+        _EVALUATION_SCORECARD_FINGERPRINT_KEY,
+        fingerprint,
+        "scorecard",
+        lambda: _log_evaluation_scorecard(run, eval_metrics),
+    )
+
+
+def _publish_evaluation_report_panel(run: Any, payload: _EvaluationPublishingPayload) -> _PublishingOutcome:
+    """Publish the HTML report panel when report bytes are available."""
+    report_bytes = payload.report_bytes
+    if report_bytes is None or payload.report_sha256 is None:
+        return _PublishingOutcome(published=False, recorded=True)
+    fingerprint = _fingerprint_payload({"report_sha256": payload.report_sha256})
+    return _publish_once(
+        run.summary,
+        _EVALUATION_REPORT_FINGERPRINT_KEY,
+        fingerprint,
+        "report",
+        lambda: _log_evaluation_report(run, report_bytes),
+    )
+
+
+def _publish_evaluation_artifact(run: Any, payload: _EvaluationPublishingPayload) -> _PublishingOutcome:
+    """Publish an artifact when at least one evaluation file is available."""
+    if payload.report_bytes is None and payload.metrics_bytes is None:
+        return _PublishingOutcome(published=False, recorded=True)
+    fingerprint = _fingerprint_payload(
+        {
+            "report_sha256": payload.report_sha256,
+            "metrics_sha256": payload.metrics_sha256,
+        }
+    )
+    return _publish_once(
+        run.summary,
+        _EVALUATION_ARTIFACT_FINGERPRINT_KEY,
+        fingerprint,
+        "report artifact",
+        lambda: _log_evaluation_artifact(run, payload),
+    )
+
+
+def _publish_once(
+    summary: Any,
+    marker_key: str,
+    fingerprint: str,
+    description: str,
+    publish: Callable[[], None],
+) -> _PublishingOutcome:
+    """Publish one W&B object unless its durable marker already matches."""
+    if _publishing_marker_matches(summary, marker_key, fingerprint):
+        return _PublishingOutcome(published=True, recorded=True)
+    try:
+        publish()
+    except Exception as exc:  # noqa: BLE001 -- W&B publishing is optional
+        logger.runtime.warning("Failed to publish W&B evaluation %s: %s", description, exc)
+        return _PublishingOutcome(published=False, recorded=False)
+    return _PublishingOutcome(
+        published=True,
+        recorded=_record_publishing_marker(summary, marker_key, fingerprint),
+    )
+
+
+def _log_evaluation_scorecard(run: Any, eval_metrics: dict[str, float | int | None]) -> None:
+    """Log the final evaluation metrics as a W&B table panel."""
+    run.log(
+        {
+            "evaluation/scorecard": wandb.Table(
+                columns=["metric", "value"],
+                data=[[key, value] for key, value in eval_metrics.items()],
             )
-            publishing_succeeded &= _record_publishing_marker(
-                run.summary,
-                _EVALUATION_SCORECARD_FINGERPRINT_KEY,
-                scorecard_fingerprint,
-            )
-        except Exception as exc:  # noqa: BLE001 -- W&B publishing is optional
-            logger.runtime.warning("Failed to publish W&B evaluation scorecard: %s", exc)
-            publishing_succeeded = False
+        }
+    )
 
-    report_sha256 = hashlib.sha256(report_bytes).hexdigest() if report_bytes is not None else None
-    report_uploaded = False
-    if upload_report and report_bytes is not None:
-        report_fingerprint = _fingerprint_payload({"report_sha256": report_sha256})
-        if _publishing_marker_matches(run.summary, _EVALUATION_REPORT_FINGERPRINT_KEY, report_fingerprint):
-            report_uploaded = True
-        else:
-            try:
-                report_html = report_bytes.decode("utf-8")
-                run.log({"evaluation/report": wandb.Html(report_html, inject=False)})
-                report_uploaded = True
-                publishing_succeeded &= _record_publishing_marker(
-                    run.summary,
-                    _EVALUATION_REPORT_FINGERPRINT_KEY,
-                    report_fingerprint,
-                )
-            except Exception as exc:  # noqa: BLE001 -- W&B publishing is optional
-                logger.runtime.warning("Failed to publish W&B evaluation report: %s", exc)
-                publishing_succeeded = False
 
-    if upload_report and (report_bytes is not None or metrics_bytes is not None):
-        artifact_fingerprint = _fingerprint_payload(
-            {
-                "report_sha256": report_sha256,
-                "metrics_sha256": hashlib.sha256(metrics_bytes).hexdigest() if metrics_bytes is not None else None,
-            }
-        )
-        if not _publishing_marker_matches(run.summary, _EVALUATION_ARTIFACT_FINGERPRINT_KEY, artifact_fingerprint):
-            try:
-                artifact = wandb.Artifact(f"safe-synthesizer-evaluation-report-{run.id}", type="evaluation-report")
-                if report_bytes is not None:
-                    artifact.add_file(str(report_path), name="evaluation_report.html")
-                if metrics_bytes is not None:
-                    artifact.add_file(str(metrics_path), name="evaluation_metrics.json")
-                run.log_artifact(artifact)
-                publishing_succeeded &= _record_publishing_marker(
-                    run.summary,
-                    _EVALUATION_ARTIFACT_FINGERPRINT_KEY,
-                    artifact_fingerprint,
-                )
-            except Exception as exc:  # noqa: BLE001 -- W&B publishing is optional
-                logger.runtime.warning("Failed to publish W&B evaluation report artifact: %s", exc)
-                publishing_succeeded = False
+def _log_evaluation_report(run: Any, report_bytes: bytes) -> None:
+    """Log the saved evaluation report as a W&B HTML panel."""
+    run.log({"evaluation/report": wandb.Html(report_bytes.decode("utf-8"), inject=False)})
 
+
+def _log_evaluation_artifact(run: Any, payload: _EvaluationPublishingPayload) -> None:
+    """Log the available evaluation files as a W&B artifact."""
+    artifact = wandb.Artifact(f"safe-synthesizer-evaluation-report-{run.id}", type="evaluation-report")
+    if payload.report_bytes is not None:
+        artifact.add_file(str(payload.report_path), name="evaluation_report.html")
+    if payload.metrics_bytes is not None:
+        artifact.add_file(str(payload.metrics_path), name="evaluation_metrics.json")
+    run.log_artifact(artifact)
+
+
+def _update_evaluation_publishing_summary(
+    summary: Any,
+    *,
+    report_state: _PublishedReportState,
+    publishing_fingerprint: str | None,
+) -> None:
+    """Record durable evaluation publishing state without failing the pipeline."""
     try:
         publishing_summary = {
-            "evaluation/report_uploaded_post_run": report_uploaded,
-            "evaluation/report_sha256": report_sha256,
+            "evaluation/report_uploaded_post_run": report_state.uploaded,
+            "evaluation/report_sha256": report_state.sha256,
         }
-        if publishing_succeeded:
-            publishing_summary[_EVALUATION_PUBLISHING_FINGERPRINT_KEY] = fingerprint
-        run.summary.update(publishing_summary)
+        if publishing_fingerprint is not None:
+            publishing_summary[_EVALUATION_PUBLISHING_FINGERPRINT_KEY] = publishing_fingerprint
+        summary.update(publishing_summary)
     except Exception as exc:  # noqa: BLE001 -- W&B publishing is optional
         logger.runtime.warning("Failed to update W&B evaluation publishing summary: %s", exc)
+
+
+def _read_published_report_state(summary: Any) -> _PublishedReportState:
+    """Read the report state already persisted in the W&B summary."""
+    uploaded = _read_publishing_summary_value(summary, "evaluation/report_uploaded_post_run", False)
+    sha256 = _read_publishing_summary_value(summary, "evaluation/report_sha256", None)
+    return _PublishedReportState(
+        uploaded=uploaded is True,
+        sha256=sha256 if isinstance(sha256, str) else None,
+    )
+
+
+def _updated_report_state(
+    previous: _PublishedReportState,
+    outcome: _PublishingOutcome,
+    report_sha256: str | None,
+) -> _PublishedReportState:
+    """Return the latest report state known to have reached W&B."""
+    if outcome.published and report_sha256 is not None:
+        return _PublishedReportState(uploaded=True, sha256=report_sha256)
+    return previous
+
+
+def _read_publishing_summary_value(summary: Any, key: str, default: object) -> object:
+    """Read a durable W&B publishing value without failing the pipeline."""
+    try:
+        value = summary.get(key)
+    except Exception as exc:  # noqa: BLE001 -- publishing remains best-effort
+        logger.runtime.warning("Failed to read W&B evaluation publishing value %s: %s", key, exc)
+        return default
+    return default if value is None else value
 
 
 def _read_optional_file(path: Path, file_description: str) -> bytes | None:
@@ -263,21 +407,9 @@ def _read_optional_file(path: Path, file_description: str) -> bytes | None:
         return None
 
 
-def _evaluation_publishing_fingerprint(
-    eval_metrics: dict[str, float | int | None],
-    upload_report: bool,
-    report_bytes: bytes | None,
-    metrics_bytes: bytes | None,
-) -> str:
-    """Return a stable marker for the exact CLI evaluation publishing payload."""
-    return _fingerprint_payload(
-        {
-            "eval_metrics": eval_metrics,
-            "upload_report": upload_report,
-            "report_sha256": hashlib.sha256(report_bytes).hexdigest() if report_bytes is not None else None,
-            "metrics_sha256": hashlib.sha256(metrics_bytes).hexdigest() if metrics_bytes is not None else None,
-        }
-    )
+def _optional_sha256(content: bytes | None) -> str | None:
+    """Hash optional evaluation content."""
+    return hashlib.sha256(content).hexdigest() if content is not None else None
 
 
 def _fingerprint_payload(payload: dict[str, object]) -> str:

--- a/src/nemo_safe_synthesizer/cli/wandb_setup.py
+++ b/src/nemo_safe_synthesizer/cli/wandb_setup.py
@@ -25,7 +25,7 @@ from .artifact_structure import Workdir
 
 logger = get_logger(__name__)
 
-_EVALUATION_PUBLICATION_FINGERPRINT_KEY = "_nss_evaluation_publication_fingerprint"
+_EVALUATION_PUBLISHING_FINGERPRINT_KEY = "_nss_evaluation_publishing_fingerprint"
 _EVALUATION_SCORECARD_FINGERPRINT_KEY = "_nss_evaluation_scorecard_fingerprint"
 _EVALUATION_REPORT_FINGERPRINT_KEY = "_nss_evaluation_report_fingerprint"
 _EVALUATION_ARTIFACT_FINGERPRINT_KEY = "_nss_evaluation_artifact_fingerprint"
@@ -165,14 +165,14 @@ def publish_evaluation_report(
     metrics_path = workdir.evaluation_metrics
     report_bytes = _read_optional_file(report_path, "report") if upload_report else None
     metrics_bytes = _read_optional_file(metrics_path, "metrics") if upload_report else None
-    fingerprint = _evaluation_publication_fingerprint(eval_metrics, upload_report, report_bytes, metrics_bytes)
+    fingerprint = _evaluation_publishing_fingerprint(eval_metrics, upload_report, report_bytes, metrics_bytes)
 
-    if _publication_marker_matches(run.summary, _EVALUATION_PUBLICATION_FINGERPRINT_KEY, fingerprint):
+    if _publishing_marker_matches(run.summary, _EVALUATION_PUBLISHING_FINGERPRINT_KEY, fingerprint):
         return
 
-    publication_succeeded = True
+    publishing_succeeded = True
     scorecard_fingerprint = _fingerprint_payload({"eval_metrics": eval_metrics})
-    if not _publication_marker_matches(run.summary, _EVALUATION_SCORECARD_FINGERPRINT_KEY, scorecard_fingerprint):
+    if not _publishing_marker_matches(run.summary, _EVALUATION_SCORECARD_FINGERPRINT_KEY, scorecard_fingerprint):
         try:
             run.log(
                 {
@@ -182,34 +182,34 @@ def publish_evaluation_report(
                     )
                 }
             )
-            publication_succeeded &= _record_publication_marker(
+            publishing_succeeded &= _record_publishing_marker(
                 run.summary,
                 _EVALUATION_SCORECARD_FINGERPRINT_KEY,
                 scorecard_fingerprint,
             )
-        except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
+        except Exception as exc:  # noqa: BLE001 -- W&B publishing is optional
             logger.runtime.warning("Failed to publish W&B evaluation scorecard: %s", exc)
-            publication_succeeded = False
+            publishing_succeeded = False
 
     report_sha256 = hashlib.sha256(report_bytes).hexdigest() if report_bytes is not None else None
     report_uploaded = False
     if upload_report and report_bytes is not None:
         report_fingerprint = _fingerprint_payload({"report_sha256": report_sha256})
-        if _publication_marker_matches(run.summary, _EVALUATION_REPORT_FINGERPRINT_KEY, report_fingerprint):
+        if _publishing_marker_matches(run.summary, _EVALUATION_REPORT_FINGERPRINT_KEY, report_fingerprint):
             report_uploaded = True
         else:
             try:
                 report_html = report_bytes.decode("utf-8")
                 run.log({"evaluation/report": wandb.Html(report_html, inject=False)})
                 report_uploaded = True
-                publication_succeeded &= _record_publication_marker(
+                publishing_succeeded &= _record_publishing_marker(
                     run.summary,
                     _EVALUATION_REPORT_FINGERPRINT_KEY,
                     report_fingerprint,
                 )
-            except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
+            except Exception as exc:  # noqa: BLE001 -- W&B publishing is optional
                 logger.runtime.warning("Failed to publish W&B evaluation report: %s", exc)
-                publication_succeeded = False
+                publishing_succeeded = False
 
     if upload_report and (report_bytes is not None or metrics_bytes is not None):
         artifact_fingerprint = _fingerprint_payload(
@@ -218,7 +218,7 @@ def publish_evaluation_report(
                 "metrics_sha256": hashlib.sha256(metrics_bytes).hexdigest() if metrics_bytes is not None else None,
             }
         )
-        if not _publication_marker_matches(run.summary, _EVALUATION_ARTIFACT_FINGERPRINT_KEY, artifact_fingerprint):
+        if not _publishing_marker_matches(run.summary, _EVALUATION_ARTIFACT_FINGERPRINT_KEY, artifact_fingerprint):
             try:
                 artifact = wandb.Artifact(f"safe-synthesizer-evaluation-report-{run.id}", type="evaluation-report")
                 if report_bytes is not None:
@@ -226,25 +226,25 @@ def publish_evaluation_report(
                 if metrics_bytes is not None:
                     artifact.add_file(str(metrics_path), name="evaluation_metrics.json")
                 run.log_artifact(artifact)
-                publication_succeeded &= _record_publication_marker(
+                publishing_succeeded &= _record_publishing_marker(
                     run.summary,
                     _EVALUATION_ARTIFACT_FINGERPRINT_KEY,
                     artifact_fingerprint,
                 )
-            except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
+            except Exception as exc:  # noqa: BLE001 -- W&B publishing is optional
                 logger.runtime.warning("Failed to publish W&B evaluation report artifact: %s", exc)
-                publication_succeeded = False
+                publishing_succeeded = False
 
     try:
-        publication_summary = {
+        publishing_summary = {
             "evaluation/report_uploaded_post_run": report_uploaded,
             "evaluation/report_sha256": report_sha256,
         }
-        if publication_succeeded:
-            publication_summary[_EVALUATION_PUBLICATION_FINGERPRINT_KEY] = fingerprint
-        run.summary.update(publication_summary)
-    except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
-        logger.runtime.warning("Failed to update W&B evaluation publication summary: %s", exc)
+        if publishing_succeeded:
+            publishing_summary[_EVALUATION_PUBLISHING_FINGERPRINT_KEY] = fingerprint
+        run.summary.update(publishing_summary)
+    except Exception as exc:  # noqa: BLE001 -- W&B publishing is optional
+        logger.runtime.warning("Failed to update W&B evaluation publishing summary: %s", exc)
 
 
 def _read_optional_file(path: Path, file_description: str) -> bytes | None:
@@ -263,13 +263,13 @@ def _read_optional_file(path: Path, file_description: str) -> bytes | None:
         return None
 
 
-def _evaluation_publication_fingerprint(
+def _evaluation_publishing_fingerprint(
     eval_metrics: dict[str, float | int | None],
     upload_report: bool,
     report_bytes: bytes | None,
     metrics_bytes: bytes | None,
 ) -> str:
-    """Return a stable marker for the exact CLI evaluation publication payload."""
+    """Return a stable marker for the exact CLI evaluation publishing payload."""
     return _fingerprint_payload(
         {
             "eval_metrics": eval_metrics,
@@ -285,22 +285,22 @@ def _fingerprint_payload(payload: dict[str, object]) -> str:
     return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 
 
-def _publication_marker_matches(summary: Any, key: str, fingerprint: str) -> bool:
-    """Return whether a best-effort W&B publication marker matches."""
+def _publishing_marker_matches(summary: Any, key: str, fingerprint: str) -> bool:
+    """Return whether a best-effort W&B publishing marker matches."""
     try:
         return summary.get(key) == fingerprint
-    except Exception as exc:  # noqa: BLE001 -- publication remains best-effort
-        logger.runtime.warning("Failed to read W&B evaluation publication marker %s: %s", key, exc)
+    except Exception as exc:  # noqa: BLE001 -- publishing remains best-effort
+        logger.runtime.warning("Failed to read W&B evaluation publishing marker %s: %s", key, exc)
         return False
 
 
-def _record_publication_marker(summary: Any, key: str, fingerprint: str) -> bool:
-    """Persist a best-effort W&B publication marker after an operation succeeds."""
+def _record_publishing_marker(summary: Any, key: str, fingerprint: str) -> bool:
+    """Persist a best-effort W&B publishing marker after an operation succeeds."""
     try:
         summary.update({key: fingerprint})
         return True
-    except Exception as exc:  # noqa: BLE001 -- publication remains best-effort
-        logger.runtime.warning("Failed to update W&B evaluation publication marker %s: %s", key, exc)
+    except Exception as exc:  # noqa: BLE001 -- publishing remains best-effort
+        logger.runtime.warning("Failed to update W&B evaluation publishing marker %s: %s", key, exc)
         return False
 
 

--- a/src/nemo_safe_synthesizer/cli/wandb_setup.py
+++ b/src/nemo_safe_synthesizer/cli/wandb_setup.py
@@ -137,9 +137,9 @@ def log_failure_to_wandb(error: Exception, phase: str) -> None:
                     f"{phase}/error_message": str(error),
                 }
             )
-            logger.info(f"Updated wandb failure summary for {phase} phase")
-    except Exception as e:
-        logger.warning(f"Failed to log error to wandb: {e}")
+            logger.runtime.info("Updated wandb failure summary for %s phase", phase)
+    except Exception as exc:  # noqa: BLE001 -- observability is best-effort
+        logger.runtime.warning("Failed to log error to wandb: %s", exc)
 
 
 def publish_evaluation_report(
@@ -188,7 +188,7 @@ def publish_evaluation_report(
                 scorecard_fingerprint,
             )
         except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
-            logger.warning(f"Failed to publish W&B evaluation scorecard: {exc}")
+            logger.runtime.warning("Failed to publish W&B evaluation scorecard: %s", exc)
             publication_succeeded = False
 
     report_sha256 = hashlib.sha256(report_bytes).hexdigest() if report_bytes is not None else None
@@ -208,7 +208,7 @@ def publish_evaluation_report(
                     report_fingerprint,
                 )
             except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
-                logger.warning(f"Failed to publish W&B evaluation report: {exc}")
+                logger.runtime.warning("Failed to publish W&B evaluation report: %s", exc)
                 publication_succeeded = False
 
     if upload_report and (report_bytes is not None or metrics_bytes is not None):
@@ -232,7 +232,7 @@ def publish_evaluation_report(
                     artifact_fingerprint,
                 )
             except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
-                logger.warning(f"Failed to publish W&B evaluation report artifact: {exc}")
+                logger.runtime.warning("Failed to publish W&B evaluation report artifact: %s", exc)
                 publication_succeeded = False
 
     try:
@@ -244,18 +244,22 @@ def publish_evaluation_report(
             publication_summary[_EVALUATION_PUBLICATION_FINGERPRINT_KEY] = fingerprint
         run.summary.update(publication_summary)
     except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
-        logger.warning(f"Failed to update W&B evaluation publication summary: {exc}")
+        logger.runtime.warning("Failed to update W&B evaluation publication summary: %s", exc)
 
 
 def _read_optional_file(path: Path, file_description: str) -> bytes | None:
     """Read an opted-in evaluation file, warning instead of failing the run."""
     try:
         if not path.is_file():
-            logger.warning(f"W&B evaluation {file_description} upload requested but file is missing: {path}")
+            logger.runtime.warning(
+                "W&B evaluation %s upload requested but file is missing: %s",
+                file_description,
+                path,
+            )
             return None
         return path.read_bytes()
     except Exception as exc:  # noqa: BLE001 -- local output inspection is optional
-        logger.warning(f"Failed to read W&B evaluation {file_description}: {exc}")
+        logger.runtime.warning("Failed to read W&B evaluation %s: %s", file_description, exc)
         return None
 
 
@@ -286,7 +290,7 @@ def _publication_marker_matches(summary: Any, key: str, fingerprint: str) -> boo
     try:
         return summary.get(key) == fingerprint
     except Exception as exc:  # noqa: BLE001 -- publication remains best-effort
-        logger.warning(f"Failed to read W&B evaluation publication marker {key}: {exc}")
+        logger.runtime.warning("Failed to read W&B evaluation publication marker %s: %s", key, exc)
         return False
 
 
@@ -296,7 +300,7 @@ def _record_publication_marker(summary: Any, key: str, fingerprint: str) -> bool
         summary.update({key: fingerprint})
         return True
     except Exception as exc:  # noqa: BLE001 -- publication remains best-effort
-        logger.warning(f"Failed to update W&B evaluation publication marker {key}: {exc}")
+        logger.runtime.warning("Failed to update W&B evaluation publication marker %s: %s", key, exc)
         return False
 
 

--- a/src/nemo_safe_synthesizer/cli/wandb_setup.py
+++ b/src/nemo_safe_synthesizer/cli/wandb_setup.py
@@ -9,6 +9,8 @@ including run initialization, configuration logging, and failure reporting.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
@@ -17,11 +19,13 @@ import wandb
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings
 
-from ..config import SafeSynthesizerParameters
+from ..config import SafeSynthesizerParameters, SafeSynthesizerSummary
 from ..observability import get_logger
 from .artifact_structure import Workdir
 
 logger = get_logger(__name__)
+
+_EVALUATION_PUBLICATION_FINGERPRINT_KEY = "_nss_evaluation_publication_fingerprint"
 
 
 def resolve_wandb_run_id(id_or_path: str) -> str:
@@ -123,16 +127,125 @@ def log_failure_to_wandb(error: Exception, phase: str) -> None:
     """
     try:
         if wandb.run is not None:
-            wandb.log(
+            wandb.run.summary.update(
                 {
                     "eval/success": 0,
                     f"{phase}/error_type": type(error).__name__,
                     f"{phase}/error_message": str(error),
                 }
             )
-            logger.info(f"Logged failure to wandb for {phase} phase")
+            logger.info(f"Updated wandb failure summary for {phase} phase")
     except Exception as e:
         logger.warning(f"Failed to log error to wandb: {e}")
+
+
+def publish_evaluation_report(
+    workdir: Workdir,
+    summary: SafeSynthesizerSummary,
+    upload_report: bool,
+) -> None:
+    """Best-effort publish final evaluation media for a CLI-managed run.
+
+    The scorecard is always sent when W&B is active. HTML and files leave the
+    local machine only when ``upload_report`` is explicitly enabled.
+
+    Args:
+        workdir: Run artifact paths containing the saved report and metrics.
+        summary: Final pipeline summary used to construct the scorecard.
+        upload_report: Whether report HTML and artifact egress is permitted.
+    """
+    run = wandb.run
+    if run is None:
+        return
+    eval_metrics = {key: value for key, value in summary._wandb_metrics().items() if key.startswith("eval/")}
+    report_path = workdir.evaluation_report
+    metrics_path = workdir.evaluation_metrics
+    report_bytes = _read_optional_file(report_path, "report") if upload_report else None
+    metrics_bytes = _read_optional_file(metrics_path, "metrics") if upload_report else None
+    fingerprint = _evaluation_publication_fingerprint(eval_metrics, upload_report, report_bytes, metrics_bytes)
+
+    try:
+        if run.summary.get(_EVALUATION_PUBLICATION_FINGERPRINT_KEY) == fingerprint:
+            return
+    except Exception as exc:  # noqa: BLE001 -- publication remains best-effort
+        logger.warning(f"Failed to read W&B evaluation publication marker: {exc}")
+
+    publication_succeeded = True
+    try:
+        run.log(
+            {
+                "evaluation/scorecard": wandb.Table(
+                    columns=["metric", "value"],
+                    data=[[key, value] for key, value in eval_metrics.items()],
+                )
+            }
+        )
+    except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
+        logger.warning(f"Failed to publish W&B evaluation scorecard: {exc}")
+        publication_succeeded = False
+
+    report_sha256: str | None = None
+    report_uploaded = False
+    if upload_report and report_bytes is not None:
+        try:
+            report_html = report_bytes.decode("utf-8")
+            run.log({"evaluation/report": wandb.Html(report_html, inject=False)})
+            report_sha256 = hashlib.sha256(report_bytes).hexdigest()
+            report_uploaded = True
+        except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
+            logger.warning(f"Failed to publish W&B evaluation report: {exc}")
+            publication_succeeded = False
+
+    if upload_report and (report_bytes is not None or metrics_bytes is not None):
+        try:
+            artifact = wandb.Artifact(f"safe-synthesizer-evaluation-report-{run.id}", type="evaluation-report")
+            if report_bytes is not None:
+                artifact.add_file(str(report_path), name="evaluation_report.html")
+            if metrics_bytes is not None:
+                artifact.add_file(str(metrics_path), name="evaluation_metrics.json")
+            run.log_artifact(artifact)
+        except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
+            logger.warning(f"Failed to publish W&B evaluation report artifact: {exc}")
+            publication_succeeded = False
+
+    try:
+        publication_summary = {
+            "evaluation/report_uploaded_post_run": report_uploaded,
+            "evaluation/report_sha256": report_sha256,
+        }
+        if publication_succeeded:
+            publication_summary[_EVALUATION_PUBLICATION_FINGERPRINT_KEY] = fingerprint
+        run.summary.update(publication_summary)
+    except Exception as exc:  # noqa: BLE001 -- W&B publication is optional
+        logger.warning(f"Failed to update W&B evaluation publication summary: {exc}")
+
+
+def _read_optional_file(path: Path, file_description: str) -> bytes | None:
+    """Read an opted-in evaluation file, warning instead of failing the run."""
+    try:
+        if not path.is_file():
+            logger.warning(f"W&B evaluation {file_description} upload requested but file is missing: {path}")
+            return None
+        return path.read_bytes()
+    except Exception as exc:  # noqa: BLE001 -- local output inspection is optional
+        logger.warning(f"Failed to read W&B evaluation {file_description}: {exc}")
+        return None
+
+
+def _evaluation_publication_fingerprint(
+    eval_metrics: dict[str, float | int | None],
+    upload_report: bool,
+    report_bytes: bytes | None,
+    metrics_bytes: bytes | None,
+) -> str:
+    """Return a stable marker for the exact CLI evaluation publication payload."""
+    payload = {
+        "eval_metrics": eval_metrics,
+        "upload_report": upload_report,
+        "report_sha256": hashlib.sha256(report_bytes).hexdigest() if report_bytes is not None else None,
+        "metrics_sha256": hashlib.sha256(metrics_bytes).hexdigest() if metrics_bytes is not None else None,
+    }
+    return hashlib.sha256(json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
 
 
 def update_wandb_config(
@@ -282,9 +395,9 @@ class WandbLoggable(Protocol):
 def log_observability_event(event: WandbLoggable, prefix: str) -> None:
     """Log an observability event to the currently active wandb run.
 
-    Generic sink shared by the training and generation observability paths.
+    Generic sink shared by final training and generation observability paths.
     No-op when no wandb run is active (``WANDB_MODE=disabled`` or the pipeline
-    hasn't called :func:`initialize_wandb_run`). Errors during ``wandb.log`` are
+    hasn't called :func:`initialize_wandb_run`). Errors during summary updates are
     swallowed at warning level -- observability is best-effort and a wandb
     failure must not break the run.
 
@@ -297,6 +410,6 @@ def log_observability_event(event: WandbLoggable, prefix: str) -> None:
     if wandb.run is None:
         return
     try:
-        wandb.log(event.to_wandb_payload(prefix=prefix))
+        wandb.run.summary.update(event.to_wandb_payload(prefix=prefix))
     except Exception as exc:  # noqa: BLE001 -- degraded mode
         logger.warning(f"failed to log observability event ({prefix!r}) to wandb: {exc}")

--- a/src/nemo_safe_synthesizer/cli/wandb_setup.py
+++ b/src/nemo_safe_synthesizer/cli/wandb_setup.py
@@ -17,10 +17,9 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
+import wandb
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import BaseSettings
-
-import wandb
 
 from ..config import SafeSynthesizerParameters, SafeSynthesizerSummary
 from ..observability import get_logger

--- a/src/nemo_safe_synthesizer/config/external_results.py
+++ b/src/nemo_safe_synthesizer/config/external_results.py
@@ -10,9 +10,12 @@ from typing import TYPE_CHECKING
 
 from pydantic import Field
 
+from ..observability import get_logger
 from .base import NSSBaseModel
 
 __all__ = ["SafeSynthesizerTiming", "SafeSynthesizerSummary"]
+
+logger = get_logger(__name__)
 
 if TYPE_CHECKING:
     import wandb
@@ -39,21 +42,24 @@ class SafeSynthesizerTiming(NSSBaseModel):
         )
 
     def log_wandb(self, run: wandb.Run | None = None) -> None:
-        """Log timing metrics to an active Weights & Biases run.
+        """Update final timing metrics on an active Weights & Biases run.
 
         Args:
             run: W&B run instance. No-op when ``None``.
         """
         if run is not None:
-            run.log(
-                {
-                    "total_time_sec": self.total_time_sec,
-                    "pii_replacer_time_sec": self.pii_replacer_time_sec,
-                    "training_time_sec": self.training_time_sec,
-                    "generation_time_sec": self.generation_time_sec,
-                    "evaluation_time_sec": self.evaluation_time_sec if self.evaluation_time_sec else 0,
-                }
-            )
+            try:
+                run.summary.update(
+                    {
+                        "total_time_sec": self.total_time_sec,
+                        "pii_replacer_time_sec": self.pii_replacer_time_sec,
+                        "training_time_sec": self.training_time_sec,
+                        "generation_time_sec": self.generation_time_sec,
+                        "evaluation_time_sec": self.evaluation_time_sec,
+                    }
+                )
+            except Exception as exc:  # noqa: BLE001 -- observability is best-effort
+                logger.runtime.warning("Failed to update W&B timing summary: %s", exc)
 
 
 class SafeSynthesizerSummary(NSSBaseModel):
@@ -167,47 +173,52 @@ class SafeSynthesizerSummary(NSSBaseModel):
             extra={"ctx": {"render_table": True, "tabular_data": self.model_dump(), "title": "Quality Metrics"}},
         )
 
+    def _wandb_metrics(self) -> dict[str, float | int | None]:
+        """Return the stable final W&B metric payload, including ``None`` values."""
+        return {
+            "gen/generation_time_sec": self.timing.generation_time_sec,
+            "gen/evaluation_time_sec": self.timing.evaluation_time_sec,
+            "eval/total_time_sec": self.timing.total_time_sec,
+            "train/pii_replacer_time_sec": self.timing.pii_replacer_time_sec,
+            "train/training_time_sec": self.timing.training_time_sec,
+            "gen/num_valid_records": self.num_valid_records,
+            "gen/num_invalid_records": self.num_invalid_records,
+            "gen/num_prompts": self.num_prompts,
+            "gen/valid_record_fraction": self.valid_record_fraction,
+            "gen/num_completion_tokens": self.num_completion_tokens,
+            "gen/num_valid_record_tokens": self.num_valid_record_tokens,
+            "gen/num_invalid_record_tokens": self.num_invalid_record_tokens,
+            "gen/num_non_record_tokens": self.num_non_record_tokens,
+            "gen/valid_record_token_fraction": self.valid_record_token_fraction,
+            "gen/tokens_per_prompt": self.tokens_per_prompt,
+            "gen/tokens_per_second": self.tokens_per_second,
+            "gen/valid_tokens_per_second": self.valid_tokens_per_second,
+            "gen/tokenization_overhead_sec": self.tokenization_overhead_sec,
+            "eval/data_privacy_score": self.data_privacy_score,
+            "eval/membership_inference_protection_score": self.membership_inference_protection_score,
+            "eval/attribute_inference_protection_score": self.attribute_inference_protection_score,
+            "eval/synthetic_data_quality_score": self.synthetic_data_quality_score,
+            "eval/column_correlation_stability_score": self.column_correlation_stability_score,
+            "eval/deep_structure_stability_score": self.deep_structure_stability_score,
+            "eval/column_distribution_stability_score": self.column_distribution_stability_score,
+            "eval/text_semantic_similarity_score": self.text_semantic_similarity_score,
+            "eval/text_structure_similarity_score": self.text_structure_similarity_score,
+            "eval/success": 1
+            if self.data_privacy_score is not None
+            and self.synthetic_data_quality_score is not None
+            and self.synthetic_data_quality_score > 0
+            else 0,
+        }
+
     def log_wandb(self) -> None:
-        """Log all summary and timing metrics to the active W&B run."""
+        """Update all final summary and timing metrics on the active W&B run."""
         import wandb
 
         if wandb.run is not None:
-            metrics: dict[str, float | int | None] = {
-                "gen/generation_time_sec": self.timing.generation_time_sec,
-                "gen/evaluation_time_sec": self.timing.evaluation_time_sec,
-                "eval/total_time_sec": self.timing.total_time_sec,
-                "train/pii_replacer_time_sec": self.timing.pii_replacer_time_sec,
-                "train/training_time_sec": self.timing.training_time_sec,
-                "gen/num_valid_records": self.num_valid_records,
-                "gen/num_invalid_records": self.num_invalid_records,
-                "gen/num_prompts": self.num_prompts,
-                "gen/valid_record_fraction": self.valid_record_fraction,
-                "gen/num_completion_tokens": self.num_completion_tokens,
-                "gen/num_valid_record_tokens": self.num_valid_record_tokens,
-                "gen/num_invalid_record_tokens": self.num_invalid_record_tokens,
-                "gen/num_non_record_tokens": self.num_non_record_tokens,
-                "gen/valid_record_token_fraction": self.valid_record_token_fraction,
-                "gen/tokens_per_prompt": self.tokens_per_prompt,
-                "gen/tokens_per_second": self.tokens_per_second,
-                "gen/valid_tokens_per_second": self.valid_tokens_per_second,
-                "gen/tokenization_overhead_sec": self.tokenization_overhead_sec,
-                "eval/data_privacy_score": self.data_privacy_score,
-                "eval/membership_inference_protection_score": self.membership_inference_protection_score,
-                "eval/attribute_inference_protection_score": self.attribute_inference_protection_score,
-                "eval/synthetic_data_quality_score": self.synthetic_data_quality_score,
-                "eval/column_correlation_stability_score": self.column_correlation_stability_score,
-                "eval/deep_structure_stability_score": self.deep_structure_stability_score,
-                "eval/column_distribution_stability_score": self.column_distribution_stability_score,
-                "eval/text_semantic_similarity_score": self.text_semantic_similarity_score,
-                "eval/text_structure_similarity_score": self.text_structure_similarity_score,
-                "eval/success": 1
-                if self.data_privacy_score is not None
-                and self.synthetic_data_quality_score is not None
-                and self.synthetic_data_quality_score > 0
-                else 0,
-            }
-            # Log ``None`` values too (rather than filtering them out) so that
-            # dashboard comparisons clearly show when a stage was skipped or a
-            # metric was not collected for a given run, instead of the metric
-            # silently carrying its last-logged value on the W&B chart.
-            wandb.log(metrics)
+            # Keep ``None`` values so dashboard comparisons show skipped or
+            # uncollected metrics rather than silently retaining stale summary
+            # values from an earlier update to a resumed W&B run.
+            try:
+                wandb.run.summary.update(self._wandb_metrics())
+            except Exception as exc:  # noqa: BLE001 -- observability is best-effort
+                logger.runtime.warning("Failed to update W&B final summary: %s", exc)

--- a/src/nemo_safe_synthesizer/config/external_results.py
+++ b/src/nemo_safe_synthesizer/config/external_results.py
@@ -176,9 +176,9 @@ class SafeSynthesizerSummary(NSSBaseModel):
     def _wandb_metrics(self) -> dict[str, float | int | None]:
         """Return the stable final W&B metric payload, including ``None`` values."""
         return {
+            "total_time_sec": self.timing.total_time_sec,
             "gen/generation_time_sec": self.timing.generation_time_sec,
-            "gen/evaluation_time_sec": self.timing.evaluation_time_sec,
-            "eval/total_time_sec": self.timing.total_time_sec,
+            "eval/evaluation_time_sec": self.timing.evaluation_time_sec,
             "train/pii_replacer_time_sec": self.timing.pii_replacer_time_sec,
             "train/training_time_sec": self.timing.training_time_sec,
             "gen/num_valid_records": self.num_valid_records,

--- a/src/nemo_safe_synthesizer/evaluation/components/membership_inference_protection.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/membership_inference_protection.py
@@ -542,22 +542,23 @@ class MembershipInferenceProtection(Component):
                 scores.append(score)
                 attack_sum_values = attack_sum_values + attack_sum
 
-            values = {}
+            attack_counts = {}
             for grade in PrivacyGrade:
-                values[grade.value] = 0
+                attack_counts[grade.value] = 0
 
-            total = 0
             for value in attack_sum_values:
-                total += 1
-                values[value] += 1
+                attack_counts[value] += 1
 
-            for i in values:
-                values[i] = int((values[i] / total) * 100)
+            total = sum(attack_counts.values())
+            attack_percentages = {
+                grade: (count / total) * 100 if total else 0.0 for grade, count in attack_counts.items()
+            }
 
             attack_sum_df = pd.DataFrame(
                 {
-                    "Protection": values.keys(),
-                    "Attack Percentage": values.values(),
+                    "Protection": attack_counts.keys(),
+                    "Attack Count": attack_counts.values(),
+                    "Attack Percentage": attack_percentages.values(),
                 }
             )
 

--- a/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
@@ -264,15 +264,16 @@ def generate_mia_figure(df: pd.DataFrame) -> go.Figure:
     )
     df.sort_values(by=PROTECTION_COLUMN, inplace=True, ascending=False)
 
+    chart_df = df.loc[df[PROTECTION_COLUMN].notna()]
     value_column = "Attack Count" if "Attack Count" in df else "Attack Percentage"
     fig = pie(
-        labels=df[PROTECTION_COLUMN].dropna().astype(str).tolist(),
-        values=df[value_column].replace({0: np.nan}),
+        labels=chart_df[PROTECTION_COLUMN].astype(str).tolist(),
+        values=chart_df[value_column].replace({0: np.nan}),
         sort=False,
     )
     title = "Membership inference attack outcomes"
     if value_column == "Attack Count":
-        title += f" ({df[value_column].sum()} attack evaluations graded)"
+        title += f" ({chart_df[value_column].sum()} attack evaluations graded)"
     fig.update_layout(
         title=title,
         margin=dict(l=0, r=0, t=24, b=0),

--- a/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/multi_modal_figures.py
@@ -264,12 +264,17 @@ def generate_mia_figure(df: pd.DataFrame) -> go.Figure:
     )
     df.sort_values(by=PROTECTION_COLUMN, inplace=True, ascending=False)
 
+    value_column = "Attack Count" if "Attack Count" in df else "Attack Percentage"
     fig = pie(
         labels=df[PROTECTION_COLUMN].dropna().astype(str).tolist(),
-        values=df["Attack Percentage"].replace({0: np.nan}),
+        values=df[value_column].replace({0: np.nan}),
         sort=False,
     )
+    title = "Membership inference attack outcomes"
+    if value_column == "Attack Count":
+        title += f" ({df[value_column].sum()} attack evaluations graded)"
     fig.update_layout(
+        title=title,
         margin=dict(l=0, r=0, t=24, b=0),
     )
 

--- a/src/nemo_safe_synthesizer/evaluation/components/text_semantic_similarity.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/text_semantic_similarity.py
@@ -188,7 +188,7 @@ class TextSemanticSimilarity(Component):
                     ) = (EvaluationScore(notes=warning_message),) * 3
 
                 if warning_message:
-                    logger.info(warning_message)
+                    logger.warning(warning_message)
 
                 # I'm PCA I've got nothing to prove pay attention my intention is to bust a move.
                 training_pca, synthetic_pca = TextSemanticSimilarity._get_pca(

--- a/src/nemo_safe_synthesizer/generation/vllm_observability.py
+++ b/src/nemo_safe_synthesizer/generation/vllm_observability.py
@@ -199,7 +199,7 @@ class GenerationObservability(BaseModel):
     )
 
     def to_wandb_payload(self, prefix: str = "vllm_gen") -> dict[str, Any]:
-        """Flatten this event into a wandb-friendly ``wandb.log(...)`` dict.
+        """Flatten this event into a W&B-summary-friendly metrics dict.
 
         Wandb plots scalars cleanly but renders tuples/dicts as opaque
         blobs, so this method:

--- a/src/nemo_safe_synthesizer/observability.py
+++ b/src/nemo_safe_synthesizer/observability.py
@@ -57,7 +57,6 @@ from pydantic_settings import BaseSettings
 from rich import box
 from rich.console import Console
 from rich.table import Table
-from structlog.processors import JSONRenderer
 from structlog.typing import EventDict
 
 P = ParamSpec("P")
@@ -209,7 +208,9 @@ def _move_category_for_column(logger: logging.Logger, method_name: str, event_di
 def _format_table_value(key: str, value: object) -> str:
     """Format values for user-facing Rich tables."""
     if isinstance(value, float):
-        is_fraction = 0 < value < 1 and key not in ("loss", "eval_loss") and not key.endswith(("_sec", "_seconds"))
+        is_fraction = key.endswith("_fraction") or (
+            0 < value < 1 and key not in ("loss", "eval_loss") and not key.endswith(("_sec", "_seconds"))
+        )
         return f"{value:.2%}" if is_fraction else f"{value:.2f}"
     if isinstance(value, Mapping):
         return ", ".join(f"{mapping_key}: {value[mapping_key]}" for mapping_key in sorted(value))
@@ -253,7 +254,7 @@ def _convert_rich_table_to_string(rich_table: Table) -> str:
     return string_io.getvalue()
 
 
-def _render_table_data_for_console(logger: logging.Logger, method_name: str, event_dict: dict) -> dict:
+def _render_table_data_for_console(logger: logging.Logger, method_name: str, event_dict: EventDict) -> EventDict:
     """Processor that renders table data keys as Rich tables for console output.
 
     For each table found in structured context, renders the data as a Rich ASCII
@@ -265,9 +266,7 @@ def _render_table_data_for_console(logger: logging.Logger, method_name: str, eve
     """
     tables_to_render = []
     rendered_keys: list[str] = list()
-    # Check both locations: ExtraAdder flattens to event_dict["ctx"] for foreign loggers,
-    # but native structlog loggers may have it in event_dict["extra"]["ctx"]
-    ctx = event_dict.get("ctx") or event_dict.get("extra", {}).get("ctx", {})
+    ctx = event_dict.get("context", {})
 
     match ctx:
         case {"rich_table": rich_table, **__} if isinstance(rich_table, Table):
@@ -299,6 +298,35 @@ def _render_table_data_for_console(logger: logging.Logger, method_name: str, eve
     return event_dict
 
 
+def _canonicalize_log_event(logger: logging.Logger, method_name: str, event_dict: EventDict) -> EventDict:
+    """Give native and foreign records the same structured context field."""
+    extra = event_dict.get("extra")
+    context = event_dict.pop("ctx", None)
+    if context is None and isinstance(extra, Mapping):
+        context = extra.get("ctx")
+    if context is not None:
+        event_dict["context"] = context
+    if isinstance(extra, Mapping) and "ctx" in extra:
+        remaining_extra = {key: value for key, value in extra.items() if key != "ctx"}
+        if remaining_extra:
+            event_dict["extra"] = remaining_extra
+        else:
+            event_dict.pop("extra", None)
+    return event_dict
+
+
+def _ensure_log_schema(logger: logging.Logger, method_name: str, event_dict: EventDict) -> EventDict:
+    """Populate the canonical JSON fields when a source omits optional metadata."""
+    event_dict.setdefault("timestamp", datetime.now().isoformat(timespec="milliseconds"))
+    event_dict.setdefault("category", LogCategory.RUNTIME.value)
+    event_dict.setdefault("context", {})
+    event_dict.setdefault("logger", getattr(logger, "name", None))
+    event_dict.setdefault("filename", None)
+    event_dict.setdefault("lineno", None)
+    event_dict.setdefault("qual_name", None)
+    return event_dict
+
+
 class DiscardSensitiveMessages(logging.Filter):
     """Discards messages marked as sensitive via the `sensitive` flag."""
 
@@ -320,47 +348,15 @@ class CategoryFilter(logging.Filter):
         return category in {c.value for c in self.include_categories}
 
 
-def _prepare_json_logging() -> tuple[
-    JSONRenderer, structlog.processors.TimeStamper, list[structlog.processors.CallsiteParameterAdder | Callable]
-]:
-    """Prepare JSON file logging."""
-    # TODO: add info context to the json logging
-    # todo: add force ascii to decode unicode to ascii
-    json_renderer = structlog.processors.JSONRenderer()
-    json_timestamp_processor = structlog.processors.TimeStamper(fmt="iso")
-    json_env_processors: list[structlog.processors.CallsiteParameterAdder | Callable] = [
-        structlog.processors.CallsiteParameterAdder(
-            {
-                structlog.processors.CallsiteParameter.FILENAME,
-                structlog.processors.CallsiteParameter.LINENO,
-            }
-        ),
-        _category_log_processor,
-    ]
-
-    return json_renderer, json_timestamp_processor, json_env_processors
-
-
-def _prepare_file_logging() -> logging.Handler | None:
+def _prepare_file_logging(shared_processors: list[Processor]) -> logging.Handler | None:
     """Prepare file logging for JSON logs."""
     if SETTINGS and SETTINGS.nss_log_file:
-        json_renderer, json_timestamp_processor, json_env_processors = _prepare_json_logging()
-        json_foreign_pre_chain = [
-            structlog.stdlib.add_log_level,
-            structlog.stdlib.add_logger_name,
-            structlog.stdlib.ExtraAdder(),
-            json_timestamp_processor,
-            structlog.processors.StackInfoRenderer(),
-            # structlog.processors.format_exc_info,
-            structlog.processors.UnicodeDecoder(),
-            *json_env_processors,
-            structlog.processors.EventRenamer(to="message"),
-        ]
         file_formatter = structlog.stdlib.ProcessorFormatter(
-            foreign_pre_chain=json_foreign_pre_chain,
+            foreign_pre_chain=shared_processors,
             processors=[
                 structlog.stdlib.ProcessorFormatter.remove_processors_meta,
-                json_renderer,
+                structlog.processors.EventRenamer(to="message"),
+                structlog.processors.JSONRenderer(),
             ],
         )
         Path(SETTINGS.nss_log_file).parent.mkdir(parents=True, exist_ok=True)
@@ -468,9 +464,10 @@ def _get_console_columns() -> list:
             prefix=dim_white + ": ",
         ),
     )
-    # Suppress "ctx" - table data is rendered separately by _render_table_data_for_console
-    ctx_suppress_column = structlog.dev.Column(
-        "ctx",
+    # Suppress structured context. Table data is rendered separately by
+    # _render_table_data_for_console.
+    context_suppress_column = structlog.dev.Column(
+        "context",
         structlog.dev.KeyValueColumnFormatter(
             key_style=None,
             value_style="",
@@ -507,15 +504,13 @@ def _get_console_columns() -> list:
         lineno_column,
         message_column,
         extra_display_column,
-        ctx_suppress_column,
+        context_suppress_column,
         extra_suppress_column,
         default_column,
     ]
 
 
-def _remove_category_before_render(
-    logger: logging.Logger, method_name: str, event_dict: MutableMapping[str, Any]
-) -> MutableMapping[str, Any]:
+def _remove_category_before_render(logger: logging.Logger, method_name: str, event_dict: EventDict) -> EventDict:
     """Remove category from event_dict right before rendering to prevent duplicate display."""
     event_dict.pop("category", None)
     return event_dict
@@ -533,7 +528,14 @@ def _prepare_console_logging(
         structlog.stdlib.ProcessorFormatter.remove_processors_meta,
     ]
     if is_plain:
-        final_processors.append(_remove_category_before_render)
+        final_processors.extend(
+            [
+                _render_table_data_for_console,
+                _move_category_for_column,
+                _remove_category_before_render,
+            ]
+        )
+    final_processors.append(structlog.processors.EventRenamer(to="message"))
     final_processors.append(renderer)
 
     console_formatter = structlog.stdlib.ProcessorFormatter(
@@ -549,12 +551,10 @@ def _prepare_console_logging(
 
 
 def _prepare_common_processors() -> tuple[list, Any]:
-    json_renderer, json_timestamp_processor, json_env_processors = _prepare_json_logging()
     global SETTINGS
     if SETTINGS and SETTINGS.nss_log_format == "json":
-        renderer = json_renderer
-        timestamp_processor = json_timestamp_processor
-        env_processors = json_env_processors
+        renderer = structlog.processors.JSONRenderer()
+        timestamp_processor: Processor = structlog.processors.TimeStamper(fmt="iso")
     else:
         renderer = structlog.dev.ConsoleRenderer(
             columns=_get_console_columns(),
@@ -566,12 +566,13 @@ def _prepare_common_processors() -> tuple[list, Any]:
 
         timestamp_processor = structlog.processors.TimeStamper()
         timestamp_processor._stamper = _stamper
-        # For console output: render table data as Rich tables, then handle categories
-        env_processors = [_category_log_processor, _render_table_data_for_console, _move_category_for_column]
 
-    # Shared processors for both native structlog and foreign loggers
+    # Shared processors enrich native and foreign events without changing their
+    # representation for a particular handler. Handler renderers own display-only
+    # transformations such as Rich tables and category columns.
     shared_processors = [
         structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
         structlog.processors.CallsiteParameterAdder(
             {
                 structlog.processors.CallsiteParameter.FILENAME,
@@ -583,11 +584,13 @@ def _prepare_common_processors() -> tuple[list, Any]:
             additional_ignores=["nemo_safe_synthesizer.observability"],
         ),
         structlog.stdlib.ExtraAdder(),
-        *env_processors,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        _category_log_processor,
+        _canonicalize_log_event,
         timestamp_processor,
+        _ensure_log_schema,
         structlog.processors.StackInfoRenderer(),
         structlog.processors.UnicodeDecoder(),
-        structlog.processors.EventRenamer(to="message"),
     ]
 
     return shared_processors, renderer
@@ -676,7 +679,7 @@ def _initialize_logging() -> None:
     # Attach handlers to root logger so ALL loggers use the configured formatters
     root_logger = logging.getLogger()
     root_logger.addHandler(console_handler)
-    file_handler = _prepare_file_logging()
+    file_handler = _prepare_file_logging(shared_processors)
     if file_handler:
         root_logger.addHandler(file_handler)
 

--- a/src/nemo_safe_synthesizer/pii_replacer/data_editor/edit.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/data_editor/edit.py
@@ -155,6 +155,11 @@ class ProgressLog:
 
             self.last_log = monotonic()
 
+    def reset_timing(self) -> None:
+        """Start a new row-rendering timing phase after preprocessing work."""
+        self.start_time = monotonic()
+        self.last_log = self.start_time
+
 
 class Step:
     """Single transformation step: applies column/row add/drop/rename/update rules to a DataFrame.
@@ -556,6 +561,7 @@ class Step:
                     continue
                 if fns & self._env.ner_cacheable_filters:
                     self.update_ner_cache(df.loc[rows, column_name])
+                    progress.reset_timing()
                 df.loc[rows, column_name] = df.loc[rows].apply(
                     self._render_cell,
                     args=(
@@ -715,7 +721,7 @@ class Editor:
         for stepn, step_config in enumerate(self.config["steps"]):
             progress.status.step_n = stepn
             logger.user.info(
-                f"Executing transform step : {stepn} / {len(self.config['steps'])}",
+                f"Executing transform step: {stepn + 1} of {len(self.config['steps'])}",
             )
             df = Step.execute(df, entities, column_types, step_config, self._env, progress, fnreport)
         return df

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -141,6 +141,14 @@ class TestRunCommandOptions:
         assert result.exit_code == 0
         assert "--emit_telemetry" in result.output
 
+    def test_run_help_explains_wandb_report_opt_out(self, cli_runner: CliRunner):
+        """The W&B report opt-out describes the output that remains enabled."""
+        result = cli_runner.invoke(run, ["--help"])
+
+        assert result.exit_code == 0
+        assert "--no-wandb-upload-evaluation-report" in result.output
+        assert "summary metrics and the evaluation scorecard" in " ".join(result.output.split())
+
     @pytest.mark.parametrize(
         ("upload_args", "expected_upload"),
         [
@@ -159,7 +167,7 @@ class TestRunCommandOptions:
         patched_run_dependencies: dict,
         monkeypatch: pytest.MonkeyPatch,
     ):
-        """Evaluation report publication defaults on and supports explicit opt-out."""
+        """Evaluation report publishing defaults on and supports explicit opt-out."""
         monkeypatch.delenv("NSS_WANDB_UPLOAD_EVALUATION_REPORT", raising=False)
 
         with patch("nemo_safe_synthesizer.cli.run.publish_evaluation_report") as mock_publish:

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -141,6 +141,47 @@ class TestRunCommandOptions:
         assert result.exit_code == 0
         assert "--emit_telemetry" in result.output
 
+    @pytest.mark.parametrize(
+        ("upload_args", "expected_upload"),
+        [
+            ([], True),
+            (["--no-wandb-upload-evaluation-report"], False),
+        ],
+    )
+    def test_run_evaluation_report_upload_default_and_opt_out(
+        self,
+        upload_args: list[str],
+        expected_upload: bool,
+        cli_runner: CliRunner,
+        dummy_csv: Path,
+        fixture_session_cache_dir: Path,
+        mock_workdir: MagicMock,
+        patched_run_dependencies: dict,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Evaluation report publication defaults on and supports explicit opt-out."""
+        monkeypatch.delenv("NSS_WANDB_UPLOAD_EVALUATION_REPORT", raising=False)
+
+        with patch("nemo_safe_synthesizer.cli.run.publish_evaluation_report") as mock_publish:
+            result = cli_runner.invoke(
+                run,
+                [
+                    "--data-source",
+                    str(dummy_csv),
+                    "--artifact-path",
+                    str(fixture_session_cache_dir),
+                    *upload_args,
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 0
+        mock_publish.assert_called_once_with(
+            mock_workdir,
+            patched_run_dependencies["safe_synthesizer"].results.summary,
+            expected_upload,
+        )
+
     def test_run_defaults_to_emit_telemetry(
         self,
         cli_runner: CliRunner,

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -148,6 +148,7 @@ class TestRunCommandOptions:
         assert result.exit_code == 0
         assert "--no-wandb-upload-evaluation-report" in result.output
         assert "summary metrics and the evaluation scorecard" in " ".join(result.output.split())
+        assert "[default: --wandb-upload-evaluation-report]" in " ".join(result.output.split())
 
     @pytest.mark.parametrize(
         ("upload_args", "expected_upload"),

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -26,6 +26,7 @@ class TestCLISettings:
         assert settings.run_path is None
         assert settings.output_file is None
         assert settings.verbose == 0
+        assert settings.wandb_upload_evaluation_report is True
         assert settings.synthesis_overrides == {}
 
     def test_env_var_loading_artifact_path(self, monkeypatch):
@@ -298,9 +299,9 @@ class TestCLISettingsIntegration:
         assert settings.wandb.wandb_project == "test-project"
 
     def test_wandb_upload_evaluation_report_env_var(self, monkeypatch):
-        """NSS_WANDB_UPLOAD_EVALUATION_REPORT enables CLI-only report publishing."""
-        monkeypatch.setenv("NSS_WANDB_UPLOAD_EVALUATION_REPORT", "true")
-        assert CLISettings().wandb_upload_evaluation_report is True
+        """NSS_WANDB_UPLOAD_EVALUATION_REPORT can disable default report publishing."""
+        monkeypatch.setenv("NSS_WANDB_UPLOAD_EVALUATION_REPORT", "false")
+        assert CLISettings().wandb_upload_evaluation_report is False
 
     def test_extra_env_vars_ignored(self, monkeypatch):
         """Test that unknown env vars are ignored (extra='ignore')."""

--- a/tests/cli/test_settings.py
+++ b/tests/cli/test_settings.py
@@ -297,6 +297,11 @@ class TestCLISettingsIntegration:
         assert settings.wandb.wandb_mode == WandbMode.OFFLINE
         assert settings.wandb.wandb_project == "test-project"
 
+    def test_wandb_upload_evaluation_report_env_var(self, monkeypatch):
+        """NSS_WANDB_UPLOAD_EVALUATION_REPORT enables CLI-only report publishing."""
+        monkeypatch.setenv("NSS_WANDB_UPLOAD_EVALUATION_REPORT", "true")
+        assert CLISettings().wandb_upload_evaluation_report is True
+
     def test_extra_env_vars_ignored(self, monkeypatch):
         """Test that unknown env vars are ignored (extra='ignore')."""
         monkeypatch.setenv("NSS_UNKNOWN_SETTING", "value")

--- a/tests/cli/test_wandb_publication.py
+++ b/tests/cli/test_wandb_publication.py
@@ -1,0 +1,187 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused W&B evaluation publication contracts."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nemo_safe_synthesizer.cli import wandb_setup
+from nemo_safe_synthesizer.config.external_results import SafeSynthesizerSummary, SafeSynthesizerTiming
+
+
+class FakeSummary:
+    """Dictionary-like W&B summary recording update calls."""
+
+    def __init__(self) -> None:
+        self.values: dict[str, object] = {}
+        self.update_calls: list[dict[str, object]] = []
+
+    def get(self, key: str) -> object | None:
+        return self.values.get(key)
+
+    def update(self, values: dict[str, object]) -> None:
+        self.update_calls.append(values)
+        self.values.update(values)
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.values
+
+    def __getitem__(self, key: str) -> object:
+        return self.values[key]
+
+
+class FakeArtifact:
+    """Hermetic replacement for W&B artifact staging."""
+
+    def __init__(self, name: str, type: str) -> None:  # noqa: A002 - W&B API spelling
+        self.name = name
+        self.type = type
+        self.files: list[tuple[str, str]] = []
+
+    def add_file(self, path: str, name: str) -> None:
+        self.files.append((path, name))
+
+
+def _summary() -> SafeSynthesizerSummary:
+    return SafeSynthesizerSummary(
+        timing=SafeSynthesizerTiming(),
+        synthetic_data_quality_score=7.5,
+        data_privacy_score=8.5,
+    )
+
+
+def _workdir(tmp_path: Path, *, report: bool = True, metrics: bool = True) -> MagicMock:
+    workdir = MagicMock()
+    workdir.evaluation_report = tmp_path / "evaluation_report.html"
+    workdir.evaluation_metrics = tmp_path / "evaluation_metrics.json"
+    if report:
+        workdir.evaluation_report.write_text("<h1>report</h1>", encoding="utf-8")
+    if metrics:
+        workdir.evaluation_metrics.write_text('{"ok": true}', encoding="utf-8")
+    return workdir
+
+
+def _run(run_id: str = "run-123") -> MagicMock:
+    run = MagicMock(id=run_id)
+    run.summary = FakeSummary()
+    return run
+
+
+def test_publish_opt_in_has_hermetic_scorecard_media_artifact_and_sha(tmp_path: Path) -> None:
+    """Opt-in writes only evaluation media history and records the exact artifact."""
+    workdir, run = _workdir(tmp_path), _run()
+    fake_artifacts: list[FakeArtifact] = []
+    html = MagicMock()
+    table = MagicMock()
+
+    def make_artifact(name: str, type: str) -> FakeArtifact:  # noqa: A002 - W&B API spelling
+        artifact = FakeArtifact(name, type)
+        fake_artifacts.append(artifact)
+        return artifact
+
+    with (
+        patch.object(wandb_setup.wandb, "run", run),
+        patch.object(wandb_setup.wandb, "Table", return_value=table) as mock_table,
+        patch.object(wandb_setup.wandb, "Html", return_value=html) as mock_html,
+        patch.object(wandb_setup.wandb, "Artifact", side_effect=make_artifact),
+    ):
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+
+    assert [set(call.args[0]) for call in run.log.call_args_list] == [{"evaluation/scorecard"}, {"evaluation/report"}]
+    assert mock_table.call_args.kwargs == {
+        "columns": ["metric", "value"],
+        "data": [[key, value] for key, value in _summary()._wandb_metrics().items() if key.startswith("eval/")],
+    }
+    mock_html.assert_called_once_with("<h1>report</h1>", inject=False)
+    assert [(artifact.name, artifact.type, artifact.files) for artifact in fake_artifacts] == [
+        (
+            "safe-synthesizer-evaluation-report-run-123",
+            "evaluation-report",
+            [
+                (str(workdir.evaluation_report), "evaluation_report.html"),
+                (str(workdir.evaluation_metrics), "evaluation_metrics.json"),
+            ],
+        )
+    ]
+    assert run.summary["evaluation/report_sha256"] == hashlib.sha256(workdir.evaluation_report.read_bytes()).hexdigest()
+
+
+def test_identical_resume_in_a_fresh_process_is_suppressed(tmp_path: Path) -> None:
+    """The persisted W&B marker, not process memory, suppresses an identical repeat."""
+    workdir, run = _workdir(tmp_path), _run()
+    with patch.object(wandb_setup.wandb, "run", run):
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=False)
+        run.log.reset_mock()  # Simulate a fresh process retaining only W&B summary state.
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=False)
+    run.log.assert_not_called()
+
+
+def test_changed_evaluation_output_publishes_a_new_report(tmp_path: Path) -> None:
+    """A changed score keeps resumed CLI work observable."""
+    workdir, run = _workdir(tmp_path), _run()
+    changed = _summary().model_copy(update={"synthetic_data_quality_score": 7.6})
+    with patch.object(wandb_setup.wandb, "run", run):
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=False)
+        wandb_setup.publish_evaluation_report(workdir, changed, upload_report=False)
+    assert run.log.call_count == 2
+
+
+def test_opt_out_then_opt_in_publishes_report_after_scorecard(tmp_path: Path) -> None:
+    """Opting in later changes the fingerprint and permits report publication."""
+    workdir, run = _workdir(tmp_path), _run()
+    with (
+        patch.object(wandb_setup.wandb, "run", run),
+        patch.object(wandb_setup.wandb, "Artifact", side_effect=FakeArtifact),
+    ):
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=False)
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+    assert [set(call.args[0]) for call in run.log.call_args_list] == [
+        {"evaluation/scorecard"},
+        {"evaluation/scorecard"},
+        {"evaluation/report"},
+    ]
+
+
+def test_failure_then_retry_is_not_suppressed(tmp_path: Path) -> None:
+    """A transient W&B failure leaves no completion marker and therefore retries."""
+    workdir, run = _workdir(tmp_path), _run()
+    run.log.side_effect = [RuntimeError("down"), None]
+    with patch.object(wandb_setup.wandb, "run", run):
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=False)
+        assert wandb_setup._EVALUATION_PUBLICATION_FINGERPRINT_KEY not in run.summary
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=False)
+    assert run.log.call_count == 2
+
+
+def test_missing_report_and_metrics_warn_without_raising(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:
+    """Absent opted-in local files are non-fatal and explain both omissions."""
+    workdir, run = _workdir(tmp_path, report=False, metrics=False), _run()
+    with patch.object(wandb_setup.wandb, "run", run):
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+    assert "report upload requested but file is missing" in caplog.text
+    assert "metrics upload requested but file is missing" in caplog.text
+
+
+@pytest.mark.parametrize("failure", ["media", "artifact", "summary"])
+def test_publication_operation_failures_never_escape(tmp_path: Path, failure: str) -> None:
+    """Media, artifact, and final-summary W&B failures preserve synthesis success."""
+    workdir, run = _workdir(tmp_path), _run()
+    if failure == "summary":
+        run.summary.update = MagicMock(side_effect=RuntimeError("summary down"))
+
+    with patch.object(wandb_setup.wandb, "run", run):
+        if failure == "media":
+            with patch.object(wandb_setup.wandb, "Html", side_effect=RuntimeError("media down")):
+                wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+        elif failure == "artifact":
+            with patch.object(wandb_setup.wandb, "Artifact", side_effect=RuntimeError("artifact down")):
+                wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+        else:
+            with patch.object(wandb_setup.wandb, "Artifact", side_effect=FakeArtifact):
+                wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)

--- a/tests/cli/test_wandb_publication.py
+++ b/tests/cli/test_wandb_publication.py
@@ -143,7 +143,6 @@ def test_opt_out_then_opt_in_publishes_report_after_scorecard(tmp_path: Path) ->
         wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
     assert [set(call.args[0]) for call in run.log.call_args_list] == [
         {"evaluation/scorecard"},
-        {"evaluation/scorecard"},
         {"evaluation/report"},
     ]
 
@@ -157,6 +156,34 @@ def test_failure_then_retry_is_not_suppressed(tmp_path: Path) -> None:
         assert wandb_setup._EVALUATION_PUBLICATION_FINGERPRINT_KEY not in run.summary
         wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=False)
     assert run.log.call_count == 2
+
+
+def test_artifact_failure_then_retry_does_not_republish_successful_media(tmp_path: Path) -> None:
+    """Retry only the failed artifact operation after scorecard and report succeed."""
+    workdir, run = _workdir(tmp_path), _run()
+    artifact_attempts = 0
+
+    def make_artifact(name: str, type: str) -> FakeArtifact:  # noqa: A002 - W&B API spelling
+        nonlocal artifact_attempts
+        artifact_attempts += 1
+        if artifact_attempts == 1:
+            raise RuntimeError("down")
+        return FakeArtifact(name, type)
+
+    with (
+        patch.object(wandb_setup.wandb, "run", run),
+        patch.object(wandb_setup.wandb, "Artifact", side_effect=make_artifact),
+    ):
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+
+    assert [set(call.args[0]) for call in run.log.call_args_list] == [
+        {"evaluation/scorecard"},
+        {"evaluation/report"},
+    ]
+    run.log_artifact.assert_called_once()
+    assert run.summary["evaluation/report_uploaded_post_run"] is True
+    assert run.summary["evaluation/report_sha256"] == hashlib.sha256(workdir.evaluation_report.read_bytes()).hexdigest()
 
 
 def test_missing_report_and_metrics_warn_without_raising(tmp_path: Path, caplog: pytest.LogCaptureFixture) -> None:

--- a/tests/cli/test_wandb_publishing.py
+++ b/tests/cli/test_wandb_publishing.py
@@ -109,6 +109,7 @@ def test_publish_opt_in_has_hermetic_scorecard_media_artifact_and_sha(tmp_path: 
             ],
         )
     ]
+    run.log_artifact.assert_called_once_with(fake_artifacts[0])
     assert run.summary["evaluation/report_sha256"] == hashlib.sha256(workdir.evaluation_report.read_bytes()).hexdigest()
 
 
@@ -120,6 +121,24 @@ def test_identical_resume_in_a_fresh_process_is_suppressed(tmp_path: Path) -> No
         run.log.reset_mock()  # Simulate a fresh process retaining only W&B summary state.
         wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=False)
     run.log.assert_not_called()
+
+
+def test_identical_opt_in_resume_does_not_duplicate_media_or_artifact(tmp_path: Path) -> None:
+    """A completed opt-in publication is suppressed by its persisted marker."""
+    workdir, run = _workdir(tmp_path), _run()
+    with (
+        patch.object(wandb_setup.wandb, "run", run),
+        patch.object(wandb_setup.wandb, "Table", return_value=MagicMock()),
+        patch.object(wandb_setup.wandb, "Html", return_value=MagicMock()),
+        patch.object(wandb_setup.wandb, "Artifact", side_effect=FakeArtifact),
+    ):
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+        run.log.reset_mock()
+        run.log_artifact.reset_mock()
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+
+    run.log.assert_not_called()
+    run.log_artifact.assert_not_called()
 
 
 def test_changed_evaluation_output_publishes_a_new_report(tmp_path: Path) -> None:
@@ -193,6 +212,37 @@ def test_missing_report_and_metrics_warn_without_raising(tmp_path: Path, caplog:
         wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
     assert "report upload requested but file is missing" in caplog.text
     assert "metrics upload requested but file is missing" in caplog.text
+
+
+def test_missing_local_report_on_resume_preserves_uploaded_summary(tmp_path: Path) -> None:
+    """A missing local file does not erase the durable state of an earlier upload."""
+    workdir, run = _workdir(tmp_path), _run()
+    with (
+        patch.object(wandb_setup.wandb, "run", run),
+        patch.object(wandb_setup.wandb, "Artifact", side_effect=FakeArtifact),
+    ):
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+        uploaded_sha = run.summary["evaluation/report_sha256"]
+        workdir.evaluation_report.unlink()
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+
+    assert run.summary["evaluation/report_uploaded_post_run"] is True
+    assert run.summary["evaluation/report_sha256"] == uploaded_sha
+
+
+def test_opt_out_after_upload_preserves_uploaded_summary(tmp_path: Path) -> None:
+    """Opting out later does not erase the durable state of an earlier upload."""
+    workdir, run = _workdir(tmp_path), _run()
+    with (
+        patch.object(wandb_setup.wandb, "run", run),
+        patch.object(wandb_setup.wandb, "Artifact", side_effect=FakeArtifact),
+    ):
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+        uploaded_sha = run.summary["evaluation/report_sha256"]
+        wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=False)
+
+    assert run.summary["evaluation/report_uploaded_post_run"] is True
+    assert run.summary["evaluation/report_sha256"] == uploaded_sha
 
 
 @pytest.mark.parametrize("failure", ["media", "artifact", "summary"])

--- a/tests/cli/test_wandb_publishing.py
+++ b/tests/cli/test_wandb_publishing.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Focused W&B evaluation publication contracts."""
+"""Focused W&B evaluation publishing contracts."""
 
 from __future__ import annotations
 
@@ -133,7 +133,7 @@ def test_changed_evaluation_output_publishes_a_new_report(tmp_path: Path) -> Non
 
 
 def test_opt_out_then_opt_in_publishes_report_after_scorecard(tmp_path: Path) -> None:
-    """Opting in later changes the fingerprint and permits report publication."""
+    """Opting in later changes the fingerprint and permits report publishing."""
     workdir, run = _workdir(tmp_path), _run()
     with (
         patch.object(wandb_setup.wandb, "run", run),
@@ -153,7 +153,7 @@ def test_failure_then_retry_is_not_suppressed(tmp_path: Path) -> None:
     run.log.side_effect = [RuntimeError("down"), None]
     with patch.object(wandb_setup.wandb, "run", run):
         wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=False)
-        assert wandb_setup._EVALUATION_PUBLICATION_FINGERPRINT_KEY not in run.summary
+        assert wandb_setup._EVALUATION_PUBLISHING_FINGERPRINT_KEY not in run.summary
         wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=False)
     assert run.log.call_count == 2
 
@@ -196,7 +196,7 @@ def test_missing_report_and_metrics_warn_without_raising(tmp_path: Path, caplog:
 
 
 @pytest.mark.parametrize("failure", ["media", "artifact", "summary"])
-def test_publication_operation_failures_never_escape(tmp_path: Path, failure: str) -> None:
+def test_publishing_operation_failures_never_escape(tmp_path: Path, failure: str) -> None:
     """Media, artifact, and final-summary W&B failures preserve synthesis success."""
     workdir, run = _workdir(tmp_path), _run()
     if failure == "summary":

--- a/tests/cli/test_wandb_publishing.py
+++ b/tests/cli/test_wandb_publishing.py
@@ -204,11 +204,19 @@ def test_publishing_operation_failures_never_escape(tmp_path: Path, failure: str
 
     with patch.object(wandb_setup.wandb, "run", run):
         if failure == "media":
-            with patch.object(wandb_setup.wandb, "Html", side_effect=RuntimeError("media down")):
+            with patch.object(wandb_setup.wandb, "Html", side_effect=RuntimeError("media down")) as mock_html:
                 wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+            mock_html.assert_called_once_with("<h1>report</h1>", inject=False)
         elif failure == "artifact":
-            with patch.object(wandb_setup.wandb, "Artifact", side_effect=RuntimeError("artifact down")):
+            with patch.object(
+                wandb_setup.wandb, "Artifact", side_effect=RuntimeError("artifact down")
+            ) as mock_artifact:
                 wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+            mock_artifact.assert_called_once_with(
+                "safe-synthesizer-evaluation-report-run-123",
+                type="evaluation-report",
+            )
         else:
             with patch.object(wandb_setup.wandb, "Artifact", side_effect=FakeArtifact):
                 wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
+            run.summary.update.assert_called()

--- a/tests/cli/test_wandb_publishing.py
+++ b/tests/cli/test_wandb_publishing.py
@@ -239,8 +239,10 @@ def test_opt_out_after_upload_preserves_uploaded_summary(tmp_path: Path) -> None
     ):
         wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=True)
         uploaded_sha = run.summary["evaluation/report_sha256"]
+        run.log_artifact.reset_mock()
         wandb_setup.publish_evaluation_report(workdir, _summary(), upload_report=False)
 
+    run.log_artifact.assert_not_called()
     assert run.summary["evaluation/report_uploaded_post_run"] is True
     assert run.summary["evaluation/report_sha256"] == uploaded_sha
 

--- a/tests/cli/test_wandb_setup.py
+++ b/tests/cli/test_wandb_setup.py
@@ -4,7 +4,9 @@
 """Tests for the wandb_setup module."""
 
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
+from nemo_safe_synthesizer.cli import wandb_setup
 from nemo_safe_synthesizer.cli.wandb_setup import resolve_wandb_run_id
 
 
@@ -51,3 +53,17 @@ class TestResolveWandbRunId:
         result = resolve_wandb_run_id(str(dir_path))
         # Since it's a directory, not a file, it's returned as-is
         assert result == str(dir_path)
+
+
+def test_failure_reporting_updates_summary_without_history() -> None:
+    """Failure status is final run state, not an additional W&B history point."""
+    fake_run = MagicMock()
+    with patch.object(wandb_setup.wandb, "run", fake_run), patch.object(wandb_setup.wandb, "log") as mock_log:
+        wandb_setup.log_failure_to_wandb(ValueError("bad input"), "generate")
+
+    mock_log.assert_not_called()
+    assert fake_run.summary.update.call_args.args[0] == {
+        "eval/success": 0,
+        "generate/error_type": "ValueError",
+        "generate/error_message": "bad input",
+    }

--- a/tests/evaluation/components/test_membership_inference_protection.py
+++ b/tests/evaluation/components/test_membership_inference_protection.py
@@ -47,6 +47,8 @@ def test_mia_tabular_unit_returns_threshold_counts():
     assert attack_sum_df["Attack Count"].sum() == 360
     assert attack_sum_df["Attack Percentage"].sum() == pytest.approx(100.0)
     assert not all(float(value).is_integer() for value in attack_sum_df["Attack Percentage"])
+    expected_percentages = attack_sum_df["Attack Count"] / attack_sum_df["Attack Count"].sum() * 100
+    assert attack_sum_df["Attack Percentage"].tolist() == pytest.approx(expected_percentages.tolist())
     assert set(tps_values) == {0.1, 0.2, 0.3, 0.4}
     assert set(fps_values) == {0.1, 0.2, 0.3, 0.4}
 

--- a/tests/evaluation/components/test_membership_inference_protection.py
+++ b/tests/evaluation/components/test_membership_inference_protection.py
@@ -43,6 +43,10 @@ def test_mia_tabular_unit_returns_threshold_counts():
 
     assert score.score is not None
     assert attack_sum_df is not None
+    assert "Attack Count" in attack_sum_df
+    assert attack_sum_df["Attack Count"].sum() == 360
+    assert attack_sum_df["Attack Percentage"].sum() == pytest.approx(100.0)
+    assert not all(float(value).is_integer() for value in attack_sum_df["Attack Percentage"])
     assert set(tps_values) == {0.1, 0.2, 0.3, 0.4}
     assert set(fps_values) == {0.1, 0.2, 0.3, 0.4}
 

--- a/tests/evaluation/components/test_multi_modal_figures.py
+++ b/tests/evaluation/components/test_multi_modal_figures.py
@@ -270,6 +270,20 @@ class TestGenerateMiaFigure:
 
         assert isinstance(fig, go.Figure)
 
+    def test_generate_mia_figure_uses_counts_without_renormalizing_percentages(self):
+        df = pd.DataFrame(
+            {
+                "Protection": ["Excellent", "Good", "Poor"],
+                "Attack Count": [120, 120, 120],
+                "Attack Percentage": [100 / 3, 100 / 3, 100 / 3],
+            }
+        )
+
+        fig = generate_mia_figure(df)
+
+        assert list(fig.data[0].values) == [120, 120, 120]
+        assert "360 attack evaluations" in fig.layout.title.text
+
 
 class TestGenerateAiaFigure:
     """Tests for generate_aia_figure function."""

--- a/tests/evaluation/components/test_multi_modal_figures.py
+++ b/tests/evaluation/components/test_multi_modal_figures.py
@@ -284,6 +284,21 @@ class TestGenerateMiaFigure:
         assert list(fig.data[0].values) == [120, 120, 120]
         assert "360 attack evaluations" in fig.layout.title.text
 
+    def test_generate_mia_figure_excludes_unavailable_label_and_value(self):
+        df = pd.DataFrame(
+            {
+                "Protection": ["Excellent", "Good", "Unavailable"],
+                "Attack Count": [120, 120, 120],
+                "Attack Percentage": [100 / 3, 100 / 3, 100 / 3],
+            }
+        )
+
+        fig = generate_mia_figure(df)
+
+        assert list(fig.data[0].labels) == ["Excellent", "Good"]
+        assert list(fig.data[0].values) == [120, 120]
+        assert "240 attack evaluations" in fig.layout.title.text
+
 
 class TestGenerateAiaFigure:
     """Tests for generate_aia_figure function."""

--- a/tests/generation/test_vllm_observability.py
+++ b/tests/generation/test_vllm_observability.py
@@ -407,26 +407,24 @@ class TestLogObservabilityEvent:
             wandb_setup.log_observability_event(populated_event, prefix="vllm_gen")
             mock_log.assert_not_called()
 
-    def test_calls_wandb_log_when_run_is_active(self, populated_event: GenerationObservability) -> None:
-        """When a run is active, the flattened payload is passed to ``wandb.log``."""
+    def test_updates_wandb_summary_when_run_is_active(self, populated_event: GenerationObservability) -> None:
+        """Final vLLM observability updates the run summary, not W&B history."""
         from nemo_safe_synthesizer.cli import wandb_setup
 
         fake_run = MagicMock()
         with patch.object(wandb_setup.wandb, "run", fake_run), patch.object(wandb_setup.wandb, "log") as mock_log:
             wandb_setup.log_observability_event(populated_event, prefix="vllm_gen")
-            mock_log.assert_called_once()
-            (call_args,) = mock_log.call_args.args
-            # The payload contains exactly the keys from to_wandb_payload (namespaced + flattened).
-            assert call_args == populated_event.to_wandb_payload(prefix="vllm_gen")
+            mock_log.assert_not_called()
+            fake_run.summary.update.assert_called_once_with(populated_event.to_wandb_payload(prefix="vllm_gen"))
 
-    def test_wandb_log_exception_swallowed(self, populated_event: GenerationObservability) -> None:
+    def test_wandb_summary_exception_swallowed(self, populated_event: GenerationObservability) -> None:
         """A wandb failure must not break generation — best-effort emission."""
         from nemo_safe_synthesizer.cli import wandb_setup
 
         fake_run = MagicMock()
+        fake_run.summary.update.side_effect = RuntimeError("wandb down")
         with (
             patch.object(wandb_setup.wandb, "run", fake_run),
-            patch.object(wandb_setup.wandb, "log", side_effect=RuntimeError("wandb down")),
         ):
             # Should not raise.
             wandb_setup.log_observability_event(populated_event, prefix="vllm_gen")

--- a/tests/observability/test_observability.py
+++ b/tests/observability/test_observability.py
@@ -20,6 +20,7 @@ from nemo_safe_synthesizer.observability import (
     LogCategory,
     NSSObservabilitySettings,
     TracedContext,
+    _canonicalize_log_event,
     _category_log_processor,
     _convert_rich_table_to_string,
     _current_log_category,
@@ -254,6 +255,13 @@ class TestCategoryLogProcessor:
         assert result["category"] == LogCategory.USER.value
         assert _current_log_category.get() is None  # Reset after use
 
+    def test_canonicalizes_native_and_foreign_structured_context(self, mock_logger):
+        native = _canonicalize_log_event(mock_logger, "info", {"extra": {"ctx": {"rows": 1}}})
+        foreign = _canonicalize_log_event(mock_logger, "info", {"ctx": {"rows": 1}})
+
+        assert native == {"context": {"rows": 1}}
+        assert foreign == {"context": {"rows": 1}}
+
 
 class TestMoveCategoryForColumn:
     """Tests for _move_category_for_column processor."""
@@ -294,6 +302,11 @@ class TestRenderRichTable:
         assert "0.35" in result
         assert "0.72" in result
         assert "95.00%" in result
+
+    def test_fraction_fields_render_as_percentages_when_generation_overshoots(self):
+        result = _render_rich_table({"progress_fraction": 1.25})
+
+        assert "125.00%" in result
 
     def test_renders_mapping_values_without_python_repr(self):
         """Mapping values in flat tables are rendered as compact key-value lists."""
@@ -494,8 +507,9 @@ class TestInitializeObservability:
 
     def test_initialize_logging_configures_json_format(self, monkeypatch, capsys, tmp_path):
         """Test that initialize_logging() configures JSON format when NSS_LOG_FORMAT=json."""
-        # Use monkeypatch.setattr for automatic cleanup of module state
-        monkeypatch.setattr(obs, "_INITIALIZED_OBSERVABILITY", False)
+        # Keep the initialization flag aligned with structlog.reset_defaults()
+        # during cleanup; monkeypatch would restore a stale True value.
+        obs._INITIALIZED_OBSERVABILITY = False
         monkeypatch.setenv("NSS_LOG_FORMAT", "json")
         monkeypatch.setenv("NSS_LOG_LEVEL", "INFO")
         monkeypatch.setenv("NSS_LOG_FILE", str(tmp_path / "test.log"))
@@ -517,6 +531,69 @@ class TestInitializeObservability:
                 if line.strip():
                     parsed = json.loads(line)
                     assert "message" in parsed or "event" in parsed
+
+    def test_plain_console_table_does_not_leak_into_json_file(self, monkeypatch, capsys, tmp_path):
+        """Console-only table rendering preserves the canonical JSONL event."""
+        root_logger = logging.getLogger()
+        original_handlers = root_logger.handlers.copy()
+        original_level = root_logger.level
+        log_file = tmp_path / "events.jsonl"
+
+        obs._INITIALIZED_OBSERVABILITY = False
+        monkeypatch.setenv("NSS_LOG_FORMAT", "plain")
+        monkeypatch.setenv("NSS_LOG_LEVEL", "INFO")
+        monkeypatch.setenv("NSS_LOG_COLOR", "false")
+        monkeypatch.setenv("NSS_LOG_FILE", str(log_file))
+        monkeypatch.setattr(obs, "SETTINGS", NSSObservabilitySettings())
+        structlog.reset_defaults()
+        root_logger.handlers.clear()
+
+        try:
+            _initialize_logging()
+            obs._INITIALIZED_OBSERVABILITY = True
+            logger = get_logger("test_mixed_handlers")
+            logger.user.info(
+                "Mixed handler table",
+                extra={"ctx": {"render_table": True, "tabular_data": {"records": 2}, "title": "Dogfood table"}},
+            )
+            logging.getLogger("test_foreign_handlers").info(
+                "Foreign %s interpolation",
+                "logger",
+                extra={"ctx": {"source": "foreign"}},
+            )
+
+            console_output = capsys.readouterr().out
+            native_record, foreign_record = [
+                json.loads(line) for line in log_file.read_text(encoding="utf-8").splitlines()
+            ]
+        finally:
+            structlog.reset_defaults()
+            root_logger.handlers = original_handlers
+            root_logger.setLevel(original_level)
+            obs._INITIALIZED_OBSERVABILITY = False
+
+        assert console_output.count("Dogfood table") == 1
+        assert "Mixed handler table" in console_output
+        assert native_record["message"] == "Mixed handler table"
+        assert native_record["category"] == LogCategory.USER.value
+        assert native_record["context"] == {
+            "render_table": True,
+            "tabular_data": {"records": 2},
+            "title": "Dogfood table",
+        }
+        assert native_record["timestamp"] in console_output
+        assert native_record["logger"] == "test_mixed_handlers"
+        assert native_record["filename"] == Path(__file__).name
+        assert native_record["lineno"] is not None
+        assert native_record["qual_name"] is not None
+        assert "_category_display" not in native_record
+        assert "positional_args" not in native_record
+        assert "+" not in native_record["message"]
+        assert foreign_record["message"] == "Foreign logger interpolation"
+        assert foreign_record["category"] == LogCategory.RUNTIME.value
+        assert foreign_record["context"] == {"source": "foreign"}
+        assert foreign_record["logger"] == "test_foreign_handlers"
+        assert "positional_args" not in foreign_record
 
 
 class TestGetLogger:
@@ -719,6 +796,15 @@ class TestObservabilityIntegration:
 
         # Verify logs were captured
         assert "User message" in caplog.text
+
+    def test_native_logger_interpolates_printf_arguments(self, caplog):
+        caplog.set_level(logging.INFO)
+
+        logger = get_logger("test_native_printf")
+        logger.info("graded %s attack evaluations", 360)
+
+        assert "graded 360 attack evaluations" in caplog.text
+        assert "positional_args" not in caplog.text
 
     def test_traced_decorator_logs_entry_exit(self, caplog):
         """Test that traced decorator logs entry and exit."""

--- a/tests/pii_replacer/test_edit.py
+++ b/tests/pii_replacer/test_edit.py
@@ -10,6 +10,7 @@ pytest.importorskip("torch", reason="torch is required for these tests (install 
 
 import re
 from unittest import TestCase
+from unittest.mock import patch
 
 import pandas as pd
 
@@ -311,3 +312,20 @@ class TestProgressLog(TestCase):
             progress.log_throttled(force=True)
             progress.log_throttled(force=True)
         self.assertEqual(len(logs.output), 5)
+
+    def test_reset_timing_excludes_preprocessing_from_row_speed(self):
+        with patch(
+            "nemo_safe_synthesizer.pii_replacer.data_editor.edit.monotonic",
+            side_effect=[10.0, 10.0, 310.0, 312.0, 313.0],
+        ):
+            progress = ProgressLog(30)
+            progress.status.row_n = 20
+            progress.reset_timing()
+            with self.assertLogs() as logs:
+                progress.log_throttled(force=True)
+
+        ctx = getattr(logs.records[0], "ctx")
+        assert progress.start_time == 310.0
+        assert progress.last_log == 313.0
+        assert ctx["tabular_data"]["transform_time"] == "2.0 seconds"
+        assert ctx["tabular_data"]["speed"] == "🐇 10.0 rows per second."

--- a/tests/test_results.py
+++ b/tests/test_results.py
@@ -102,8 +102,9 @@ class TestSafeSynthesizerSummaryLogWandb:
         with patch.dict(sys.modules, {"wandb": mock_wandb}):
             summary.log_wandb()
 
-        assert mock_wandb.log.call_count == 1
-        logged = mock_wandb.log.call_args[0][0]
+        mock_wandb.log.assert_not_called()
+        mock_wandb.run.summary.update.assert_called_once()
+        logged = mock_wandb.run.summary.update.call_args.args[0]
 
         assert logged["gen/num_completion_tokens"] == 1000
         assert logged["gen/num_valid_record_tokens"] == 700
@@ -126,8 +127,8 @@ class TestSafeSynthesizerSummaryLogWandb:
         with patch.dict(sys.modules, {"wandb": mock_wandb}):
             summary.log_wandb()
 
-        assert mock_wandb.log.call_count == 1
-        logged = mock_wandb.log.call_args[0][0]
+        mock_wandb.log.assert_not_called()
+        logged = mock_wandb.run.summary.update.call_args.args[0]
         assert logged["gen/num_completion_tokens"] is None
         assert logged["gen/tokens_per_second"] is None
 

--- a/tests/test_wandb_summary.py
+++ b/tests/test_wandb_summary.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""W&B final-scalar summary contracts."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from nemo_safe_synthesizer.config.external_results import SafeSynthesizerSummary, SafeSynthesizerTiming
+
+
+def test_summary_log_wandb_updates_run_summary_without_history() -> None:
+    """Final scalar metrics update W&B summary and preserve ``None`` values."""
+    summary = SafeSynthesizerSummary(
+        timing=SafeSynthesizerTiming(generation_time_sec=None),
+        num_completion_tokens=None,
+    )
+    mock_wandb = MagicMock()
+    mock_wandb.run = MagicMock()
+
+    with patch.dict(sys.modules, {"wandb": mock_wandb}):
+        summary.log_wandb()
+
+    mock_wandb.log.assert_not_called()
+    payload = mock_wandb.run.summary.update.call_args.args[0]
+    assert payload["gen/generation_time_sec"] is None
+    assert payload["gen/num_completion_tokens"] is None
+
+
+def test_timing_log_wandb_updates_summary_and_preserves_none() -> None:
+    """Timing-only W&B output also avoids history and does not coerce ``None``."""
+    timing = SafeSynthesizerTiming(evaluation_time_sec=None)
+    run = MagicMock()
+
+    timing.log_wandb(run)
+
+    run.log.assert_not_called()
+    assert run.summary.update.call_args.args[0]["evaluation_time_sec"] is None
+
+
+def test_summary_log_wandb_failure_is_best_effort() -> None:
+    """Final summary publication cannot turn a successful synthesis into a failure."""
+    summary = SafeSynthesizerSummary(timing=SafeSynthesizerTiming())
+    mock_wandb = MagicMock()
+    mock_wandb.run.summary.update.side_effect = RuntimeError("wandb down")
+
+    with patch.dict(sys.modules, {"wandb": mock_wandb}):
+        summary.log_wandb()
+
+
+def test_timing_log_wandb_failure_is_best_effort() -> None:
+    """Timing summary publication has the same non-fatal contract."""
+    run = MagicMock()
+    run.summary.update.side_effect = RuntimeError("wandb down")
+    SafeSynthesizerTiming().log_wandb(run)

--- a/tests/test_wandb_summary.py
+++ b/tests/test_wandb_summary.py
@@ -29,6 +29,25 @@ def test_summary_log_wandb_updates_run_summary_without_history() -> None:
     assert payload["gen/num_completion_tokens"] is None
 
 
+def test_summary_wandb_timing_metrics_use_stage_appropriate_namespaces() -> None:
+    """Timing metrics use evaluation, generation, or run-level names consistently."""
+    summary = SafeSynthesizerSummary(
+        timing=SafeSynthesizerTiming(
+            total_time_sec=12.0,
+            generation_time_sec=4.0,
+            evaluation_time_sec=3.0,
+        )
+    )
+
+    payload = summary._wandb_metrics()
+
+    assert payload["total_time_sec"] == 12.0
+    assert payload["gen/generation_time_sec"] == 4.0
+    assert payload["eval/evaluation_time_sec"] == 3.0
+    assert "eval/total_time_sec" not in payload
+    assert "gen/evaluation_time_sec" not in payload
+
+
 def test_timing_log_wandb_updates_summary_and_preserves_none() -> None:
     """Timing-only W&B output also avoids history and does not coerce ``None``."""
     timing = SafeSynthesizerTiming(evaluation_time_sec=None)


### PR DESCRIPTION
## Summary

- keep structured JSONL events canonical, render Rich tables only on the plain console, and correct progress timing and user-facing log categories
- report exact membership-inference counts and percentages, with consistent chart labels, values, and graded totals
- store final metrics in W&B summaries and publish the evaluation scorecard and report by default for active CLI runs, with idempotent retries and an explicit opt-out for HTML and artifact publishing that retains summary metrics and the scorecard

## Test plan

- [x] `mise run check`
- [x] `mise run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--wandb-upload-evaluation-report/--no-wandb-upload-evaluation-report` and `NSS_WANDB_UPLOAD_EVALUATION_REPORT` to control publishing of the final evaluation HTML report and artifacts to Weights & Biases.
* **Bug Fixes**
  * Improved W&B publishing reliability via best-effort updates to run summaries, deduped/idempotent uploads, and updated failure reporting.
* **Documentation**
  * Expanded user guide coverage for the new control and evaluation scorecard/report upload behavior.
* **Tests / Quality**
  * Updated and added unit tests for settings, CLI publishing flows, W&B summary behavior, MIA visuals, and structured logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
