### PR TITLE
feat(pii): default column classifier to nemotron-3-ultra-550b-a55b

### DIFF
--- a/docs/user-guide/environment.md
+++ b/docs/user-guide/environment.md
@@ -49,7 +49,7 @@ Grouped by the `Category` column -- `nss`-native settings first, then
 | `NSS_WANDB_PROJECT` | nss | `--wandb-project` | WandB | -- | WandB project name | Alias for `WANDB_PROJECT` |
 | `NSS_INFERENCE_ENDPOINT` | nss | `--inference-endpoint-url` | PII column classifier | NVIDIA integrate URL | OpenAI-compatible endpoint for column classification | [PII appendix](#pii-ner-and-column-classification) |
 | `NSS_INFERENCE_KEY` | nss | `--inference-api-key` | PII column classifier | -- | API key for `NSS_INFERENCE_ENDPOINT` | Required for LLM column classification |
-| `NSS_INFERENCE_MODEL` | nss | `--inference-model-id` | PII column classifier | `qwen/qwen3-next-80b-a3b-instruct` | Model ID sent to the inference endpoint | [PII appendix](#pii-ner-and-column-classification) |
+| `NSS_INFERENCE_MODEL` | nss | `--inference-model-id` | PII column classifier | `nvidia/nemotron-3-ultra-550b-a55b` | Model ID sent to the inference endpoint | [PII appendix](#pii-ner-and-column-classification) |
 | `NSS_PII_REPLACER_CPU_COUNT` | nss | `--cpu-count` | NER worker pool | `max(1, cpu_count - 1)` | CPU processes for PII NER | [PII appendix](#pii-ner-and-column-classification) |
 | `NEMO_TELEMETRY_ENABLED` | telemetry | `--emit_telemetry` | telemetry | `true` | Enable anonymous usage telemetry | Also `emit_telemetry` in YAML; see [Telemetry](#telemetry) |
 | `HF_HOME` | third-party | -- | Hugging Face Hub | platform cache dir | Root directory for HF downloads | [HF appendix](#hugging-face-cache-and-offline) |
@@ -195,7 +195,7 @@ See [Configuration Reference -- Replacing PII](configuration.md#replacing-pii).
 ### `NSS_INFERENCE_MODEL`
 
 Model ID sent to the inference endpoint. Defaults to
-`qwen/qwen3-next-80b-a3b-instruct`. Override with `--inference-model-id`.
+`nvidia/nemotron-3-ultra-550b-a55b`. Override with `--inference-model-id`.
 
 ### `NSS_PII_REPLACER_CPU_COUNT`
 

--- a/script/slurm/slurm_nss_matrix.sh
+++ b/script/slurm/slurm_nss_matrix.sh
@@ -149,7 +149,7 @@ echo "[NSS SLURM] nemo-safe-synthesizer version: $(python -c 'from nemo_safe_syn
 
 # for column classification
 export NSS_INFERENCE_ENDPOINT=https://integrate.api.nvidia.com/v1
-export NSS_INFERENCE_MODEL=qwen/qwen3-next-80b-a3b-instruct
+export NSS_INFERENCE_MODEL=nvidia/nemotron-3-ultra-550b-a55b
 
 # Extract dataset name for path construction (handles both full paths and simple names)
 # e.g., "/path/to/adult.csv" -> "adult", "/path/to/data.parquet" -> "data", "adult" -> "adult"

--- a/src/nemo_safe_synthesizer/cli/run.py
+++ b/src/nemo_safe_synthesizer/cli/run.py
@@ -187,7 +187,7 @@ def common_run_options(f: Callable[..., object]) -> Callable[..., object]:
             default=None,
             help="Model ID sent to the inference endpoint for PII column classification. "
             "Can also be set via NSS_INFERENCE_MODEL env var. "
-            "[default: qwen/qwen3-next-80b-a3b-instruct]",
+            "[default: nvidia/nemotron-3-ultra-550b-a55b]",
         )
     )
     options.append(

--- a/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
@@ -45,7 +45,7 @@ class DefaultLLMConfig:
             Lower values give more deterministic output.
     """
 
-    DEFAULT_CONFIG_ID = "qwen/qwen3-next-80b-a3b-instruct"
+    DEFAULT_CONFIG_ID = "nvidia/nemotron-3-ultra-550b-a55b"
     SYSTEM_PROMPT = "You are a helpful AI that annotates columns in datasets with their respective types. "
     MAX_OUTPUT_TOKENS = 2048
     TEMPERATURE = 0.2

--- a/tests/nss_pii_replacer_test.py
+++ b/tests/nss_pii_replacer_test.py
@@ -14,7 +14,7 @@ from nemo_safe_synthesizer.pii_replacer.nemo_pii import NemoPII
 # Currently use env variables to configure the endpoint and model for column classification.
 # export NSS_INFERENCE_KEY=<...>
 # export NSS_INFERENCE_ENDPOINT=https://integrate.api.nvidia.com/v1
-# export NSS_INFERENCE_MODEL=qwen/qwen3-next-80b-a3b-instruct
+# export NSS_INFERENCE_MODEL=nvidia/nemotron-3-ultra-550b-a55b
 
 
 def main():

--- a/tests/preflight/test_preflight.py
+++ b/tests/preflight/test_preflight.py
@@ -419,7 +419,7 @@ class TestInferenceModelCheck:
     def test_valid_model_is_silent(self, default_config):
         with patch.dict(
             "os.environ",
-            {"NSS_INFERENCE_KEY": "test-key", "NSS_INFERENCE_MODEL": "qwen/qwen3-next-80b-a3b-instruct"},
+            {"NSS_INFERENCE_KEY": "test-key", "NSS_INFERENCE_MODEL": "nvidia/nemotron-3-ultra-550b-a55b"},
         ):
             issues = InferenceModelCheck().run(make_ctx(config=default_config))
         assert not any(i.code == "inference_model_blank" for i in issues)


### PR DESCRIPTION
## Summary

Switches the default model for PII column classification from `qwen/qwen3-next-80b-a3b-instruct` to `nvidia/nemotron-3-ultra-550b-a55b`.

- `DefaultLLMConfig.DEFAULT_CONFIG_ID` in `pii_replacer/data_editor/detect.py`
- `--inference-model-id` help text in `cli/run.py`
- `docs/user-guide/environment.md` (table + `NSS_INFERENCE_MODEL` section)
- Example env values in `script/slurm/slurm_nss_matrix.sh` and tests

Behavior is unchanged for anyone setting `NSS_INFERENCE_MODEL` or `--inference-model-id` explicitly.

## Test plan

- `uv run pytest tests/preflight/test_preflight.py tests/nss_pii_replacer_test.py` — 123 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the default inference model to `nvidia/nemotron-3-ultra-550b-a55b` for column classification.
  * The new default is applied consistently across the CLI, environment configuration, and scheduled jobs.

* **Documentation**
  * Updated setup guidance and reference documentation to reflect the new default model.
  * Clarified that the model can still be overridden with `--inference-model-id`.

* **Tests**
  * Updated examples and validation coverage for the new model configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->