### PR TITLE
fix: add gcc and redo hf setup on container

### DIFF
--- a/containers/Dockerfile.cuda
+++ b/containers/Dockerfile.cuda
@@ -148,6 +148,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 
 ENV PATH="/opt/venv/bin:${PATH}" \
     HF_HOME=/workspace/.hf_cache \
+    TRITON_CACHE_DIR=/workspace/.triton_cache \
     NSS_CONTAINER_EXTRA=${CONTAINER_EXTRA} \
     NSS_CONTAINER_VARIANT=${CONTAINER_VARIANT} \
     NVIDIA_VISIBLE_DEVICES=all \

--- a/containers/Dockerfile.cuda
+++ b/containers/Dockerfile.cuda
@@ -14,11 +14,13 @@
 #     --target runtime -t nss-gpu:latest .
 #   docker build -f containers/Dockerfile.cuda --target dev -t nss-gpu-dev:latest .
 #
-# Run with your data:
+# Run with your data. HF_HOME already points at /workspace/.hf_cache, so
+# mounting a host cache there is enough; --user keeps the container uid aligned
+# with the owner of that cache so model downloads can be written.
 #   docker run --gpus all --shm-size=1g \
+#     --user $(id -u):$(id -g) \
 #     -v $(pwd)/my_data:/workspace/data \
-#     -v ~/.cache/huggingface:/workspace/.hf_cache \
-#     -e HF_HOME=/workspace/.hf_cache \
+#     -v $HOME/.cache/huggingface:/workspace/.hf_cache \
 #     nss-gpu:latest \
 #     run --data-source /workspace/data/input.csv
 #
@@ -53,8 +55,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update && apt-get install -y --no-install-recommends \
         bash \
         ca-certificates \
+        gcc \
+        libc6-dev \
         libgomp1 \
         tini
+
+# gcc and libc6-dev are runtime dependencies, not build dependencies: Triton
+# JIT-compiles its CUDA driver shim (driver.c) the first time vLLM touches a
+# GPU, so without a C compiler in the final image every generation run dies
+# with "Failed to find C compiler".
 
 # uv settings for reproducible container builds.
 ENV UV_PROJECT_ENVIRONMENT=/opt/venv \
@@ -138,6 +147,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         --no-group dev
 
 ENV PATH="/opt/venv/bin:${PATH}" \
+    HF_HOME=/workspace/.hf_cache \
     NSS_CONTAINER_EXTRA=${CONTAINER_EXTRA} \
     NSS_CONTAINER_VARIANT=${CONTAINER_VARIANT} \
     NVIDIA_VISIBLE_DEVICES=all \
@@ -152,10 +162,18 @@ LABEL org.opencontainers.image.title="Safe Synthesizer" \
       org.opencontainers.image.base.name="python:${PYTHON_VERSION}-slim-bookworm" \
       com.nvidia.nemo.safe-synthesizer.extra="${CONTAINER_EXTRA}" \
       com.nvidia.nemo.safe-synthesizer.variant="${CONTAINER_VARIANT}" \
-      org.opencontainers.image.usage="docker run --gpus all --shm-size=1g -v /path/to/data:/workspace/data -v ~/.cache/huggingface:/workspace/.hf_cache -e HF_HOME=/workspace/.hf_cache nss-gpu:latest run --config /workspace/data/config.yaml --data-source /workspace/data/input.csv"
+      org.opencontainers.image.usage="docker run --gpus all --shm-size=1g --user \$(id -u):\$(id -g) -v /path/to/data:/workspace/data -v \$HOME/.cache/huggingface:/workspace/.hf_cache ghcr.io/nvidia-nemo/safe-synthesizer:${CONTAINER_VARIANT} run --config /workspace/data/config.yaml --data-source /workspace/data/input.csv"
 
 RUN groupadd -r -g 1000 appuser && \
     useradd -r -u 1000 -g appuser -m appuser
+
+# /workspace is the default HF_HOME parent and the usual bind-mount point.
+# World-writable so the image also works under an arbitrary `--user`, which is
+# how callers match the container uid to the owner of a mounted model cache.
+# Bind mounts keep their host ownership and are unaffected by these modes.
+RUN mkdir -p /workspace/.hf_cache && \
+    chown appuser:appuser /workspace /workspace/.hf_cache && \
+    chmod 777 /workspace /workspace/.hf_cache
 
 COPY --chmod=755 containers/entrypoint.sh /usr/local/bin/entrypoint.sh
 

--- a/containers/entrypoint.sh
+++ b/containers/entrypoint.sh
@@ -10,6 +10,10 @@ set -euo pipefail
 
 warn() { echo "[nss-container] $*" >&2; }
 
+# Hints are copy-pasted by users, so they must name the image the caller
+# actually pulled rather than the local build tag.
+image_ref="ghcr.io/nvidia-nemo/safe-synthesizer:${NSS_CONTAINER_VARIANT:-cu129}"
+
 # Skip all diagnostic checks for info-only commands.
 needs_runtime=true
 for arg in "$@"; do
@@ -22,43 +26,52 @@ done
 if $needs_runtime; then
 
 # -- Check: is anything mounted at /workspace?
-if [ -z "$(ls -A /workspace 2>/dev/null)" ]; then
+# .hf_cache is created by the image, so it does not count as user content.
+if [ -z "$(find /workspace -mindepth 1 -maxdepth 1 ! -name '.hf_cache' -print -quit 2>/dev/null)" ]; then
     warn "WARNING: /workspace is empty -- no data or config files are available."
     echo >&2
     warn "  Mount your data directory (use absolute paths):"
     warn "    docker run --gpus all -v /path/to/data:/workspace/data \\"
