### PR TITLE
fix(evaluation): use a 1-D vector for AIA text similarity

### DIFF
--- a/src/nemo_safe_synthesizer/evaluation/components/attribute_inference_protection.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/attribute_inference_protection.py
@@ -546,11 +546,16 @@ class AttributeInferenceProtection(Component):
                         # Compare synthetic and training embeddings
                         # if all embeddings were nan, then synth_val is an int with value 0
                         if not isinstance(synth_val, int):
-                            denom = np.linalg.norm(train_val_embedding) * np.linalg.norm(synth_val)
+                            # ``encode`` returns a batch, so this is (1, dim); take the
+                            # single row. Without it ``np.dot`` yields a one-element
+                            # array rather than a scalar, and ``float()`` on that raises
+                            # under NumPy >= 2.4 (deprecated since 1.25).
+                            train_val_vector = train_val_embedding[0]
+                            denom = np.linalg.norm(train_val_vector) * np.linalg.norm(synth_val)
                             if denom == 0:
                                 sim = 0
                             else:
-                                sim = float(np.dot(train_val_embedding, synth_val) / denom)
+                                sim = float(np.dot(train_val_vector, synth_val) / denom)
                             dist = 1 - sim
                             if dist <= 0.35:
                                 correct[column] += 1

--- a/src/nemo_safe_synthesizer/evaluation/components/attribute_inference_protection.py
+++ b/src/nemo_safe_synthesizer/evaluation/components/attribute_inference_protection.py
@@ -546,10 +546,6 @@ class AttributeInferenceProtection(Component):
                         # Compare synthetic and training embeddings
                         # if all embeddings were nan, then synth_val is an int with value 0
                         if not isinstance(synth_val, int):
-                            # ``encode`` returns a batch, so this is (1, dim); take the
-                            # single row. Without it ``np.dot`` yields a one-element
-                            # array rather than a scalar, and ``float()`` on that raises
-                            # under NumPy >= 2.4 (deprecated since 1.25).
                             train_val_vector = train_val_embedding[0]
                             denom = np.linalg.norm(train_val_vector) * np.linalg.norm(synth_val)
                             if denom == 0:

