### PR TITLE
fix(config): reject null rope scaling factor cleanly

### DIFF
--- a/src/nemo_safe_synthesizer/configurator/validators.py
+++ b/src/nemo_safe_synthesizer/configurator/validators.py
@@ -150,20 +150,26 @@ class ValueValidator:
         return core_schema.with_info_after_validator_function(self.validate, handler(source_type))
 
 
-def range_validator(value: int | float, func: Callable) -> bool:
+def range_validator(value: int | float | str | None, func: Callable) -> bool:
     """Check a numeric value against ``func``, passing ``"auto"`` sentinels unconditionally.
 
     ``func`` is typically a predicate that asserts a numeric range (e.g.
     non-negative, within ``(0, 1)``).
 
     Args:
-        value: The value to validate -- may be a number or the string ``"auto"``.
+        value: The value to validate -- may be a number, ``None``, or the string ``"auto"``.
         func: Predicate applied when ``value`` is numeric (e.g. ``lambda v: v >= 0``).
 
     Returns:
         ``True`` if ``value`` is ``"auto"`` or ``func(value)`` is truthy.
+        ``None`` is rejected cleanly so callers produce a validation error
+        instead of leaking comparison ``TypeError`` exceptions.
     """
-    return True if value == "auto" else func(value)
+    if value == "auto":
+        return True
+    if value is None:
+        return False
+    return func(value)
 
 
 AutoParamRangeValidator = ValueValidator(lambda p: range_validator(p, lambda v: v >= 0))

--- a/tests/config/test_nss_config.py
+++ b/tests/config/test_nss_config.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from collections.abc import Callable
 from typing import Annotated, Literal
 
 import pytest
@@ -12,9 +13,11 @@ from nemo_safe_synthesizer.config import (
     PiiReplacerConfig,
     SafeSynthesizerParameters,
     TimeSeriesParameters,
+    TrainingHyperparams,
 )
 from nemo_safe_synthesizer.configurator.parameters import Parameters
 from nemo_safe_synthesizer.configurator.validators import ValueValidator
+from nemo_safe_synthesizer.sdk.config_builder import ConfigBuilder
 
 
 class SubGroup(Parameters):
@@ -95,6 +98,35 @@ class TestValueValidation:
         # This should fail validation
         with pytest.raises(ValidationError):
             TestParams(validation_ratio=1.2)
+
+
+class TestTrainingHyperparams:
+    @pytest.mark.parametrize(
+        "validate",
+        [
+            pytest.param(
+                lambda: TrainingHyperparams.model_validate({"rope_scaling_factor": None}),
+                id="model_validate",
+            ),
+            pytest.param(
+                lambda: TrainingHyperparams.from_yaml_str("rope_scaling_factor: null\n"),
+                id="section_yaml",
+            ),
+            pytest.param(
+                lambda: SafeSynthesizerParameters.from_yaml_str("training:\n  rope_scaling_factor: null\n"),
+                id="top_level_yaml",
+            ),
+            pytest.param(
+                lambda: ConfigBuilder().with_train({"rope_scaling_factor": None}),
+                id="builder",
+            ),
+        ],
+    )
+    def test_rope_scaling_factor_null_rejected_as_validation_error(self, validate: Callable[[], object]):
+        with pytest.raises(ValidationError) as exc_info:
+            validate()
+
+        assert "rope_scaling_factor" in str(exc_info.value)
 
 
 class TestParametersClass:


### PR DESCRIPTION
<!-- SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
<!-- SPDX-License-Identifier: Apache-2.0 -->

<!-- Thank you for contributing to Safe Synthesizer! -->

# Summary
<!-- Brief description of changes -->

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [ ] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

<!-- Please add the issue number that should be closed when this PR is merged. -->
- Closes #<issue>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration validation for range-based settings.
  * Invalid null values now consistently produce clear validation errors across supported configuration formats and builder workflows.

* **Tests**
  * Added coverage for direct, section-level YAML, top-level YAML, and configuration-builder validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->