-    warn "      -v ~/.cache/huggingface:/workspace/.hf_cache \\"
-    warn "      -e HF_HOME=/workspace/.hf_cache \\"
-    warn "      nss-gpu:latest run --config /workspace/data/config.yaml --data-source /workspace/data/input.csv"
+    warn "      -v \$HOME/.cache/huggingface:/workspace/.hf_cache \\"
+    warn "      $image_ref run --config /workspace/data/config.yaml --data-source /workspace/data/input.csv"
     echo >&2
     warn "  Relative paths don't work with docker -v. Use \$(pwd) to expand them:"
     warn "    -v \$(pwd)/my_data:/workspace/data"
     echo >&2
 fi
 
-# -- Check: is HF_HOME set and does it exist?
-if [ -n "${HF_HOME:-}" ] && [ ! -d "$HF_HOME" ]; then
+# -- Check: is the Hugging Face cache present and writable?
+# The image defaults HF_HOME to /workspace/.hf_cache, so an unset value means
+# the caller overrode it away.
+if [ -z "${HF_HOME:-}" ]; then
+    warn "HINT: HF_HOME is not set. Models will download to a temporary location."
+    warn "  To persist model downloads across runs:"
+    warn "    -v \$HOME/.cache/huggingface:/workspace/.hf_cache"
+    echo >&2
+elif [ ! -d "$HF_HOME" ]; then
     warn "WARNING: HF_HOME=$HF_HOME does not exist. Model downloads will use a temporary directory"
     warn "  and be lost when the container exits."
     echo >&2
     warn "  Mount your Hugging Face cache:"
-    warn "    -v ~/.cache/huggingface:/workspace/.hf_cache -e HF_HOME=/workspace/.hf_cache"
+    warn "    -v \$HOME/.cache/huggingface:/workspace/.hf_cache"
     echo >&2
-elif [ -z "${HF_HOME:-}" ]; then
-    warn "HINT: HF_HOME is not set. Models will download to a temporary location."
-    warn "  To persist model downloads across runs:"
-    warn "    -v ~/.cache/huggingface:/workspace/.hf_cache -e HF_HOME=/workspace/.hf_cache"
+elif [ ! -w "$HF_HOME" ]; then
+    warn "WARNING: HF_HOME=$HF_HOME is not writable by uid $(id -u). Downloading any model"
+    warn "  that is not already cached will fail with a permission error."
+    echo >&2
+    warn "  Run as the user that owns the mounted cache:"
+    warn "    --user \$(id -u):\$(id -g)"
     echo >&2
 fi
 
 # -- Check: HF_TOKEN for gated model access (Llama, Mistral, etc.)
 if [ -z "${HF_TOKEN:-}" ] && [ -z "${HUGGING_FACE_HUB_TOKEN:-}" ]; then
-    token_file="${HF_HOME:-$HOME/.cache/huggingface}/token"
+    token_file="${HF_HOME:-${HOME:-/tmp}/.cache/huggingface}/token"
     if [ ! -f "$token_file" ]; then
         warn "HINT: No HF_TOKEN set and no cached token found."
         warn "  Gated models (Llama, Mistral) will fail to download."
         warn "  Pass your token:  -e HF_TOKEN=\"hf_...\""
-        warn "  Or mount a cache that contains one:  -v ~/.cache/huggingface:/workspace/.hf_cache"
+        warn "  Or mount a cache that contains one:  -v \$HOME/.cache/huggingface:/workspace/.hf_cache"
         echo >&2
     fi
 fi

--- a/docs/user-guide/docker.md
+++ b/docs/user-guide/docker.md
@@ -144,13 +144,16 @@ Mount a host directory to persist downloads across container runs:
 ```bash
 docker run --gpus all \
   -v ~/.cache/huggingface:/workspace/.hf_cache \
-  -e HF_HOME=/workspace/.hf_cache \
   ...
 ```
 
 | Host path | Container path | Env var | Purpose |
 |-----------|---------------|---------|---------|
 | `~/.cache/huggingface` | `/workspace/.hf_cache` | `HF_HOME` | Model weights, tokenizers, configs |
+
+The image sets `HF_HOME=/workspace/.hf_cache`, so mounting the cache there is
+enough -- passing `-e HF_HOME=/workspace/.hf_cache` is redundant but harmless.
+Override the variable only to point at a different container path.
 
 Without this mount, models are downloaded into the container's ephemeral
 filesystem and lost when it exits.
@@ -208,7 +211,8 @@ Generation-only runs are typically fine without it.
 The container runs as `appuser` (uid 1000). When bind-mounting host
 directories, Docker preserves host ownership. If your host user has a
 different uid, writes to the mounted directory (artifacts, outputs) will
-fail with "Permission denied".
+fail with "Permission denied". A mounted Hugging Face cache is affected the
+same way: already-cached models still load, but downloading a new one fails.
 
 Fix by matching the container user to your host uid:
 


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced GPU container run guidance to align with the image’s default Hugging Face cache location.
  * Improved runtime setup for Triton JIT by using dedicated cache directories.
* **Bug Fixes**
  * Updated container diagnostics to avoid false “empty workspace” warnings when Hugging Face cache is present.
  * Refined runtime hints for Hugging Face token and cache mounts.
* **Documentation**
  * Clarified that explicitly setting `HF_HOME` is typically unnecessary, and expanded guidance on file permission issues with mounted caches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->