### PR TITLE
fix(ci): keep source-only indexes in GPU test env resolution

### DIFF
--- a/.github/actions/setup-gpu-test-env/action.yml
+++ b/.github/actions/setup-gpu-test-env/action.yml
@@ -81,15 +81,31 @@ runs:
         import tomllib
 
         with open(sys.argv[1], "rb") as handle:
-            indexes = tomllib.load(handle)["tool"]["uv"]["index"]
+            uv_config = tomllib.load(handle)["tool"]["uv"]
 
+        indexes = uv_config["index"]
         cuda_extra = sys.argv[2]
+
+        # Some indexes are reached only through [tool.uv.sources] and carry no
+        # CUDA variant in their name or URL (flashinfer-cubin serves a single
+        # https://flashinfer.ai/whl/ for every extra). We pass --no-sources
+        # below, so collect those by their declared extra or they are dropped.
+        source_indexes = {
+            entry["index"]
+            for value in uv_config.get("sources", {}).values()
+            for entry in (value if isinstance(value, list) else [value])
+            if isinstance(entry, dict)
+            and entry.get("extra") == cuda_extra
+            and "index" in entry
+        }
+
         print(
             "\n".join(
                 index["url"]
                 for index in indexes
                 if index["name"].endswith(f"-{cuda_extra}")
                 or f"/{cuda_extra}" in index["url"]
+                or index["name"] in source_indexes
             )
         )
         PY


### PR DESCRIPTION
# Summary

Fixes GPU smoke + e2e failing on `main` with:

```
× No solution found when resolving dependencies:
╰─▶ Because there is no version of flashinfer-cubin{sys_platform == 'linux'}==0.6.14 ...
    conclude that your requirements are unsatisfiable.
```

## Root cause

`setup-gpu-test-env` infers which indexes to pass to `uv` by matching the CUDA extra
against each index's name or URL:

```python
if index["name"].endswith(f"-{cuda_extra}") or f"/{cuda_extra}" in index["url"]
```

When that inference landed (#691, Aug 4 16:50 UTC) every index encoded its variant one
of those two ways, so the rule held. #664 landed 27 minutes later (17:17 UTC) and added
the first index that doesn't: `flashinfer-cubin`, which serves a single
variant-agnostic `https://flashinfer.ai/whl/` and is bound to packages only through
`[tool.uv.sources]`.

It matches neither branch of the rule, so it was silently dropped — and since the
install also passes `--no-sources`, the sources table couldn't reach it either. Both
PRs were green on their own base; the breakage exists only in the merge.

That index is the only place `flashinfer-cubin==0.6.14` exists:

| Index | max `flashinfer-cubin` |
| ----- | ---------------------- |
| `https://flashinfer.ai/whl/` | 0.6.16.post1 (has 0.6.14) |
| PyPI | 0.6.13 |
| `https://flashinfer.ai/whl/cu129` | does not serve the package |
| `https://wheels.vllm.ai/0.26.0/cu129` | 0.6.13 |

## Fix

Also collect indexes referenced by `[tool.uv.sources]` for the target extra.

Before / after, run against `pyproject.toml` at `cu129`:

```
  https://download.pytorch.org/whl/cu129
  https://flashinfer.ai/whl/cu129
+ https://flashinfer.ai/whl/
  https://wheels.vllm.ai/0.26.0/cu129
```

This matches the index set in the documented manual install command, which is why
installing by hand works today while CI does not.

## Verification

Resolution flips with exactly that one index, reproducing CI's error before and
succeeding after:

```
$ uv pip install --dry-run --no-deps --default-index https://pypi.org/simple \
    --index .../cu129 (x3) --index-strategy unsafe-best-match flashinfer-cubin==0.6.14
  × No solution found ... there is no version of flashinfer-cubin==0.6.14

$ # same, plus --index https://flashinfer.ai/whl/
  Resolved 1 package
   + flashinfer-cubin==0.6.14
```

`mise run format-check` passes. No dependency versions change.

## Pre-Review Checklist

- [x] `mise run format && mise run check`
- [x] GPU CI status check passes -- this PR is the fix for it

## Other Notes

CI-only change; no source or dependency changes. Worth noting the
`index_count < 3` guard did not catch this — the count stayed at exactly 3
while the wrong index was dropped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU test environment setup to reliably discover all CUDA package indexes configured for the selected extra.
  * Added support for indexes declared through source configuration, alongside existing name- and URL-based matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->