### PR TITLE
docs: Fix binary name in README dataset registry example

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ When a dataset registry is provided, you can use dataset names defined in the re
 For example:
 
 ```bash
-nemo-safe-synthesizer run --dataset-registry my_registry.yaml --data-source my_dataset
+safe-synthesizer run --dataset-registry my_registry.yaml --data-source my_dataset
 ```
 
 This will load the dataset from the url plus apply any overrides for `my_dataset` from the registry YAML.


### PR DESCRIPTION
# Summary

Fix typo/wrong binary name in example CLI usage in README.

## Human review

Select exactly one. The default is no human review; uncheck it when choosing another level.

- [ ] ⚪ No human review; automated review only
- [ ] 🟡 Partially reviewed or spot-checked by a human
- [ ] 🔵 Complete diff reviewed by a human
- [x] 🟢 Complete diff reviewed and verified by a human

Verification performed: @kendrickb-nvidia 

## Pre-Review Checklist

<!-- These checks should be completed before a PR is reviewed, -->
<!-- but you can submit a draft early to indicate that the issue is being worked on. -->

Ensure that the following pass:

- [x] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

<!-- These checks need to be completed before a PR is merged, -->
<!-- but as PRs often change significantly during review, -->
<!-- it's OK for them to be incomplete when review is first requested. -->

- [ ] New or updated tests for any fix or new behavior
- [ ] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the dataset registry example to use the current `safe-synthesizer` CLI command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->