--- a/tests/evaluation/components/test_attribute_inference_protection.py
+++ b/tests/evaluation/components/test_attribute_inference_protection.py
@@ -3,6 +3,7 @@
 
 # ruff: noqa: E402
 import logging
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -164,3 +165,58 @@ def test_attribute_inference_protection_text_only(
 
     # Verify the protection score was computed
     assert attribute_inference_protection.score is not None
+
+
+def test_aia_text_column_similarity_returns_scalar(monkeypatch: pytest.MonkeyPatch):
+    """Text-column similarity must not rely on array-to-scalar conversion.
+
+    ``SentenceTransformer.encode`` returns a batch, so encoding one string yields a
+    ``(1, dim)`` array. Taking ``np.dot`` of that against the ``(dim,)`` synthetic
+    vector produces a one-element array, and ``float()`` on it is deprecated in
+    NumPy 1.25 and an error from 2.4 on. Warnings are escalated so this fails on
+    the pinned NumPy in CI as well as on newer releases.
+    """
+    training_df = pd.DataFrame(
+        {
+            "quasi": [1, 2, 3, 4],
+            "text": [
+                "reserve a table for two at eight",
+                "cancel my reservation for friday",
+                "what is the weather in denver",
+                "add milk to my shopping list",
+            ],
+        }
+    )
+    synthetic_df = training_df.copy()
+
+    class StubEmbedder:
+        """Minimal stand-in that mirrors the real batch-shaped return value."""
+
+        def encode(self, sentences, **_kwargs):
+            return np.ones((len(list(sentences)), 8), dtype=np.float32)
+
+    monkeypatch.setattr(
+        "nemo_safe_synthesizer.evaluation.components.attribute_inference_protection.SentenceTransformer",
+        lambda *_args, **_kwargs: StubEmbedder(),
+    )
+    monkeypatch.setattr(
+        "nemo_safe_synthesizer.evaluation.components.attribute_inference_protection.find_text_fields",
+        lambda df: [column for column in df.columns if column == "text"],
+    )
+    monkeypatch.setattr(
+        AttributeInferenceProtection,
+        "_get_synth_nn",
+        staticmethod(lambda *_args, **_kwargs: synthetic_df.head(2)),
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        score, col_accuracy_df = AttributeInferenceProtection._aia(
+            training_df=training_df,
+            synthetic_df=synthetic_df,
+            quasi_identifier_count=1,
+        )
+
+    assert score.score is not None
+    assert col_accuracy_df is not None
+    assert "text" in list(col_accuracy_df["Column"])


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

# Summary

The Attribute Inference Attack metric crashes for anyone who installs from PyPI:

```
TypeError: only 0-dimensional arrays can be converted to Python scalars
  attribute_inference_protection.py:553 in _aia
```

`SentenceTransformer.encode` returns a batch, so encoding a single training value produced a
`(1, dim)` array. `np.dot((1, dim), (dim,))` yields a one-element array, not a scalar, and
`float()` on that is the failure.

The fix indexes the single row before the dot product. `np.linalg.norm` is unaffected — the
Frobenius norm of a `(1, dim)` array equals the norm of its only row — so scores are unchanged
wherever the code already worked.

## Why this surfaced now, and why CI never caught it

Array-to-scalar conversion for `ndim > 0` was deprecated in NumPy **1.25** and became an error in
**2.4.0**. I verified the boundary directly rather than from release notes:

| NumPy | `float(np.zeros(1))` |
| ----- | -------------------- |
| 2.2.6 | allowed (DeprecationWarning) |
| 2.3.0 | allowed (DeprecationWarning) |
| 2.4.0 | `TypeError` |
| 2.5.1 | `TypeError` |

`uv.lock` pins NumPy 2.2.6, and developers and CI install with `--frozen`, so locally this has
only ever been a warning. Nothing in `pyproject.toml` constrains NumPy, so a PyPI install resolves
to 2.5.x and hits the error. The bug is not new — the warning has been firing since 1.25 with
nobody positioned to see it.

Worth a separate discussion: whether the package should carry a NumPy upper bound. Today the
lockfile protects contributors while end users track every NumPy release.

## Audit

Checked whether the same mistake appears elsewhere. The bug class is treating `encode`'s batch
output as a single vector; all four call sites:

| Site | Handling | Verdict |
| ---- | -------- | ------- |
| `attribute_inference_protection.py:541` | dotted directly | the bug, fixed here |
| `attribute_inference_protection.py:495` | `np.mean(..., axis=0)` → `(dim,)` | safe |
| `text_semantic_similarity.py:278` | collapsed by `_average_embedded_vectors` before the dot | safe |
| `privacy_metric_utils.py:73` | torch mean over columns → per-row 1-D | safe |

A wider scan of `float()`/`int()` over NumPy expressions found 18 further hits, all genuine
scalars (`np.min`/`np.max`/`np.mean` return 0-d; indexing a 1-D array gives a NumPy scalar).

Dynamically, the unit suite was run with that specific deprecation escalated to an error:

```bash
pytest tests -W "error:Conversion of an array with ndim > 0:DeprecationWarning"
```

1547 passed, zero hits. So this is one instance, not a pattern.

## Testing

`test_aia_text_column_similarity_returns_scalar` stubs the embedder, so unlike the existing
text-path AIA tests it needs no model download and no GPU, and runs in ~8s. It escalates
`DeprecationWarning` to an error so it is meaningful on CI's pinned NumPy 2.2.6 as well as on
2.4+, where the same defect raises `TypeError`.

Negative control: reverting the one-line fix makes the new test fail at exactly that line;
restoring it passes.

## Pre-Review Checklist

- [x] `mise run format && mise run check` — `format` passes. `check` fails only on pre-existing
      `unresolved-import` diagnostics for `vllm`, from a local venv without the `cu129` extra.
- [x] `mise run test` passes locally — the AIA module's tests pass (7/7). The 54 failures in
      `tests/generation/test_vllm_backend.py` are the same missing-`vllm` environment issue and
      reproduce on unmodified `main`.
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally
- [ ] GPU CI status check passes

## Pre-Merge Checklist

- [x] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors — no user-facing behavior change

## Other Notes

- Found while running the tutorial notebook on an NVIDIA Brev instance, where the environment is
  built from the published wheel rather than the lockfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text similarity evaluation to produce valid scalar scores with newer NumPy versions.
  * Preserved existing zero-norm handling and similarity thresholds.
  * Improved reliability of attribute inference evaluation for text columns.

* **Tests**
  * Added regression coverage to verify valid scoring and text-column accuracy without deprecation warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->