### PR TITLE
chore: Disable dependabot PRs to bump python deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,18 +3,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
-    commit-message:
-      prefix: "chore(deps)"
-    # constraints.txt is generated from [tool.uv] constraint-dependencies in pyproject.toml
-    # via tools/patch_dependabot.py; do not update it independently.
-    exclude-paths:
-      - "constraints.txt"
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary
- Remove the `pip` ecosystem from `.github/dependabot.yml` so Dependabot no longer opens Python dependency update PRs
- Keep weekly GitHub Actions version updates with the existing cooldown

## Test plan
- [ ] Confirm Dependabot alerts still appear at `/security/dependabot`
- [ ] Confirm no new `dependabot/pip` PRs are opened after the next weekly run
- [ ] Confirm Actions group bump PRs continue as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed automated weekly update checks for Python dependencies.
  * Continued automated update checks for GitHub Actions dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->