### PR TITLE
docs: disclose human review status in pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,17 @@
 # Summary
 <!-- Brief description of changes -->
 
+## Human review
+
+Select one:
+
+- [ ] No human review; automated review only
+- [ ] Partially reviewed or spot-checked by a human
+- [ ] Complete diff reviewed by a human
+- [ ] Complete diff reviewed and verified by a human
+
+Verification performed:
+
 ## Pre-Review Checklist
 
 <!-- These checks should be completed before a PR is reviewed, -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,12 +8,12 @@
 
 ## Human review
 
-Select one:
+Select exactly one. The default is no human review; uncheck it when choosing another level.
 
-- [ ] No human review; automated review only
-- [ ] Partially reviewed or spot-checked by a human
-- [ ] Complete diff reviewed by a human
-- [ ] Complete diff reviewed and verified by a human
+- [x] ⚪ No human review; automated review only
+- [ ] 🟡 Partially reviewed or spot-checked by a human
+- [ ] 🔵 Complete diff reviewed by a human
+- [ ] 🟢 Complete diff reviewed and verified by a human
 
 Verification performed:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,8 @@ Feature branches off `main`. Branch names often include an issue number prefix (
 
 Do not commit unless the user asks for a commit or PR work. When committing, all commits require DCO sign-off and GPG signing. Always use `git commit --signoff --gpg-sign` (or `-s -S`) -- never write the `Signed-off-by` trailer manually, and never pass `--no-gpg-sign`.
 
+When creating or updating a pull request, complete the Human review section accurately. Do not claim that a human reviewed or verified a change unless the human explicitly confirmed it; otherwise select “No human review; automated review only.”
+
 Shell scripting: never use `~` inside double-quoted strings -- it does not expand. Use `$HOME` or an absolute path instead.
 
 Testing gotchas: `asyncio_mode = auto` in `pytest.ini` -- async tests work without `@pytest.mark.asyncio`. The `unit_test` marker is deprecated; use `unit`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ Feature branches off `main`. Branch names often include an issue number prefix (
 
 Do not commit unless the user asks for a commit or PR work. When committing, all commits require DCO sign-off and GPG signing. Always use `git commit --signoff --gpg-sign` (or `-s -S`) -- never write the `Signed-off-by` trailer manually, and never pass `--no-gpg-sign`.
 
-When creating or updating a pull request, complete the Human review section accurately. Do not claim that a human reviewed or verified a change unless the human explicitly confirmed it; otherwise select “No human review; automated review only.”
+When creating or updating a pull request, complete the Human review section in `.github/PULL_REQUEST_TEMPLATE.md` accurately. Keep its default checkbox unless a human explicitly confirms a higher review level; then select exactly that level and report only review or verification the human confirmed.
 
 Shell scripting: never use `~` inside double-quoted strings -- it does not expand. Use `$HOME` or an absolute path instead.
 


### PR DESCRIPTION
## Summary
- add four human-review disclosure levels to the pull request template
- preselect the safe default and use neutral status lights to make review depth easy to scan
- instruct agents to report human review accurately without claiming unconfirmed review

## Human review

Select exactly one. The default is no human review; uncheck it when choosing another level.

- [ ] ⚪ No human review; automated review only
- [ ] 🟡 Partially reviewed or spot-checked by a human
- [ ] 🔵 Complete diff reviewed by a human
- [x] 🟢 Complete diff reviewed and verified by a human

Verification performed: Agent compared the final diff with the linked proposal and ran the checks below, and also checked by human

## Test plan
- [x] `mise run format-check`
- [x] `mise run lock-check`
- [ ] `mise run test` -- attempted; existing vLLM-dependent tests cannot run on macOS because `vllm` is unavailable
- [ ] `mise run typecheck` -- existing `vllm` and `pynvml` imports are unavailable on macOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Human review section to the pull request template, including review-status options and verification details.
  * Added guidance for accurately documenting whether human review was completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->