### PR TITLE
fix(ci): restore NVSkills workflow startup

### DIFF
--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -6,11 +6,14 @@ name: Request NVSkills CI
 on:
   issue_comment:
     types: [created]
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
   push:
 
 jobs:
   request:
     if: >
+      github.event_name == 'pull_request' ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         startsWith(github.event.comment.body, '/nvskills-ci')) ||
@@ -20,6 +23,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      statuses: read
     uses: NVIDIA/skills/.github/workflows/team-request.yml@main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary

- Trigger the NVSkills requester on pull request lifecycle events.
- Grant the shared workflow the required `statuses: read` permission.
- Preserve the existing issue-comment and trusted signature-push paths.

Ports the caller-contract fix from NVIDIA-NeMo/Anonymizer#242. Safe Synthesizer currently has repeated startup failures because the shared `NVIDIA/skills` workflow now requires pull request status access.

## Validation

- [x] `prek run --files .github/workflows/request-nvskills-ci.yml`
- [x] `mise run format-check`
- [x] YAML parse check
- [ ] Unit, end-to-end, and container suites were not run because this is a workflow-only change.

## Other Notes

No linked issue required: maintainer-owned CI workflow repair.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated pull request checks to run for additional pull request events.
  * Enabled the required read access for commit status information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->