### PR TITLE
chore: ignore local development settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ env*/
 *.envrc
 mise.local.toml
 .mise.local.toml
+.devmachine.local.toml
 temp
 __pycache__/*
 *.pyc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "terminal.integrated.env.linux": {
-        "PATH": "${env:HOME}/.local/share/mise/shims:${env:HOME}/.local/bin:${env:PATH}"
-    },
-    "python.defaultInterpreterPath": "${workspaceFolder}/.venv"
-}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ mise run bootstrap-nss cuda
 
 Development tools (`dprint`, `ruff`, `ty`, `yq`, `gh`, etc.) are managed via [mise](https://mise.jdx.dev/). Tool versions are declared in `.mise.toml` and locked in `mise.lock` (committed). mise also manages environment variables -- place project-local secrets or overrides in `.env` or `.env.local` (both git-ignored, auto-loaded by mise).
 
+For IDEs to discover mise-managed tools, [add mise shims to the `PATH` in your default shell profile](https://mise.jdx.dev/ide-integration.html#adding-shims-to-path-in-your-default-shell).
+
 Project commands run through mise tasks under `.mise/tasks/`: `*.toml` files for declarative tasks, executable scripts for bash-heavy logic.
 
 ```bash


### PR DESCRIPTION
## Summary
- stop tracking local VS Code settings and ignore machine-specific development configuration
- point IDE users to Mise's shell-profile shim guidance

## Test plan
- [x] `mise run format-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring IDE shell profiles to include mise shims in the `PATH`.

* **Chores**
  * Added local development machine configuration files to the ignore list.
  * Removed workspace-specific terminal and Python interpreter settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->