### PR TITLE
fix: preserve requested Python during dependency sync

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -109,6 +109,7 @@ runs:
           python_version="$(tr -d '[:space:]' < .python-version)"
         fi
         echo "PYTHON_VERSION=${python_version}" >> "$GITHUB_ENV"
+        echo "UV_PYTHON=${python_version}" >> "$GITHUB_ENV"
 
     - name: Install mise and dev tools (uv, ruff, ty, etc.)
       if: inputs.bootstrap-tools == 'true'

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -193,6 +193,20 @@ jobs:
       - name: Bootstrap
         run: mise run bootstrap-nss cpu
 
+      - name: Verify matrix Python version
+        env:
+          EXPECTED_PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          actual_python_version="$(.venv/bin/python --version 2>&1)"
+          echo "Using ${actual_python_version}"
+          case "${actual_python_version}" in
+            "Python ${EXPECTED_PYTHON_VERSION}."*) ;;
+            *)
+              echo "::error::Expected Python ${EXPECTED_PYTHON_VERSION}.x, got ${actual_python_version}"
+              exit 1
+              ;;
+          esac
+
       - name: Run unit tests with coverage
         run: mise run test:ci
 

--- a/.mise/tasks/_lib.sh
+++ b/.mise/tasks/_lib.sh
@@ -40,20 +40,21 @@ resolve_venv_path() {
 
 sync_nss_dependencies() {
   local extra="${1:?Python dependency profile is required}"
+  local python="${2:-$(resolve_python_version)}"
   local sync_uv_bin="${NSS_UV_BIN:-uv}"
 
   case "${extra}" in
     cuda|cu129)
-      "${sync_uv_bin}" sync --frozen --extra cu129 --extra engine --group dev
+      "${sync_uv_bin}" sync --frozen --python "${python}" --extra cu129 --extra engine --group dev
       ;;
     cpu)
-      "${sync_uv_bin}" sync --frozen --extra cpu --extra engine --group dev
+      "${sync_uv_bin}" sync --frozen --python "${python}" --extra cpu --extra engine --group dev
       ;;
     engine)
-      "${sync_uv_bin}" sync --frozen --extra engine --group dev
+      "${sync_uv_bin}" sync --frozen --python "${python}" --extra engine --group dev
       ;;
     dev)
-      "${sync_uv_bin}" sync --frozen --group dev
+      "${sync_uv_bin}" sync --frozen --python "${python}" --group dev
       ;;
     *)
       echo "Error: Invalid extra '${extra}'. Use one of: dev engine cpu cuda cu129" >&2

