### PR TITLE
fix: column classifier truncation and DP tutorial OOM

### DIFF
--- a/docs/tutorials/differential-privacy.ipynb
+++ b/docs/tutorials/differential-privacy.ipynb
@@ -167,7 +167,7 @@
     "    SafeSynthesizer()\n",
     "    .with_data_source(df)  # .with_replace_pii(enable=False) to disable PII replacement\n",
     "    .with_differential_privacy(dp_enabled=True, delta=recommended_delta)\n",
-    "    .with_train(batch_size=16)  # Override the default batch size of 1, which is designed for non-DP training\n",
+    "    .with_train(batch_size=4, gradient_accumulation_steps=32)  # Override the default batch size of 1, which is designed for non-DP training\n",
     "    .with_generate(structured_generation={'enabled': True})  # Improves the percentage of valid records when DP is enabled\n",
     ")\n",
     "builder.run()\n",

--- a/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
@@ -138,6 +138,7 @@ def _format_prompt(
     df: pd.DataFrame,
     entities: set[str],
     num_samples: Optional[int],
+    column_samples: Optional[dict[str, pd.Series]] = None,
 ) -> Optional[str]:
     """Build the LLM prompt for column classification from sampled DataFrame columns.
 
@@ -145,6 +146,9 @@ def _format_prompt(
         df: DataFrame to sample from.
         entities: Set of valid entity type names.
         num_samples: Number of value samples per column (or ``None`` for default).
+        column_samples: Pre-computed output of ``sample_columns``. Callers that
+            need to know which columns actually reached the prompt can sample
+            once and pass the result here; omitted, it is computed internally.
 
     Returns:
         Formatted prompt string, or ``None`` if no sampleable columns.
@@ -229,7 +233,8 @@ def _format_prompt(
     # Not actually valid json with notes, but it's what AS team has found to work.
     valid_types_str = "\n".join(f"{t}{notes.get(t, '')}," for t in types)
 
-    column_samples = sample_columns(df, num_samples)
+    if column_samples is None:
+        column_samples = sample_columns(df, num_samples)
     if not column_samples:
         return None
     prompt_columns = "\n".join([f"{name}: {', '.join(values)}" for name, values in column_samples.items()])
@@ -260,7 +265,10 @@ def classify_columns(
     Returns:
         Map of column name to entity type (or ``UNKNOWN_ENTITY``).
     """
-    formatted_prompt = _format_prompt(df, entities, num_samples)
+    # Sample once and reuse: the prompt only covers columns that survive
+    # sampling, so this is also the set the response is checked against below.
+    column_samples = sample_columns(df, num_samples)
+    formatted_prompt = _format_prompt(df, entities, num_samples, column_samples)
     if not formatted_prompt:
         return {}
 
