### PR TITLE
chore: drop unreferenced NVIDIA package indexes

### DIFF
--- a/cuda_deps.toml
+++ b/cuda_deps.toml
@@ -74,16 +74,6 @@ url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
 [[indexes]]
-name = "nv-shared-pypi-local"
-url = "https://urm.nvidia.com/artifactory/api/pypi/nv-shared-pypi-local/simple"
-explicit = true
-
-[[indexes]]
-name = "nvidia-pypi-public"
-url = "https://pypi.nvidia.com"
-explicit = true
-
-[[indexes]]
 name = "flashinfer-cubin"
 url = "https://flashinfer.ai/whl/"
 explicit = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -316,16 +316,6 @@ url = "https://download.pytorch.org/whl/cpu"
 explicit = true
 
 [[tool.uv.index]]
-name = "nv-shared-pypi-local"
-url = "https://urm.nvidia.com/artifactory/api/pypi/nv-shared-pypi-local/simple"
-explicit = true
-
-[[tool.uv.index]]
-name = "nvidia-pypi-public"
-url = "https://pypi.nvidia.com"
-explicit = true
-
-[[tool.uv.index]]
 name = "flashinfer-cubin"
 url = "https://flashinfer.ai/whl/"
 explicit = true


### PR DESCRIPTION
# Summary

Removes two `[[indexes]]` entries from `cuda_deps.toml` (and the regenerated
`pyproject.toml` block) that the resolver cannot reach:

- `nv-shared-pypi-local` -> `https://urm.nvidia.com/artifactory/api/pypi/nv-shared-pypi-local/simple`
- `nvidia-pypi-public` -> `https://pypi.nvidia.com`

Both have been declared since the initial commit, carried over when the project
moved off NVIDIA's internal GitLab, and copied verbatim into `cuda_deps.toml`
by #655.

## Why they are inert

Both are `explicit = true`, which in uv means the index is consulted *only* for
packages that name it in `[tool.uv.sources]`. No package names either one:

```
index -> packages bound via [tool.uv.sources]
  pytorch-cu129                ['-', 'cu129']
  flashinfer-jit-cache-cu129   ['cu129']
  pytorch-cpu                  ['cpu']
  nv-shared-pypi-local         NOT IN SOURCES
  nvidia-pypi-public           NOT IN SOURCES
  flashinfer-cubin             ['cpu', 'cu129']
  vllm-v0-26-0-cu129           ['cu129']
```

Every `nvidia-*` package in the lock resolves from PyPI or
`download.pytorch.org` instead.

## This does not stop pypi.nvidia.com being used

Worth stating explicitly, since it looks contradictory in the lock:
`nvidia-cublas-cu12` is resolved from the PyTorch cu129 index but its wheels are
*hosted* on `pypi.nvidia.com` — PyTorch's index links to NVIDIA's host rather
than rehosting the artifacts.

```toml
[[package]]
name = "nvidia-cublas-cu12"
source = { registry = "https://download.pytorch.org/whl/cu129" }
wheels = [
    { url = "https://pypi.nvidia.com/nvidia-cublas-cu12/..." },
]
```

That download follows the URL recorded in `uv.lock` and is unaffected by
whether the index is declared here.

## Verification

Regenerating and relocking leaves `uv.lock` **byte-identical** across all 356
packages — the strongest available evidence that neither index participated in
resolution:

```
$ python tools/gen_cuda_deps.py cuda_deps.toml --pyproject pyproject.toml
$ uv lock
Resolved 356 packages in 2ms
$ git diff --quiet uv.lock && echo "byte-identical"
byte-identical
```

- `mise run lock-check` passes
- `mise run format-check` passes
- `pytest tests/test_gen_cuda_deps.py` -- 19 passed

## Notes for reviewers

Two places still mention these names; neither is affected, but flagging so a
grep does not cause confusion:

- `CONTRIBUTING.md:870` documents that the internal NMP service pulls
  `nemo-safe-synthesizer` *from* `nv-shared-pypi-local`. That is about how NMP
  consumes this package, not how this project resolves its own dependencies, so
  it is unaffected.
- `tests/test_gen_cuda_deps.py` uses `nvidia-pypi-public` in inline fixture data
  to exercise the generator's `index =` binding support. The generator still
  supports it; the real config just does not use it. If binding
  `nvidia-cublas` to that index was intended at some point, that would be a
  deliberate change (re-adding `index = "nvidia-pypi-public"` to the cublas
  entry) rather than a reason to keep an orphaned declaration.

## Pre-Review Checklist

- [x] `mise run format && mise run check`
- [x] `mise run test` passes locally (targeted: `tests/test_gen_cuda_deps.py`)

## Other Notes

Config-only change. No dependency versions change and `uv.lock` is untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package installation configuration by removing two obsolete package sources.
  * Existing package indexes and CUDA-related configuration remain unchanged.
  * No user-facing functionality or public APIs were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->