### PR TITLE
fix(slurm): update dp configs to new shape

### DIFF
--- a/script/slurm/configs/mistral-dp.yaml
+++ b/script/slurm/configs/mistral-dp.yaml
@@ -8,5 +8,6 @@ training:
 privacy:
   dp_enabled: true
 generation:
-  use_structured_generation: true
+  structured_generation:
+    enabled: true
   num_records: 3000

--- a/script/slurm/configs/smollm3-dp.yaml
+++ b/script/slurm/configs/smollm3-dp.yaml
@@ -8,5 +8,6 @@ training:
 privacy:
   dp_enabled: true
 generation:
-  use_structured_generation: true
+  structured_generation:
+    enabled: true
   num_records: 3000

--- a/script/slurm/configs/tinyllama-dp.yaml
+++ b/script/slurm/configs/tinyllama-dp.yaml
@@ -8,5 +8,6 @@ training:
 privacy:
   dp_enabled: true
 generation:
-  use_structured_generation: true
+  structured_generation:
+    enabled: true
   num_records: 3000


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->
Following up to #595, needed to update the configs for the DP runs to reflex the new shape for `structured_generation`, so that slurm runs with those configs can succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Updated generation settings across supported training configurations to use the nested structured-generation option.
  - Structured generation remains enabled with the updated configuration format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->