--- a/.mise/tasks/_lib.sh
+++ b/.mise/tasks/_lib.sh
@@ -40,8 +40,12 @@ resolve_venv_path() {
 
 sync_nss_dependencies() {
   local extra="${1:?Python dependency profile is required}"
-  local python="${2:-$(resolve_python_version)}"
+  local python="${2:-}"
   local sync_uv_bin="${NSS_UV_BIN:-uv}"
+
+  if [[ -z "${python}" ]]; then
+    python="$(resolve_python_version)" || return
+  fi
 
   case "${extra}" in
     cuda|cu129)

--- a/.mise/tasks/bootstrap-nss-slurm
+++ b/.mise/tasks/bootstrap-nss-slurm
@@ -82,7 +82,7 @@ fi
 "${uv_bin}" venv --seed --allow-existing --python "${python_bin}" "${venv_path}"
 
 echo "[slurm-bootstrap] syncing NSS dependencies with profile ${usage_extra?}"
-sync_nss_dependencies "${usage_extra?}"
+sync_nss_dependencies "${usage_extra?}" "${python_bin}"
 
 venv_python="$(readlink -f "${venv_path}/bin/python")"
 readonly venv_python

--- a/tests/tools/test_mise_tasks.py
+++ b/tests/tools/test_mise_tasks.py
@@ -82,3 +82,10 @@ def test_sync_dependencies_accepts_explicit_python_override(pytestconfig: pytest
     )
 
     assert args == ["sync", "--frozen", "--python", "/lustre/python3.12", "--group", "dev"]
+
+
+def test_ci_setup_exports_requested_python_to_uv(pytestconfig: pytest.Config) -> None:
+    action = Path(pytestconfig.rootpath, ".github/actions/setup-python-env/action.yml").read_text()
+
+    assert 'echo "PYTHON_VERSION=${python_version}" >> "$GITHUB_ENV"' in action
+    assert 'echo "UV_PYTHON=${python_version}" >> "$GITHUB_ENV"' in action

--- a/tests/tools/test_mise_tasks.py
+++ b/tests/tools/test_mise_tasks.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def fake_uv(tmp_path: Path) -> Path:
+    uv = tmp_path / "uv"
+    uv.write_text("#!/usr/bin/env bash\nprintf '%s\\n' \"$@\"\n")
+    uv.chmod(0o755)
+    return uv
+
+
+def _sync_dependencies(
+    repo_root: Path,
+    fake_uv: Path,
+    profile: str,
+    *,
+    python_version: str | None = None,
+    python_override: str | None = None,
+) -> list[str]:
+    command = 'source "$1"; sync_nss_dependencies "$2" "${3:-}"'
+    env = os.environ | {"MISE_CONFIG_ROOT": str(repo_root), "NSS_UV_BIN": str(fake_uv)}
+    if python_version is not None:
+        env["PYTHON_VERSION"] = python_version
+    else:
+        env.pop("PYTHON_VERSION", None)
+
+    result = subprocess.run(
+        ["bash", "-c", command, "bash", str(repo_root / ".mise/tasks/_lib.sh"), profile, python_override or ""],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    return result.stdout.splitlines()
+
+
+@pytest.mark.parametrize("python_version", ["3.11", "3.12", "3.14"])
+def test_sync_dependencies_passes_requested_python(
+    pytestconfig: pytest.Config, fake_uv: Path, python_version: str
+) -> None:
+    args = _sync_dependencies(Path(pytestconfig.rootpath), fake_uv, "dev", python_version=python_version)
+
+    assert args == ["sync", "--frozen", "--python", python_version, "--group", "dev"]
+
+
+@pytest.mark.parametrize(
+    ("profile", "expected"),
+    [
+        ("dev", ["--group", "dev"]),
+        ("engine", ["--extra", "engine", "--group", "dev"]),
+        ("cpu", ["--extra", "cpu", "--extra", "engine", "--group", "dev"]),
+        ("cuda", ["--extra", "cu129", "--extra", "engine", "--group", "dev"]),
+        ("cu129", ["--extra", "cu129", "--extra", "engine", "--group", "dev"]),
+    ],
+)
+def test_sync_dependencies_preserves_profile_arguments(
+    pytestconfig: pytest.Config, fake_uv: Path, profile: str, expected: list[str]
+) -> None:
+    args = _sync_dependencies(Path(pytestconfig.rootpath), fake_uv, profile, python_version="3.12")
+
+    assert args == ["sync", "--frozen", "--python", "3.12", *expected]
+
+
+def test_sync_dependencies_accepts_explicit_python_override(pytestconfig: pytest.Config, fake_uv: Path) -> None:
+    args = _sync_dependencies(
+        Path(pytestconfig.rootpath),
+        fake_uv,
+        "dev",
+        python_version="3.13",
+        python_override="/lustre/python3.12",
+    )
+
+    assert args == ["sync", "--frozen", "--python", "/lustre/python3.12", "--group", "dev"]

--- a/tests/tools/test_mise_tasks.py
+++ b/tests/tools/test_mise_tasks.py
@@ -84,8 +84,21 @@ def test_sync_dependencies_accepts_explicit_python_override(pytestconfig: pytest
     assert args == ["sync", "--frozen", "--python", "/lustre/python3.12", "--group", "dev"]
 
 
-def test_ci_setup_exports_requested_python_to_uv(pytestconfig: pytest.Config) -> None:
-    action = Path(pytestconfig.rootpath, ".github/actions/setup-python-env/action.yml").read_text()
+def test_sync_dependencies_propagates_python_resolution_failure(
+    pytestconfig: pytest.Config, fake_uv: Path, tmp_path: Path
+) -> None:
+    repo_root = Path(pytestconfig.rootpath)
+    env = os.environ | {"MISE_CONFIG_ROOT": str(tmp_path), "NSS_UV_BIN": str(fake_uv)}
+    env.pop("PYTHON_VERSION", None)
 
-    assert 'echo "PYTHON_VERSION=${python_version}" >> "$GITHUB_ENV"' in action
-    assert 'echo "UV_PYTHON=${python_version}" >> "$GITHUB_ENV"' in action
+    result = subprocess.run(
+        ["bash", "-c", 'source "$1"; sync_nss_dependencies dev', "bash", str(repo_root / ".mise/tasks/_lib.sh")],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+    )
+
+    assert result.returncode != 0
+    assert "PYTHON_VERSION is unset" in result.stderr
+    assert result.stdout == ""

--- a/tests/tools/test_mise_tasks.py
+++ b/tests/tools/test_mise_tasks.py
@@ -45,7 +45,7 @@ def _sync_dependencies(
     return result.stdout.splitlines()
 
 
-@pytest.mark.parametrize("python_version", ["3.11", "3.12", "3.14"])
+@pytest.mark.parametrize("python_version", ["3.11", "3.12", "3.13"])
 def test_sync_dependencies_passes_requested_python(
     pytestconfig: pytest.Config, fake_uv: Path, python_version: str
 ) -> None:


### PR DESCRIPTION
## Summary
- pass the resolved Python interpreter explicitly to `uv sync` so CI and local bootstraps retain the requested version
- preserve the Slurm managed-interpreter override and add regression coverage for all dependency profiles

## Test plan
- [x] `uv run --frozen pytest tests/tools/test_mise_tasks.py -n 0 -q` (9 passed)
- [x] real `bootstrap-nss dev` runs retained Python 3.11 and 3.12
- [x] formatting, type checking, and lock checks passed
- [ ] full local unit suite was blocked by the existing CPU vLLM environment missing `libcudart.so.13`; rely on CI for the complete matrix


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dependency synchronization to consistently use the requested Python version.
  * Preserved profile-specific dependency options during environment setup.
  * Added support for explicitly selecting a Python executable during setup.
  * Added validation to ensure CI uses the configured Python version.

* **Tests**
  * Added coverage for Python version selection, profile options, executable overrides, and environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->