### PR TITLE
chore: Add composite actions to dependabot and fix comments"

### DIFF
--- a/.github/actions/detect-changes/action.yml
+++ b/.github/actions/detect-changes/action.yml
@@ -63,7 +63,7 @@ runs:
     # (b) dorny/paths-filter can diff against git history on push events.
     - name: Detect changed paths
       id: filter
-      uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
+      uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
       with:
         filters: |
           src:

--- a/.github/actions/setup-gpu-test-env/action.yml
+++ b/.github/actions/setup-gpu-test-env/action.yml
@@ -33,7 +33,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup uv cache
-      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       with:
         enable-cache: true
         cache-dependency-glob: |

--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -47,7 +47,7 @@ runs:
   steps:
     - name: Checkout repository
       if: inputs.checkout == 'true'
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: ${{ inputs.ref || github.ref }}
         fetch-depth: ${{ inputs.fetch-depth }}
@@ -90,13 +90,13 @@ runs:
 
     - name: Set up Python ${{ inputs.python-version }}
       if: inputs.python-version != ''
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ inputs.python-version }}
 
     - name: Set up Python from .python-version
       if: inputs.python-version == ''
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version-file: ".python-version"
 
@@ -126,7 +126,7 @@ runs:
 
     - name: Install uv (fallback when mise is skipped)
       if: inputs.bootstrap-tools != 'true'
-      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6
+      uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # v6.8.0
       with:
         enable-cache: true
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,9 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories:
+      - "/"
+      - "/.github/actions/*"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -237,6 +237,16 @@ The workflow performs the following steps:
 5. Create GitHub release
 6. Publish versioned documentation for final releases
 