@@ -304,7 +312,26 @@ def classify_columns(
         return {}
 
     col_entities = _try_extract_entities(entities_str, on_validation_error)
-    return {col: ent if ent in entities else UNKNOWN_ENTITY for col, ent in col_entities.items()}
+
+    # A response can be well-formed yet cover only some of the columns it was
+    # asked about. Those columns are indistinguishable downstream from ones the
+    # model deliberately typed as UNKNOWN_ENTITY, so name them here rather than
+    # letting the gap pass silently. The partial result is still used -- it
+    # classifies more than the degraded-mode fallback would.
+    missing = [col for col in column_samples if col not in col_entities]
+    if missing:
+        logger.warning(
+            "Classification response covered %d of %d submitted columns. The rest are treated as "
+            "unclassified, so PII in them is only caught if NER covers the column: %s",
+            len(column_samples) - len(missing),
+            len(column_samples),
+            ", ".join(missing),
+            extra={"ctx": {"missing_columns": missing}},
+        )
+
+    # Keyed off the submitted columns, so a column the model invented cannot
+    # enter the map and every submitted column gets an explicit entry.
+    return {col: col_entities[col] if col_entities.get(col) in entities else UNKNOWN_ENTITY for col in column_samples}
 
 
 def sample_columns(df: pd.DataFrame, num_samples: int, random_state: Optional[int] = None) -> dict[str, pd.Series]:

--- a/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
@@ -46,8 +46,9 @@ class DefaultLLMConfig:
         No ``max_tokens`` is sent with the request. The default classifier is a
         reasoning model, and ``max_tokens`` budgets reasoning and visible output
         together, so any cap large enough for the reasoning trace on a wide
-        frame is not a meaningful guard anyway. Truncation is instead detected
-        from ``finish_reason`` in ``classify_columns``.
+        frame is not a meaningful guard anyway. A cut-off response is instead
+        detected from ``finish_reason`` (see ``INCOMPLETE_FINISH_REASONS``) and,
+        as a backstop, from the column-coverage check in ``classify_columns``.
     """
 
     DEFAULT_CONFIG_ID = "nvidia/nemotron-3-ultra-550b-a55b"
@@ -91,6 +92,13 @@ DEFAULT_ENTITIES: set[str] = {
 UNKNOWN_ENTITY: str = "none"
 
 MAX_COL_STR_LEN = 128
+
+# ``finish_reason`` values that mean the completion stopped before the model was
+# done, so any JSON it contains describes only part of the frame. The OpenAI
+# schema also defines "tool_calls" and "function_call"; neither can occur here
+# because no tools are sent, and both leave ``content`` empty, which the
+# no-content guard in ``classify_columns`` catches.
+INCOMPLETE_FINISH_REASONS = frozenset({"length", "content_filter"})
 
 TEMPLATE = """Valid types are: [
 {valid_types_str}
@@ -293,20 +301,45 @@ def classify_columns(
         },
     )
 
-    # A truncated response often still repairs into well-formed JSON covering
-    # only the columns emitted before the cut, which would silently classify
-    # part of the frame and leave the rest unclassified with no error. Treat it
-    # as a failure so the caller falls back instead of trusting partial output.
-    if choice.finish_reason == "length":
+    # A cut-off response often still repairs into well-formed JSON covering only
+    # the columns emitted before the cut, which would silently classify part of
+    # the frame and leave the rest unclassified with no error. Treat it as a
+    # failure so the caller falls back instead of trusting partial output.
+    if choice.finish_reason in INCOMPLETE_FINISH_REASONS:
         logger.error(
-            "Classification response from the LLM was truncated before it finished "
-            "(finish_reason='length'); discarding the partial result.",
+            "Classification response from the LLM did not run to completion "
+            "(finish_reason=%r); discarding the partial result.",
+            choice.finish_reason,
             extra={
                 "ctx": {
+                    "finish_reason": choice.finish_reason,
                     "num_columns": len(df.columns),
                     "completion_tokens": getattr(response.usage, "completion_tokens", None),
                 },
             },
+        )
+        on_validation_error()
+        return {}
+
+    # Only "stop" positively means the model finished on its own. Servers do
+    # return values outside the OpenAI schema, so an unrecognized one is not
+    # treated as fatal -- the coverage check below is what actually catches a
+    # response that came up short.
+    if choice.finish_reason != "stop":
+        logger.warning(
+            "Classification response reported an unrecognized finish_reason=%r; treating it as complete.",
+            choice.finish_reason,
+            extra={"ctx": {"finish_reason": choice.finish_reason}},
+        )
+
+    # Guards the parse below, which raises an opaque TypeError on None. Content
+    # can be absent whenever the model returned something other than a message
+    # (a tool call, or a provider-specific empty completion).
+    if not entities_str or not entities_str.strip():
+        logger.error(
+            "Classification response from the LLM had no content (finish_reason=%r).",
+            choice.finish_reason,
+            extra={"ctx": {"finish_reason": choice.finish_reason}},
         )
         on_validation_error()
         return {}

--- a/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
@@ -143,23 +143,21 @@ Output:
 
 
 def _format_prompt(
-    df: pd.DataFrame,
+    column_samples: dict[str, pd.Series],
     entities: set[str],
-    num_samples: Optional[int],
-    column_samples: Optional[dict[str, pd.Series]] = None,
 ) -> Optional[str]:
     """Build the LLM prompt for column classification from sampled DataFrame columns.
 
+    Takes the samples rather than the frame so the caller keeps hold of which
+    columns actually reached the prompt -- ``classify_columns`` checks the
+    response against exactly that set.
+
     Args:
-        df: DataFrame to sample from.
+        column_samples: Output of ``sample_columns``: column name to sampled values.
         entities: Set of valid entity type names.
-        num_samples: Number of value samples per column (or ``None`` for default).
-        column_samples: Pre-computed output of ``sample_columns``. Callers that
-            need to know which columns actually reached the prompt can sample
-            once and pass the result here; omitted, it is computed internally.
 
     Returns:
-        Formatted prompt string, or ``None`` if no sampleable columns.
+        Formatted prompt string, or ``None`` if there are no sampled columns.
     """
     types = [
         "certificate_license_number",
@@ -241,8 +239,6 @@ def _format_prompt(
     # Not actually valid json with notes, but it's what AS team has found to work.
     valid_types_str = "\n".join(f"{t}{notes.get(t, '')}," for t in types)
 
-    if column_samples is None:
-        column_samples = sample_columns(df, num_samples)
     if not column_samples:
         return None
     prompt_columns = "\n".join([f"{name}: {', '.join(values)}" for name, values in column_samples.items()])
@@ -273,10 +269,10 @@ def classify_columns(
     Returns:
         Map of column name to entity type (or ``UNKNOWN_ENTITY``).
     """
-    # Sample once and reuse: the prompt only covers columns that survive
-    # sampling, so this is also the set the response is checked against below.
+    # Sampling drops all-NaN and over-long columns, so this is the set that
+    # actually reaches the prompt -- and the set the response is checked against.
     column_samples = sample_columns(df, num_samples)
-    formatted_prompt = _format_prompt(df, entities, num_samples, column_samples)
+    formatted_prompt = _format_prompt(column_samples, entities)
     if not formatted_prompt:
         return {}
 
@@ -307,9 +303,8 @@ def classify_columns(
     # failure so the caller falls back instead of trusting partial output.
     if choice.finish_reason in INCOMPLETE_FINISH_REASONS:
         logger.error(
-            "Classification response from the LLM did not run to completion "
-            "(finish_reason=%r); discarding the partial result.",
-            choice.finish_reason,
+            f"Classification response from the LLM did not run to completion "
+            f"(finish_reason={choice.finish_reason!r}); discarding the partial result.",
             extra={
                 "ctx": {
                     "finish_reason": choice.finish_reason,
@@ -327,8 +322,8 @@ def classify_columns(
     # response that came up short.
     if choice.finish_reason != "stop":
         logger.warning(
-            "Classification response reported an unrecognized finish_reason=%r; treating it as complete.",
-            choice.finish_reason,
+            f"Classification response reported an unrecognized finish_reason={choice.finish_reason!r}; "
+            "treating it as complete.",
             extra={"ctx": {"finish_reason": choice.finish_reason}},
         )
 
@@ -337,8 +332,7 @@ def classify_columns(
     # (a tool call, or a provider-specific empty completion).
     if not entities_str or not entities_str.strip():
         logger.error(
-            "Classification response from the LLM had no content (finish_reason=%r).",
-            choice.finish_reason,
+            f"Classification response from the LLM had no content (finish_reason={choice.finish_reason!r}).",
             extra={"ctx": {"finish_reason": choice.finish_reason}},
         )
         on_validation_error()
@@ -354,11 +348,9 @@ def classify_columns(
     missing = [col for col in column_samples if col not in col_entities]
     if missing:
         logger.warning(
-            "Classification response covered %d of %d submitted columns. The rest are treated as "
-            "unclassified, so PII in them is only caught if NER covers the column: %s",
-            len(column_samples) - len(missing),
-            len(column_samples),
-            ", ".join(missing),
+            f"Classification response covered {len(column_samples) - len(missing)} of {len(column_samples)} "
+            f"submitted columns. The rest are treated as unclassified, so PII in them is only caught if "
+            f"NER covers the column: {', '.join(missing)}",
             extra={"ctx": {"missing_columns": missing}},
         )
 

--- a/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/data_editor/detect.py
@@ -39,15 +39,19 @@ class DefaultLLMConfig:
     Attributes:
         SYSTEM_PROMPT: System message describing the column-type annotation task
             sent to the LLM.
-        MAX_OUTPUT_TOKENS: Maximum number of tokens allowed in the LLM response
-            (default 2048).
         TEMPERATURE: Sampling temperature for LLM generation (default 0.2).
             Lower values give more deterministic output.
+
+    Note:
+        No ``max_tokens`` is sent with the request. The default classifier is a
+        reasoning model, and ``max_tokens`` budgets reasoning and visible output
+        together, so any cap large enough for the reasoning trace on a wide
+        frame is not a meaningful guard anyway. Truncation is instead detected
+        from ``finish_reason`` in ``classify_columns``.
     """
 
     DEFAULT_CONFIG_ID = "nvidia/nemotron-3-ultra-550b-a55b"
     SYSTEM_PROMPT = "You are a helpful AI that annotates columns in datasets with their respective types. "
-    MAX_OUTPUT_TOKENS = 2048
     TEMPERATURE = 0.2
 
     @classmethod
@@ -268,9 +272,9 @@ def classify_columns(
             {"role": "user", "content": formatted_prompt},
         ],
         temperature=DefaultLLMConfig.TEMPERATURE,
-        max_tokens=DefaultLLMConfig.MAX_OUTPUT_TOKENS,
     )
-    entities_str = response.choices[0].message.content
+    choice = response.choices[0]
+    entities_str = choice.message.content
     llm_elapsed = timer() - llm_start
     logger.info(
         f"LLM column classification took {llm_elapsed} seconds.",
@@ -280,6 +284,24 @@ def classify_columns(
             },
         },
     )
+
+    # A truncated response often still repairs into well-formed JSON covering
+    # only the columns emitted before the cut, which would silently classify
+    # part of the frame and leave the rest unclassified with no error. Treat it
+    # as a failure so the caller falls back instead of trusting partial output.
+    if choice.finish_reason == "length":
+        logger.error(
+            "Classification response from the LLM was truncated before it finished "
+            "(finish_reason='length'); discarding the partial result.",
+            extra={
+                "ctx": {
+                    "num_columns": len(df.columns),
+                    "completion_tokens": getattr(response.usage, "completion_tokens", None),
+                },
+            },
+        )
+        on_validation_error()
+        return {}
 
     col_entities = _try_extract_entities(entities_str, on_validation_error)
     return {col: ent if ent in entities else UNKNOWN_ENTITY for col, ent in col_entities.items()}
@@ -403,7 +425,8 @@ class ColumnClassifierLLM(ColumnClassifier):
     def _on_validation_error(self) -> None:
         raise RuntimeError(
             "There was an error performing classification: "
-            "the classifier LLM failed to return valid JSON. "
+            "the classifier LLM did not return usable JSON (the response was either "
+            "malformed or truncated before it finished). "
             "Please reach out to support if the error recurs."
         )
 

--- a/tests/pii_replacer/test_detect.py
+++ b/tests/pii_replacer/test_detect.py
@@ -421,8 +421,12 @@ def test_detect_types_llm_bad_json():
     )
 
     def attach_mock_response(content: str):
+        # finish_reason is set explicitly: `classify_columns` rejects a response
+        # marked "length" as truncated, so a bare MagicMock would leave these
+        # cases passing only because the auto-created attribute happens not to
+        # compare equal to that string.
         open_ai_mock.chat.completions.create.return_value = MagicMock(
-            choices=[MagicMock(message=MagicMock(content=content))]
+            choices=[MagicMock(message=MagicMock(content=content), finish_reason="stop")]
         )
 
     # LLMs sometimes append extra commentary after the output, but the
@@ -450,7 +454,7 @@ def test_detect_types_llm_bad_json():
     attach_mock_response("""[["pii", "pii"], "b", "c"]""")
     with pytest.raises(RuntimeError) as exc:
         llm_classifier.detect_types(df, DEFAULT_ENTITIES)
-    assert "LLM failed" in exc.value.args[0]
+    assert "did not return usable JSON" in exc.value.args[0]
 
     # ensure none of the (private) payload makes it into the error
     validation_err = exc.value.__context__
@@ -466,7 +470,7 @@ def test_detect_types_llm_bad_json():
     """)
     with pytest.raises(RuntimeError) as exc:
         llm_classifier.detect_types(df, DEFAULT_ENTITIES)
-    assert "LLM failed" in exc.value.args[0]
+    assert "did not return usable JSON" in exc.value.args[0]
 
 
 def test_redact_from_entities():

--- a/tests/pii_replacer/test_detect.py
+++ b/tests/pii_replacer/test_detect.py
@@ -21,6 +21,7 @@ from nemo_safe_synthesizer.pii_replacer.data_editor.detect import (
     DefaultLLMConfig,
     EntityExtractorGliner,
     _format_prompt,
+    classify_columns,
     merge_subsume,
     redact_from_entities,
     sample_columns,
@@ -471,6 +472,86 @@ def test_detect_types_llm_bad_json():
     with pytest.raises(RuntimeError) as exc:
         llm_classifier.detect_types(df, DEFAULT_ENTITIES)
     assert "did not return usable JSON" in exc.value.args[0]
+
+
+def _completion(content: str | None, finish_reason: str = "stop") -> MagicMock:
+    """Mock one chat completion carrying ``content`` and ``finish_reason``."""
+    return MagicMock(
+        choices=[MagicMock(message=MagicMock(content=content), finish_reason=finish_reason)],
+        usage=MagicMock(completion_tokens=2048),
+    )
+
+
+@pytest.fixture
+def llm_classifier_and_df():
+    """A classifier whose LLM is mocked, plus the frame the tests classify."""
+    classifier = ColumnClassifierLLM()
+    classifier._llm = MagicMock()
+    df = pd.DataFrame({"ColA": ["small string", "ok string"], "ColB": [1, 2]})
+    return classifier, df
+
+
+@pytest.mark.parametrize("finish_reason", ["length", "content_filter"])
+def test_detect_types_rejects_response_cut_short(llm_classifier_and_df, finish_reason):
+    """A response that stopped early is discarded even though its JSON parses.
+
+    ``json_repair`` turns the truncated object below into a valid single-key
+    dict, so without the ``finish_reason`` guard this would silently classify
+    ColA and leave ColB unclassified with no error raised.
+    """
+    classifier, df = llm_classifier_and_df
+    classifier._llm.chat.completions.create.return_value = _completion('{"ColA": "none"', finish_reason)
+
+    with pytest.raises(RuntimeError) as exc:
+        classifier.detect_types(df, DEFAULT_ENTITIES)
+    assert "did not return usable JSON" in exc.value.args[0]
+
+
+@pytest.mark.parametrize("content", [None, "", "   "])
+def test_detect_types_rejects_empty_content(llm_classifier_and_df, content):
+    """Tool-call and empty completions leave content unset; json_repair raises TypeError on None."""
+    classifier, df = llm_classifier_and_df
+    classifier._llm.chat.completions.create.return_value = _completion(content, "tool_calls")
+
+    with pytest.raises(RuntimeError) as exc:
+        classifier.detect_types(df, DEFAULT_ENTITIES)
+    assert "did not return usable JSON" in exc.value.args[0]
+
+
+def test_detect_types_accepts_unrecognized_finish_reason(llm_classifier_and_df):
+    """Servers return reasons outside the OpenAI schema; those are warned about, not rejected."""
+    classifier, df = llm_classifier_and_df
+    classifier._llm.chat.completions.create.return_value = _completion('{"ColA": "none", "ColB": "none"}', "eos_token")
+
+    assert classifier.detect_types(df, DEFAULT_ENTITIES) == {"ColA": "none", "ColB": "none"}
+
+
+def test_classify_columns_warns_when_response_omits_columns():
+    """Columns the model skipped are named in a warning and returned as UNKNOWN_ENTITY.
+
+    Absent keys are indistinguishable downstream from a deliberate "none", so
+    the warning is the only signal that the frame was partly classified.
+    """
+    df = pd.DataFrame({"ColA": ["a string"], "ColB": ["b string"]})
+    client = MagicMock()
+    client.chat.completions.create.return_value = _completion('{"ColA": "none"}')
+    logger = MagicMock()
+
+    result = classify_columns(df, DEFAULT_ENTITIES, 3, client, lambda: None, logger)
+
+    assert result == {"ColA": "none", "ColB": UNKNOWN_ENTITY}
+    logger.warning.assert_called_once()
+    assert "ColB" in logger.warning.call_args.args[0]
+    assert logger.warning.call_args.kwargs["extra"]["ctx"]["missing_columns"] == ["ColB"]
+
+
+def test_classify_columns_drops_columns_that_were_never_submitted():
+    """A column the model invents cannot enter the map."""
+    df = pd.DataFrame({"ColA": ["a string"]})
+    client = MagicMock()
+    client.chat.completions.create.return_value = _completion('{"ColA": "none", "Invented": "name"}')
+
+    assert classify_columns(df, DEFAULT_ENTITIES, 3, client, lambda: None, MagicMock()) == {"ColA": "none"}
 
 
 def test_redact_from_entities():

--- a/tests/pii_replacer/test_detect.py
+++ b/tests/pii_replacer/test_detect.py
@@ -339,7 +339,7 @@ def test_format_prompt_renders_template_and_samples():
             "count_col": [7],
         }
     )
-    prompt = _format_prompt(df, DEFAULT_ENTITIES, num_samples=2)
+    prompt = _format_prompt(sample_columns(df, num_samples=2), DEFAULT_ENTITIES)
     assert prompt is not None
     assert "Valid types are: [" in prompt
     assert "Additional instructions:" in prompt
@@ -359,7 +359,7 @@ def test_format_prompt_includes_custom_entity_types():
     """User-defined entity names are appended to the valid-types list before 'none'."""
     custom = "custom_entity_acme"
     df = pd.DataFrame({"x": [1]})
-    prompt = _format_prompt(df, DEFAULT_ENTITIES | {custom}, num_samples=1)
+    prompt = _format_prompt(sample_columns(df, num_samples=1), DEFAULT_ENTITIES | {custom})
     assert prompt is not None
     assert f"{custom}," in prompt
     none_idx = prompt.index(f"{UNKNOWN_ENTITY},")
@@ -378,7 +378,7 @@ def test_format_prompt_returns_none_without_sampleable_columns():
             "ColC": [np.nan, np.nan, np.nan],
         }
     )
-    assert _format_prompt(df, DEFAULT_ENTITIES, num_samples=3) is None
+    assert _format_prompt(sample_columns(df, num_samples=3), DEFAULT_ENTITIES) is None
 
 
 def test_no_columns_after_filter():


### PR DESCRIPTION
Two independent fixes found while investigating why the differential-privacy tutorial failed.

## `fix(pii)`: drop the `max_tokens` cap on the column classifier

`MAX_OUTPUT_TOKENS = 2048` dates to the initial commit, when the default classifier was `qwen/qwen2.5-coder-32b-instruct` — a non-reasoning model, so the whole budget went to the JSON response and 2048 was ample.

The default became `nvidia/nemotron-3-ultra-550b-a55b` in #683. For a reasoning model `max_tokens` budgets the reasoning trace and the visible output *together*, so the cap now starves the thing it was meant to protect. Reproduced against the live endpoint on the tutorial's 45-column frame:

```
finish_reason: length
usage: completion_tokens=2048, prompt_tokens=1987
reasoning_content: 4545 chars
content (172 chars): '{"Source": "none", ..., "End_Lat": "'
```

The trace consumed the budget and the JSON was cut off seven columns in.

The worse half of this is silent. A truncated response frequently repairs into *well-formed* JSON covering only the columns emitted before the cut — in my repro `json_repair` produced a valid 7-key dict and `TypeAdapter` accepted it, so classification would have silently succeeded on 7 of 45 columns with no error raised at all. The `RuntimeError` some runs hit is the lucky path.

This PR stops sending `max_tokens` and treats `finish_reason == "length"` as a failure, so the caller falls back to degraded mode rather than trusting a partial result. The `RuntimeError` message now covers truncation as well as malformed JSON.

## `fix(docs)`: lower the DP tutorial batch size

`batch_size=16` with DP enabled OOMs on an 80 GiB A100 running the default SmolLM3-3B. Opacus materializes per-sample gradients, so memory scales with the *physical* batch size, not the effective one, and there is no `BatchMemoryManager` in the DP path to split it.

Now `batch_size=4, gradient_accumulation_steps=32`, holding the effective batch at 128 — the same per-device batch size already exercised for this model by `tests/e2e/required_configs/smollm3-dp.yaml`.

This value has been in the tutorial since it was added in #253 and was never valid: the notebook was committed with outputs stripped, and no CI job executes notebooks (`mkdocs-jupyter` runs with `execute: false`), so it had never run end-to-end in CI.

## Testing

The classifier change is reasoned from a reproduced failure, not confirmed against a passing call — worth one live run before merge. No unit tests were added; nothing under `tests/` referenced `MAX_OUTPUT_TOKENS` or `classify_columns`. `mise run format` passes.

Also worth noting separately, not addressed here: when a prior run leaves GPU memory allocated, the `vram_exceeds_capacity` preflight reports `available ~0.0 GiB` alongside `training.max_vram_fraction=0.8`, which reads as though the configured fraction were applied. The remediation points at batch size, when the actual fix is to free the card.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved classification reliability by detecting incomplete, truncated, empty, or content-filtered responses.
  * Prevented malformed responses from being accepted as valid results and clarified related validation errors.
  * Added fallback handling for missing or unrecognized column classifications.

* **Documentation**
  * Updated the differential privacy tutorial to use smaller batches with gradient accumulation for more memory-efficient training.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->