### PR TITLE
fix: dataset registry example uses package name not CLI name

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ When a dataset registry is provided, you can use dataset names defined in the re
 For example:
 
 ```bash
-nemo-safe-synthesizer run --dataset-registry my_registry.yaml --data-source my_dataset
+safe-synthesizer run --dataset-registry my_registry.yaml --data-source my_dataset
 ```
 
 This will load the dataset from the url plus apply any overrides for `my_dataset` from the registry YAML.

--- a/tests/test_readme_cli_name.py
+++ b/tests/test_readme_cli_name.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def test_readme_dataset_registry_uses_cli_name():
+    readme = README.read_text(encoding="utf-8")
+    # Positive check: the documented dataset-registry example must use the CLI
+    # entry point name, not the Python package name.
+    assert "safe-synthesizer run --dataset-registry" in readme, (
+        "README dataset-registry example should show the CLI entry point "
+        "'safe-synthesizer', not the Python package name"
+    )
+    assert "nemo-safe-synthesizer run" not in readme, (
+        "README dataset-registry example uses package name 'nemo-safe-synthesizer' "
+        "instead of CLI entry point 'safe-synthesizer'"
+    )


### PR DESCRIPTION
This PR corrects the documentation in `README.md`: dataset registry example uses package name not CLI name.

## Changes
- `README.md`: dataset registry example uses package name not CLI name.

## Details
```diff
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-```bash
-nemo-safe-synthesizer run --dataset-registry my_registry.yaml --data-source my_dataset
-```
+```bash
+safe-synthesizer run --dataset-registry my_registry.yaml --data-source my_dataset
+```
```

## Tests
- `tests/test_readme_cli_name.py`

```diff
--- /dev/null
+++ b/tests/test_readme_cli_name.py
@@ -0,0 +1,11 @@
+from pathlib import Path
+
+README = Path(__file__).resolve().parents[1] / "README.md"
+
+
+def test_readme_dataset_registry_uses_cli_name():
+    readme = README.read_text(encoding="utf-8")
+    assert "nemo-safe-synthesizer run" not in readme, (
+        "README dataset-registry example uses package name 'nemo-safe-synthesizer' "
+        "instead of CLI entry point 'safe-synthesizer'"
+    )
```

## Contributor guidelines

Per this repo's [CONTRIBUTING.md](CONTRIBUTING.md):
- All commits are signed off (`Signed-off-by` trailer, DCO).
- The change is contained in a single commit (squashed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the dataset registry example to use the current `safe-synthesizer` command.
  * Removed the outdated `nemo-safe-synthesizer` package reference.

* **Tests**
  * Added a regression test to verify README examples use the correct command.
  * Added validation to prevent outdated CLI references from reappearing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->