+## Third-party action pinning
+
+Every `uses:` that is not a local composite (`./.github/actions/...`) must pin a 40-character commit SHA, with the full release tag in a trailing comment:
+
+```yaml
+uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+```
+
+Do not pin a floating tag or branch (`@v7`, `@main`). Local composites stay unpinned. If the upstream repo has no version tags, pin the commit SHA and comment the ref name (`# main`), this fallback is only allowed for other NVIDIA owned repos. Dependabot's `github-actions` updates keep the SHA and comment in sync.
+
 ## Reusable Workflows
 
 Compliance workflows reuse templates from [NVIDIA-NeMo/FW-CI-templates](https://github.com/NVIDIA-NeMo/FW-CI-templates), pinned to immutable commit SHAs in the workflow files:

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -239,13 +239,21 @@ The workflow performs the following steps:
 
 ## Third-party action pinning
 
-Every `uses:` that is not a local composite (`./.github/actions/...`) must pin a 40-character commit SHA, with the full release tag in a trailing comment:
+Pin every `uses:` that references an external GitHub repository (`owner/repo/...`)
+to a 40-character commit SHA, with the full release tag in a trailing comment:
 
 ```yaml
 uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 ```
 
-Do not pin a floating tag or branch (`@v7`, `@main`). Local composites stay unpinned. If the upstream repo has no version tags, pin the commit SHA and comment the ref name (`# main`), this fallback is only allowed for other NVIDIA owned repos. Dependabot's `github-actions` updates keep the SHA and comment in sync.
+This applies in workflow files and in composite `action.yml` files. Do not pin a
+floating tag or branch (`@v7`, `@main`). Local composites (`./.github/actions/...`)
+and local reusable workflows (`./.github/workflows/...`) stay unpinned.
+
+If the upstream repo has no version tags, pin the commit SHA and comment the ref
+name (`# main`). That fallback is only allowed for other NVIDIA-owned repos.
+
+Dependabot's `github-actions` updates keep the SHA and comment in sync.
 
 ## Reusable Workflows
 

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -211,14 +211,14 @@ jobs:
         run: mise run test:ci
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: matrix.python-version == '3.13'
         with:
           name: coverage-report
           path: coverage.json
           retention-days: 30
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         if: matrix.python-version == '3.13'
         with:
           files: coverage.json

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -47,15 +47,15 @@ jobs:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: python
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: "/language:python"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -42,7 +42,7 @@ jobs:
     name: Apply area labels
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v7
+      - uses: actions/labeler@bf12e9b00b37c5c0ca2b87b79b2daf7891dbda13 # v7.0.0
         with:
           configuration-path: .github/labeler.yml
           sync-labels: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Verify clean end-user wheel install
         run: mise run release:verify-wheel
 
-      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: nemo-safe-synthesizer-${{ steps.build.outputs.version }}
           path: dist/*.whl
@@ -113,7 +113,7 @@ jobs:
           fetch-depth: 0
 
       - name: Download wheel artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nemo-safe-synthesizer-${{ needs.publish-wheel.outputs.version }}
           path: dist/

--- a/.github/workflows/request-nvskills-ci.yml
+++ b/.github/workflows/request-nvskills-ci.yml
@@ -24,6 +24,6 @@ jobs:
       contents: read
       pull-requests: read
       statuses: read
-    uses: NVIDIA/skills/.github/workflows/team-request.yml@main
+    uses: NVIDIA/skills/.github/workflows/team-request.yml@3a38625bf3e863eb9f26ea0d985130ddfb5c66ae # main
     secrets:
       NVSKILLS_CI_DISPATCH_TOKEN: ${{ secrets.NVSKILLS_CI_DISPATCH_TOKEN }}

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -821,7 +821,8 @@ readonly OUTPUT_DIR="${1:?Usage: $0 <output-dir>}"
 - SPDX copyright headers at top
 - Unquoted values unless special characters require them
 - Newline at end of file
-- GitHub Actions workflows: `#` with dashes for section dividers. Pin third-party `uses:` to a commit SHA with a full version comment; see [`.github/workflows/README.md`](.github/workflows/README.md).
+- GitHub Actions workflows: `#` with dashes for section dividers.
+- GitHub Actions `uses:` in workflows and composite `action.yml` files: pin every external repository reference (`owner/repo/...`) to a commit SHA with a full version comment. Local composites (`./.github/actions/...`) and local reusable workflows (`./.github/workflows/...`) stay unpinned. See [`.github/workflows/README.md`](.github/workflows/README.md).
 
 ### TOML
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -821,7 +821,7 @@ readonly OUTPUT_DIR="${1:?Usage: $0 <output-dir>}"
 - SPDX copyright headers at top
 - Unquoted values unless special characters require them
 - Newline at end of file
-- GitHub Actions workflows: `#` with dashes for section dividers
+- GitHub Actions workflows: `#` with dashes for section dividers. Pin third-party `uses:` to a commit SHA with a full version comment; see [`.github/workflows/README.md`](.github/workflows/README.md).
 
 ### TOML
 


### PR DESCRIPTION
# Summary

- Add composite actions (in `.github/actions/`) to Dependabot scope for updating deps. Previously these were excluded, so some deps in `.github/actions/` are older and have diverged from the version used in `.github/workflows/`. (Will let the next Dependabot update actually change pinned versions.)
- Document our rule that all non-composite `uses:` are pinned to a commit SHA with the full version in a trailling comment.
- Update existing comments to match the above guidance, adding minor/patch versions to several comments.
- Update actions/labeler to pin a SHA commit instead of the v7 label.

## Human review

Select exactly one. The default is no human review; uncheck it when choosing another level.

- [ ] ⚪ No human review; automated review only
- [ ] 🟡 Partially reviewed or spot-checked by a human
- [ ] 🔵 Complete diff reviewed by a human
- [x] 🟢 Complete diff reviewed and verified by a human

Verification performed:

## Pre-Review Checklist

Ensure that the following pass:

- [x] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

- [ ] New or updated tests for any fix or new behavior
- [x] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automation metadata with precise action versions.
  * Pinned workflow dependencies to immutable commit references for more predictable execution.
  * Expanded automated dependency monitoring to cover reusable local actions.

* **Documentation**
  * Added guidance for securely pinning third-party workflow actions.
  * Updated contribution conventions to require commit SHA pins and version comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->