### PR TITLE
fix: provision Triton compiler on Brev

### DIFF
--- a/script/brev/README.md
+++ b/script/brev/README.md
@@ -16,8 +16,9 @@ update it in the console for the change to take effect.
 ### Files
 
 - `setup.sh`: Pasted into the Launchable's Setup Script field. Installs the CUDA
-  build of Safe Synthesizer into a dedicated venv, registers it as the default Jupyter
-  kernel, and drops the tutorial notebooks in `$HOME`.
+  build of Safe Synthesizer into a dedicated venv, provisions Triton's runtime compiler,
+  registers the venv as the default Jupyter kernel, and drops the tutorial notebooks in
+  `$HOME`.
 - `welcome.md`: Added to the Launchable's Source files so it renders on the Launchable
   webpage and appears as the customer's `$HOME/welcome.md`.
 
@@ -113,9 +114,12 @@ hard way on a real instance.
 - The setup script has a 16 KiB limit. Brev rejects anything larger, which is why
   the script carries short comments pointing here rather than full explanations. Check
   `wc -c script/brev/setup.sh` before pasting.
-- The script runs unprivileged. Brev executes it as the instance user, not root, so
-  `/usr/local/bin`, `/var/log`, and `/etc/profile.d` are all unwritable. Everything
-  installs under `$HOME`.
+- The script runs as the instance user, not root, so Python and customer-facing assets
+  install under `$HOME`. The sole host-level dependency is `gcc` plus `libc6-dev`:
+  Triton JIT-compiles a CUDA driver shim the first time vLLM uses the GPU. Some provider
+  images include these packages and others do not, so the script installs them with
+  non-interactive passwordless `sudo` when needed. If the provider does not grant that
+  permission, setup fails before presenting the notebooks as ready.
 - The venv is deliberately separate from Brev's. Installing `[cu129,engine]` into
   `$HOME/.venv` would resolve torch, vllm, and flashinfer alongside jupyterlab's own
   pins. If that breaks the notebook server, the customer's only interface is gone and

--- a/script/brev/setup.sh
+++ b/script/brev/setup.sh
@@ -75,6 +75,19 @@ else
   log "WARNING: nvidia-smi not found. Training and generation will not work."
 fi
 
+# Triton needs a C compiler on first GPU use.
+if ! command -v gcc >/dev/null 2>&1 || [[ ! -f /usr/include/stdlib.h ]]; then
+  if ! command -v sudo >/dev/null 2>&1 || ! sudo -n true; then
+    log "ERROR: Triton requires gcc and libc6-dev, but passwordless sudo is unavailable."
+    exit 1
+  fi
+  log "installing Triton runtime compiler"
+  sudo -n apt-get update
+  sudo -n apt-get install -y --no-install-recommends gcc libc6-dev
+else
+  log "Triton runtime compiler already present"
+fi
+
 # uv -- installed into ~/.local/bin, which needs no privileges.
 
 if [[ "$(uv --version 2>/dev/null | awk '{print $2}')" != "${UV_VERSION}" ]]; then


### PR DESCRIPTION
## Summary
- install `gcc` and `libc6-dev` when a Brev provider image omits them
- fail during provisioning when the required passwordless sudo access is unavailable
- document Triton's runtime compiler requirement

## Test plan
- [x] `mise run validate`
- [x] `bash -n script/brev/setup.sh`
- [x] verify `script/brev/setup.sh` remains below Brev's 16 KiB limit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Setup now provisions Triton’s runtime compiler prerequisites, including `gcc` and required development headers.
  * Clearly reports whether compiler dependencies were installed or already available.

* **Bug Fixes**
  * Setup now stops with an actionable error when required passwordless installation permissions are unavailable.

* **Documentation**
  * Updated setup documentation to describe compiler provisioning and permission requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->