### PR TITLE
feat: add PII replacement plan interfaces

### DIFF
--- a/docs/product-overview/pii_replacement.md
+++ b/docs/product-overview/pii_replacement.md
@@ -27,9 +27,9 @@ replace_pii:
   replacement_plan: auto_discovery
 ```
 
-### Embedded plan
+### Inline plan
 
-An embedded plan is written directly under `replacement_plan` in the main NSS
+An inline plan is written directly under `replacement_plan` in the main NSS
 configuration:
 
 ```yaml
@@ -49,7 +49,7 @@ replace_pii:
 
 ### Plan file
 
-A plan file is a separate YAML file containing the same mapping as an embedded
+A plan file is a separate YAML file containing the same mapping as an inline
 plan. Set `replacement_plan` to its path:
 
 ```yaml
@@ -57,7 +57,7 @@ replace_pii:
   replacement_plan: ./pii_replacement_plan.yaml
 ```
 
-Embedded plans and plan files are authoritative: NSS validates them against the
+Inline plans and plan files are authoritative: NSS validates them against the
 input dataframe but does not run heuristic or LLM discovery. This bypass applies
 only to plan discovery. If `llm` is configured, the replacement executor can
 still use it to replace PII found inside free-text columns named by the plan.

--- a/docs/product-overview/pii_replacement.md
+++ b/docs/product-overview/pii_replacement.md
@@ -17,7 +17,7 @@ call `.with_replace_pii(enable=False)` to run the synthesis pipeline.
 `replace_pii.replacement_plan` accepts three forms.
 
 The `replace_pii` configuration has an integer `schema_version`. This release
-accepts version `1`; an omitted version is interpreted as version `1`. NSS
+accepts version `3`; an omitted version is interpreted as version `3`. NSS
 includes the version whenever it serializes the configuration.
 
 ### Automatic discovery
@@ -28,7 +28,7 @@ validating the final plan.
 
 ```yaml
 replace_pii:
-  schema_version: 1
+  schema_version: 3
   replacement_plan: auto_discovery
 ```
 
@@ -39,7 +39,7 @@ configuration:
 
 ```yaml
 replace_pii:
-  schema_version: 1
+  schema_version: 3
   replacement_plan:
     scope: dataframe
     columns_to_replace:
@@ -59,7 +59,7 @@ A plan file is a separately versioned YAML document containing
 `schema_version` followed by the same fields as an inline plan:
 
 ```yaml
-schema_version: 1
+schema_version: 3
 scope: dataframe
 columns_to_replace:
   - column_name: email
@@ -70,7 +70,7 @@ Set `replacement_plan` to its path:
 
 ```yaml
 replace_pii:
-  schema_version: 1
+  schema_version: 3
   replacement_plan: ./pii_replacement_plan.yaml
 ```
 
@@ -122,7 +122,7 @@ free-text columns in the resolved plan.
 
 ```yaml
 replace_pii:
-  schema_version: 1
+  schema_version: 3
   replacement_plan: auto_discovery
   llm:
     model_id: nvidia/nemotron-3-ultra-550b-a55b

--- a/docs/product-overview/pii_replacement.md
+++ b/docs/product-overview/pii_replacement.md
@@ -16,6 +16,10 @@ call `.with_replace_pii(enable=False)` to run the synthesis pipeline.
 
 `replace_pii.replacement_plan` accepts three forms.
 
+The `replace_pii` configuration has an integer `schema_version`. This release
+accepts version `1`; an omitted version is interpreted as version `1`. NSS
+includes the version whenever it serializes the configuration.
+
 ### Automatic discovery
 
 Use `auto_discovery` to run the heuristic plan discoverer. When `llm` is
@@ -24,6 +28,7 @@ validating the final plan.
 
 ```yaml
 replace_pii:
+  schema_version: 1
   replacement_plan: auto_discovery
 ```
 
@@ -34,6 +39,7 @@ configuration:
 
 ```yaml
 replace_pii:
+  schema_version: 1
   replacement_plan:
     scope: dataframe
     columns_to_replace:
@@ -49,11 +55,22 @@ replace_pii:
 
 ### Plan file
 
-A plan file is a separate YAML file containing the same mapping as an inline
-plan. Set `replacement_plan` to its path:
+A plan file is a separately versioned YAML document containing
+`schema_version` followed by the same fields as an inline plan:
+
+```yaml
+schema_version: 1
+scope: dataframe
+columns_to_replace:
+  - column_name: email
+    entity_type: email
+```
+
+Set `replacement_plan` to its path:
 
 ```yaml
 replace_pii:
+  schema_version: 1
   replacement_plan: ./pii_replacement_plan.yaml
 ```
 
@@ -105,6 +122,7 @@ free-text columns in the resolved plan.
 
 ```yaml
 replace_pii:
+  schema_version: 1
   replacement_plan: auto_discovery
   llm:
     model_id: nvidia/nemotron-3-ultra-550b-a55b

--- a/docs/product-overview/pii_replacement.md
+++ b/docs/product-overview/pii_replacement.md
@@ -7,8 +7,8 @@ PII replacement v3 uses a dataset-specific replacement plan. The plan names
 the columns NSS should replace, the entity type in each column, optional format
 patterns, and dependencies between related columns.
 
-This branch provides the configuration and plan-resolution contract. The
-replacement executor and production LLM adapter will be added separately. Until
+This branch provides the configuration and plan-resolution contract plus
+plan-only CLI and SDK workflows. Replacement execution remains deferred. Until
 the executor is available, set `replace_pii: null`, pass `--no-replace-pii`, or
 call `.with_replace_pii(enable=False)` to run the synthesis pipeline.
 
@@ -61,6 +61,40 @@ Embedded plans and plan files are authoritative: NSS validates them against the
 input dataframe but does not run heuristic or LLM discovery. This bypass applies
 only to plan discovery. If `llm` is configured, the replacement executor can
 still use it to replace PII found inside free-text columns named by the plan.
+
+## Plan-only workflow
+
+Resolve and save a plan from the full input dataframe without running holdout,
+model metadata, replacement, training, generation, or evaluation:
+
+```bash
+safe-synthesizer run replace-pii --plan-only \
+  --config config.yaml \
+  --data-source data.csv \
+  --run-path ./pii-plan
+```
+
+The command writes `./pii-plan/pii_replacement_plan.yaml`. Without
+`--run-path`, it writes the same filename in the standard timestamped NSS run
+directory under `--artifact-path`.
+
+The matching SDK interface returns the resolved plan and writes YAML only when
+an output path is supplied:
+
+```python
+from nemo_safe_synthesizer.config import SafeSynthesizerParameters
+from nemo_safe_synthesizer.sdk.library_builder import SafeSynthesizer
+
+config = SafeSynthesizerParameters.from_yaml("config.yaml")
+plan = (
+    SafeSynthesizer(config)
+    .with_data_source("data.csv")
+    .plan_pii_replacement("pii_replacement_plan.yaml")
+)
+```
+
+The generated standalone plan can be reviewed, edited, and reused as
+`replace_pii.replacement_plan` in a later run.
 
 ## LLM-assisted planning and free-text replacement
 

--- a/docs/product-overview/pii_replacement.md
+++ b/docs/product-overview/pii_replacement.md
@@ -3,7 +3,89 @@
 
 # PII Replacement
 
-PII replacement v3 will be added and documented in a later update.
+PII replacement v3 uses a dataset-specific replacement plan. The plan names
+the columns NSS should replace, the entity type in each column, optional format
+patterns, and dependencies between related columns.
 
-On this branch, set `replace_pii: null`, pass `--no-replace-pii`, or call
-`.with_replace_pii(enable=False)` to run NeMo Safe Synthesizer.
+This branch provides the configuration and plan-resolution contract. The
+replacement executor and production LLM adapter will be added separately. Until
+the executor is available, set `replace_pii: null`, pass `--no-replace-pii`, or
+call `.with_replace_pii(enable=False)` to run the synthesis pipeline.
+
+## Replacement plan sources
+
+`replace_pii.replacement_plan` accepts three forms.
+
+### Automatic discovery
+
+Use `auto_discovery` to run the heuristic plan discoverer. When `llm` is
+configured, NSS passes the heuristic result to the LLM plan enhancer before
+validating the final plan.
+
+```yaml
+replace_pii:
+  replacement_plan: auto_discovery
+```
+
+### Embedded plan
+
+An embedded plan is written directly under `replacement_plan` in the main NSS
+configuration:
+
+```yaml
+replace_pii:
+  replacement_plan:
+    scope: dataframe
+    columns_to_replace:
+      - column_name: full_name
+        entity_type: full_name
+        pattern: "{First} {Last}"
+      - column_name: email
+        entity_type: email
+        pattern: "{f}.{last}@{domain}"
+        depends_on:
+          - column_name: full_name
+```
+
+### Plan file
+
+A plan file is a separate YAML file containing the same mapping as an embedded
+plan. Set `replacement_plan` to its path:
+
+```yaml
+replace_pii:
+  replacement_plan: ./pii_replacement_plan.yaml
+```
+
+Embedded plans and plan files are authoritative: NSS validates them against the
+input dataframe but does not run heuristic or LLM discovery. This bypass applies
+only to plan discovery. If `llm` is configured, the replacement executor can
+still use it to replace PII found inside free-text columns named by the plan.
+
+## LLM-assisted planning and free-text replacement
+
+The `llm` mapping configures the OpenAI-compatible inference service shared by
+plan enhancement and free-text replacement. During automatic discovery, the LLM
+enhances the heuristic plan. During execution, the same service processes
+free-text columns in the resolved plan.
+
+```yaml
+replace_pii:
+  replacement_plan: auto_discovery
+  llm:
+    endpoint_url: https://integrate.api.nvidia.com/v1
+    model_id: nvidia/nemotron-3-ultra-550b-a55b
+    max_workers: 8
+```
+
+An empty mapping (`llm: {}`) enables the existing NSS inference defaults. A
+local vLLM OpenAI-compatible server can be selected with an endpoint such as
+`http://localhost:8000/v1` and its served model ID.
+
+Supply the inference API key at runtime through `NSS_INFERENCE_KEY` or the
+`--inference-api-key` CLI option. NSS does not store the key in configuration or
+plan artifacts.
+
+LLM operations can send bounded raw cell samples during plan enhancement and raw
+free-text values during replacement. Do not enable them unless the endpoint is
+approved to receive the input data.

--- a/docs/product-overview/pii_replacement.md
+++ b/docs/product-overview/pii_replacement.md
@@ -107,14 +107,14 @@ free-text columns in the resolved plan.
 replace_pii:
   replacement_plan: auto_discovery
   llm:
-    endpoint_url: https://integrate.api.nvidia.com/v1
     model_id: nvidia/nemotron-3-ultra-550b-a55b
     max_workers: 8
 ```
 
-An empty mapping (`llm: {}`) enables the existing NSS inference defaults. A
-local vLLM OpenAI-compatible server can be selected with an endpoint such as
-`http://localhost:8000/v1` and its served model ID.
+An empty mapping (`llm: {}`) enables the existing NSS inference defaults. Set
+the OpenAI-compatible endpoint at runtime through `NSS_INFERENCE_ENDPOINT` or
+the `--inference-endpoint-url` CLI option. For example, a local vLLM server may
+use `NSS_INFERENCE_ENDPOINT=http://localhost:8000/v1` with its served model ID.
 
 Supply the inference API key at runtime through `NSS_INFERENCE_KEY` or the
 `--inference-api-key` CLI option. NSS does not store the key in configuration or

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -291,8 +291,15 @@ for the full API reference.
 
 ## Replacing PII
 
-PII replacement v3 will be added and documented in a later update. On this
-branch, set `replace_pii: null` or use `--no-replace-pii`.
+PII replacement accepts automatic discovery, a plan embedded in the main NSS
+configuration, or a path to a separate plan YAML. See
+[PII Replacement](../product-overview/pii_replacement.md) for the plan-source
+definitions, examples, and the shared LLM configuration for plan enhancement and
+free-text replacement.
+
+The replacement executor is not available on this branch. Set
+`replace_pii: null` or use `--no-replace-pii` when running the synthesis
+pipeline.
 
 ---
 

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -291,7 +291,7 @@ for the full API reference.
 
 ## Replacing PII
 
-PII replacement accepts automatic discovery, a plan embedded in the main NSS
+PII replacement accepts automatic discovery, a plan written inline in the main NSS
 configuration, or a path to a separate plan YAML. See
 [PII Replacement](../product-overview/pii_replacement.md) for the plan-source
 definitions, examples, and the shared LLM configuration for plan enhancement and

--- a/docs/user-guide/running.md
+++ b/docs/user-guide/running.md
@@ -118,6 +118,7 @@ You can also run stages individually:
 
 - `safe-synthesizer run train` -- train only, saves the adapter
 - `safe-synthesizer run generate` -- generate only (use `--auto-discover-adapter` or `--run-path`)
+- `safe-synthesizer run replace-pii --plan-only` -- resolve a PII replacement plan without entering the pipeline
 - SDK stepwise: `process_data()` → `train()` → `generate()` → `evaluate()`
 
 ## Pre-flight Validation
@@ -203,16 +204,17 @@ safe-synthesizer run --config config.yaml --data-source data.csv
 
 #### Common Options
 
-These options apply to `run` and `run generate`. Only `--data-source` is required;
-all others have defaults or are optional.
+These options apply to `run`, `run train`, `run generate`, and `run replace-pii`.
+Only `--data-source` is required for new runs; all others have defaults or are
+optional.
 
 | Option | Env var | Default | Description |
 |--------|---------|---------|-------------|
 | `--config` | `NSS_CONFIG` | (model defaults) | Path to YAML config file; omit to use all model defaults |
 | `--data-source` | -- | (required) | Dataset path, URL, or name from `--dataset-registry` |
 | `--artifact-path` | `NSS_ARTIFACTS_PATH` | `./safe-synthesizer-artifacts` | Base directory for all runs |
-| `--run-path` | -- | -- | Explicit run directory (for `run generate`, must point to an existing trained run) |
-| `--output-file` | -- | -- | Path to output CSV file |
+| `--run-path` | -- | -- | Explicit run directory (for `run generate`, must point to an existing trained run; for plan-only, receives the plan artifact) |
+| `--output-file` | -- | -- | Path to synthetic output CSV; unused by plan-only |
 | `--log-format` | `NSS_LOG_FORMAT` | `plain` (TTY) / `json` (non-TTY) | Console log format -- auto-detected from TTY; accepts `plain` or `json` |
 | `--log-file` | `NSS_LOG_FILE` | -- | Log file path (defaults to run directory) |
 | `--log-color` / `--no-log-color` | `NSS_LOG_COLOR` | auto | Colorize console output (auto-detected from TTY) |
@@ -274,6 +276,39 @@ Accepts the same common options and synthesis parameter override syntax as `run`
     keep their saved values. `training`, `data`, `privacy`, and `time_series`
     are always inherited from the trained run and cannot be changed at generate
     time, since they describe how the adapter was produced.
+
+### `run replace-pii --plan-only`
+
+Resolve a PII replacement plan against the full input dataframe and exit. This
+does not invoke holdout, model metadata, replacement, training, generation, or
+evaluation.
+
+```bash
+safe-synthesizer run replace-pii --plan-only \
+  --config config.yaml \
+  --data-source data.csv \
+  --run-path ./pii-plan
+```
+
+The command writes `./pii-plan/pii_replacement_plan.yaml`. When `--run-path` is
+omitted, the plan is written to the standard timestamped run directory beneath
+`--artifact-path`. `run replace-pii` without `--plan-only` remains unavailable
+until replacement execution is implemented.
+
+The SDK equivalent returns the plan object. Supplying `output_path` also writes
+the reusable YAML artifact; omitting it performs no plan write.
+
+```python
+from nemo_safe_synthesizer.config import SafeSynthesizerParameters
+from nemo_safe_synthesizer.sdk.library_builder import SafeSynthesizer
+
+config = SafeSynthesizerParameters.from_yaml("config.yaml")
+plan = (
+    SafeSynthesizer(config)
+    .with_data_source("data.csv")
+    .plan_pii_replacement(output_path="pii_replacement_plan.yaml")
+)
+```
 
 ### `run --validate`
 
@@ -536,10 +571,19 @@ See [Configuration Reference -- Data](configuration.md#data) for the full parame
 
 ## PII Replacement
 
-PII replacement v3 will be added and documented in a later update.
+PII replacement v3 supports resolving a reviewable plan from the full input
+without entering the synthesis pipeline:
 
-On this branch, set `replace_pii: null`, pass `--no-replace-pii`, or call
-`.with_replace_pii(enable=False)` before running the pipeline.
+```bash
+safe-synthesizer run replace-pii --plan-only \
+  --config config.yaml \
+  --data-source data.csv \
+  --run-path ./pii-plan
+```
+
+Replacement execution is not available on this branch. Set `replace_pii: null`,
+pass `--no-replace-pii`, or call `.with_replace_pii(enable=False)` before running
+the training and generation pipeline.
 
 ---
 

--- a/src/nemo_safe_synthesizer/cli/run.py
+++ b/src/nemo_safe_synthesizer/cli/run.py
@@ -18,6 +18,7 @@ from ..configurator.pydantic_click_options import (
     parse_overrides,
     pydantic_options,
 )
+from ..defaults import PII_REPLACEMENT_PLAN_FILENAME
 from ..errors import UserError
 from ..observability import traced_user
 from ..telemetry import DeploymentTypeEnum, TaskStatusEnum
@@ -400,7 +401,8 @@ def run(
     """Run the Safe Synthesizer end-to-end pipeline.
 
     Without a subcommand, runs the full end-to-end pipeline.
-    Use 'run train' or 'run generate' for individual stages.
+    Use 'run train' or 'run generate' for individual stages, or
+    'run replace-pii --plan-only' to resolve a PII replacement plan.
     """
     # If a subcommand is invoked, skip the default behavior
     if ctx.invoked_subcommand is not None:
@@ -450,6 +452,53 @@ def run(
             finally:
                 if hasattr(nss, "generator") and nss.generator is not None:
                     nss.generator.teardown()
+    except UserError as exc:
+        click.secho(str(exc), fg="red", err=True)
+        raise SystemExit(1)
+
+
+@run.command("replace-pii")
+@common_run_options
+@pydantic_options(SafeSynthesizerParameters, field_separator=CLI_NESTED_FIELD_SEPARATOR)
+@click.option(
+    "--plan-only",
+    is_flag=True,
+    default=False,
+    help="Resolve and write the PII replacement plan without running replacement, training, generation, or evaluation.",
+)
+def run_replace_pii(
+    plan_only: bool = False,
+    **kwargs: Any,
+) -> None:
+    """Plan PII replacement for the full input dataset.
+
+    Replacement execution is deferred; this command currently requires
+    ``--plan-only``.
+    """
+    if not plan_only:
+        raise click.UsageError("run replace-pii currently requires --plan-only")
+
+    _set_cli_deployment_type_default()
+    settings = _settings_from_run_kwargs(kwargs)
+    run_logger, config, df, workdir = common_setup(
+        settings=settings,
+        phase="replace_pii",
+        skip_wandb=True,
+    )
+
+    try:
+        with traced_user("SafeSynthesizer"):
+            from ..sdk.library_builder import SafeSynthesizer
+
+            assert df is not None
+            output_path = workdir.run_dir / PII_REPLACEMENT_PLAN_FILENAME
+            nss = SafeSynthesizer(
+                config=config,
+                workdir=workdir,
+                emit_telemetry=config.emit_telemetry,
+            ).with_data_source(df)
+            nss.plan_pii_replacement(output_path=output_path)
+            run_logger.info(f"PII replacement plan saved to: {output_path}")
     except UserError as exc:
         click.secho(str(exc), fg="red", err=True)
         raise SystemExit(1)

--- a/src/nemo_safe_synthesizer/config/replace_pii.py
+++ b/src/nemo_safe_synthesizer/config/replace_pii.py
@@ -19,7 +19,14 @@ from enum import Enum, StrEnum, auto
 from pathlib import Path
 from typing import ClassVar, Literal, Self, cast
 
-from pydantic import Field, ValidationError, field_validator, model_validator
+from pydantic import (
+    Field,
+    SerializerFunctionWrapHandler,
+    ValidationError,
+    field_validator,
+    model_serializer,
+    model_validator,
+)
 
 from ..configurator.parameters import Parameters
 from ..defaults import NSS_MANAGED_ASSETS_PATH_ENV, default_managed_assets_path
@@ -53,6 +60,7 @@ __all__ = [
 # Sentinel value for ``ReplacePiiConfig.replacement_plan`` requesting automatic
 # entity discovery instead of an explicit plan.
 AUTO_DISCOVERY = "auto_discovery"
+_CURRENT_REPLACE_PII_SCHEMA_VERSION = 1
 
 
 class EntityType(StrEnum):
@@ -643,10 +651,10 @@ class ReplacePiiConfig(Parameters):
     )
 
     schema_version: Literal[1] = Field(
-        default=1,
+        default=_CURRENT_REPLACE_PII_SCHEMA_VERSION,
         description=(
-            "Version of this replace_pii config shape. Bump when fields or plan "
-            "semantics change incompatibly; only 1 is accepted in this release."
+            "Version of this replace_pii configuration schema. Missing versions are treated as version 1; "
+            "this release accepts only version 1."
         ),
     )
     replacement_plan: PiiReplacementPlan | str = Field(
@@ -681,6 +689,30 @@ class ReplacePiiConfig(Parameters):
         if isinstance(value, Mapping):
             raise_if_removed_legacy_fields(cls, cast(Mapping[str, object], value), path=())
         return value
+
+    @model_validator(mode="before")
+    @classmethod
+    def _validate_schema_version(cls, value: object) -> object:
+        """Reject invalid or unsupported versions before validating the schema body."""
+        if not isinstance(value, Mapping):
+            return value
+        mapping = cast(Mapping[str, object], value)
+        version = mapping.get("schema_version", _CURRENT_REPLACE_PII_SCHEMA_VERSION)
+        if type(version) is not int:
+            raise ParameterError("replace_pii.schema_version must be an integer")
+        if version != _CURRENT_REPLACE_PII_SCHEMA_VERSION:
+            raise ParameterError(
+                f"replace_pii schema version {version} is unsupported; "
+                f"this NSS release supports version {_CURRENT_REPLACE_PII_SCHEMA_VERSION}"
+            )
+        return value
+
+    @model_serializer(mode="wrap")
+    def _serialize_schema_version(self, handler: SerializerFunctionWrapHandler) -> dict[str, object]:
+        """Include the current schema version even in sparse serialization."""
+        serialized = cast(dict[str, object], handler(self))
+        serialized["schema_version"] = _CURRENT_REPLACE_PII_SCHEMA_VERSION
+        return serialized
 
     @field_validator("replacement_plan", mode="before")
     @classmethod

--- a/src/nemo_safe_synthesizer/config/replace_pii.py
+++ b/src/nemo_safe_synthesizer/config/replace_pii.py
@@ -60,7 +60,7 @@ __all__ = [
 # Sentinel value for ``ReplacePiiConfig.replacement_plan`` requesting automatic
 # entity discovery instead of an explicit plan.
 AUTO_DISCOVERY = "auto_discovery"
-_CURRENT_REPLACE_PII_SCHEMA_VERSION = 1
+_CURRENT_REPLACE_PII_SCHEMA_VERSION = 3
 
 
 class EntityType(StrEnum):
@@ -650,11 +650,11 @@ class ReplacePiiConfig(Parameters):
         "for the current configuration."
     )
 
-    schema_version: Literal[1] = Field(
+    schema_version: Literal[3] = Field(
         default=_CURRENT_REPLACE_PII_SCHEMA_VERSION,
         description=(
-            "Version of this replace_pii configuration schema. Missing versions are treated as version 1; "
-            "this release accepts only version 1."
+            "Version of this replace_pii configuration schema. Missing versions are treated as version 3; "
+            "this release accepts only version 3."
         ),
     )
     replacement_plan: PiiReplacementPlan | str = Field(

--- a/src/nemo_safe_synthesizer/config/replace_pii.py
+++ b/src/nemo_safe_synthesizer/config/replace_pii.py
@@ -625,13 +625,13 @@ class ReplacePiiConfig(Parameters):
     ``replacement_plan`` accepts three forms:
 
     * ``"auto_discovery"`` (default) detects and plans replacements automatically;
-    * an embedded ``PiiReplacementPlan`` mapping in the main NSS config; or
+    * an inline ``PiiReplacementPlan`` mapping in the main NSS config; or
     * a string path to a separate plan YAML containing that same mapping.
 
     ``llm=None`` leaves auto-discovery at the heuristic baseline and disables
     LLM-assisted free-text replacement. Supplying an ``llm`` mapping enables
     LLM enhancement after heuristic discovery and provides the same inference
-    settings to replacement-time free-text processing. An embedded plan or plan
+    settings to replacement-time free-text processing. An inline plan or plan
     file bypasses only discovery; it does not disable replacement-time LLM use.
     The API key remains a runtime secret supplied through ``NSS_INFERENCE_KEY``
     or the corresponding CLI option; it is never stored in this model.
@@ -656,7 +656,7 @@ class ReplacePiiConfig(Parameters):
     replacement_plan: PiiReplacementPlan | str = Field(
         default=AUTO_DISCOVERY,
         description=(
-            f"{AUTO_DISCOVERY!r} to discover the plan from the data, an embedded plan "
+            f"{AUTO_DISCOVERY!r} to discover the plan from the data, an inline plan "
             "mapping in the main NSS config, or a path to a separate plan YAML. "
             "Other strings are treated as paths. The CLI option only accepts the "
             "sentinel or a path."
@@ -690,7 +690,7 @@ class ReplacePiiConfig(Parameters):
     def _resolve_replacement_plan(cls, value: object) -> object:
         """Resolve the plan/string union here so errors describe the plan, not the union.
 
-        Left to the union, a malformed embedded plan reports the plan's own errors
+        Left to the union, a malformed inline plan reports the plan's own errors
         *and* "input should be a valid string", which reads as though a file path
         was expected. Validating a mapping as a plan up front keeps the report to
         the fields the user actually got wrong.
@@ -702,13 +702,13 @@ class ReplacePiiConfig(Parameters):
                 details = "; ".join(
                     f"{'.'.join(str(part) for part in error['loc'])}: {error['msg']}" for error in exc.errors()
                 )
-                raise ParameterError(f"invalid embedded replacement plan ({details})") from exc
+                raise ParameterError(f"invalid inline replacement plan ({details})") from exc
         if isinstance(value, Path):
             return str(value)
         if isinstance(value, str | PiiReplacementPlan):
             return value
         raise ParameterError(
-            f"replacement_plan must be {AUTO_DISCOVERY!r}, an embedded plan, or a path to a plan file; "
+            f"replacement_plan must be {AUTO_DISCOVERY!r}, an inline plan, or a path to a plan file; "
             f"got {type(value).__name__}"
         )
 
@@ -725,6 +725,6 @@ class ReplacePiiConfig(Parameters):
         return None
 
     @property
-    def embedded_plan(self) -> PiiReplacementPlan | None:
-        """The embedded plan, or ``None`` for auto-discovery or a plan file."""
+    def inline_plan(self) -> PiiReplacementPlan | None:
+        """The inline plan, or ``None`` for auto-discovery or a plan file."""
         return self.replacement_plan if isinstance(self.replacement_plan, PiiReplacementPlan) else None

--- a/src/nemo_safe_synthesizer/config/replace_pii.py
+++ b/src/nemo_safe_synthesizer/config/replace_pii.py
@@ -546,18 +546,14 @@ class PiiReplacementPlan(Parameters):
 
 
 class LLMConfig(NSSBaseModel):
-    """OpenAI-compatible inference settings shared by PII planning and replacement.
+    """Inference behavior shared by PII planning and replacement.
 
     Presence on ``ReplacePiiConfig.llm`` is itself the enable signal; there is no
-    separate boolean flag.
+    separate boolean flag. The OpenAI-compatible endpoint is supplied at runtime
+    through ``NSS_INFERENCE_ENDPOINT`` or ``--inference-endpoint-url`` rather than
+    persisted in NSS configuration.
     """
 
-    endpoint_url: str | None = Field(
-        default=None,
-        description=(
-            "OpenAI-compatible inference endpoint. When unset, uses NSS_INFERENCE_ENDPOINT or the NSS default endpoint."
-        ),
-    )
     model_id: str | None = Field(
         default=None,
         description=(
@@ -665,7 +661,8 @@ class ReplacePiiConfig(Parameters):
     llm: LLMConfig | None = Field(
         default=None,
         description=(
-            "Optional OpenAI-compatible settings shared by plan enhancement and free-text replacement. "
+            "Optional inference behavior shared by plan enhancement and free-text replacement. "
+            "The endpoint is configured at runtime through NSS_INFERENCE_ENDPOINT or --inference-endpoint-url. "
             "Use an empty mapping to enable NSS inference defaults."
         ),
     )

--- a/src/nemo_safe_synthesizer/config/replace_pii.py
+++ b/src/nemo_safe_synthesizer/config/replace_pii.py
@@ -645,7 +645,8 @@ class ReplacePiiConfig(Parameters):
 
     removed_legacy_fields: ClassVar[frozenset[str]] = frozenset({"globals", "steps"})
     removed_legacy_fields_message: ClassVar[str] = (
-        "PII replacement v2 configuration was removed. "
+        "This configuration uses the PII replacement v2 schema, which is not supported by PII replacement v3. "
+        "Configure replace_pii.replacement_plan instead. "
         "See docs/user-guide/configuration.md#replacing-pii "
         "for the current configuration."
     )

--- a/src/nemo_safe_synthesizer/config/replace_pii.py
+++ b/src/nemo_safe_synthesizer/config/replace_pii.py
@@ -546,19 +546,31 @@ class PiiReplacementPlan(Parameters):
 
 
 class LLMConfig(NSSBaseModel):
-    """Shared LLM settings for discovery and free-text replacement.
+    """OpenAI-compatible inference settings shared by PII planning and replacement.
 
     Presence on ``ReplacePiiConfig.llm`` is itself the enable signal; there is no
-    separate boolean flag. Reserved for future use.
+    separate boolean flag.
     """
 
-    model_provider: str | None = Field(
+    endpoint_url: str | None = Field(
         default=None,
-        description="Reserved: inference provider for LLM-assisted discovery/replacement.",
+        description=(
+            "OpenAI-compatible inference endpoint. When unset, uses NSS_INFERENCE_ENDPOINT or the NSS default endpoint."
+        ),
+    )
+    model_id: str | None = Field(
+        default=None,
+        description=(
+            "Model identifier served by the inference endpoint. When unset, uses "
+            "NSS_INFERENCE_MODEL or the NSS default model."
+        ),
     )
     max_workers: int = Field(
-        default=64,
-        description="Reserved: maximum parallel workers for LLM-assisted operations.",
+        default=8,
+        ge=1,
+        description=(
+            "Maximum concurrent requests for LLM-assisted plan discovery and free-text replacement. Must be at least 1."
+        ),
     )
 
 
@@ -610,11 +622,19 @@ class PiiSamplerConfig(NSSBaseModel):
 class ReplacePiiConfig(Parameters):
     """Top-level ``replace_pii`` config wrapping the replacement plan.
 
-    ``replacement_plan`` is one of:
+    ``replacement_plan`` accepts three forms:
 
-    * ``"auto_discovery"`` (default) -- detect and plan replacements automatically;
-    * a path (string) to a plan file;
-    * an inline ``PiiReplacementPlan``.
+    * ``"auto_discovery"`` (default) detects and plans replacements automatically;
+    * an embedded ``PiiReplacementPlan`` mapping in the main NSS config; or
+    * a string path to a separate plan YAML containing that same mapping.
+
+    ``llm=None`` leaves auto-discovery at the heuristic baseline and disables
+    LLM-assisted free-text replacement. Supplying an ``llm`` mapping enables
+    LLM enhancement after heuristic discovery and provides the same inference
+    settings to replacement-time free-text processing. An embedded plan or plan
+    file bypasses only discovery; it does not disable replacement-time LLM use.
+    The API key remains a runtime secret supplied through ``NSS_INFERENCE_KEY``
+    or the corresponding CLI option; it is never stored in this model.
 
     v2 fields ``globals`` and ``steps`` are rejected with a removal error.
     """
@@ -636,18 +656,17 @@ class ReplacePiiConfig(Parameters):
     replacement_plan: PiiReplacementPlan | str = Field(
         default=AUTO_DISCOVERY,
         description=(
-            f"{AUTO_DISCOVERY!r} to discover the plan from the data, a path to a plan "
-            "file, or an inline plan (YAML/SDK mapping or PiiReplacementPlan). "
-            f"Other strings are treated as paths. The CLI option only accepts the "
+            f"{AUTO_DISCOVERY!r} to discover the plan from the data, an embedded plan "
+            "mapping in the main NSS config, or a path to a separate plan YAML. "
+            "Other strings are treated as paths. The CLI option only accepts the "
             "sentinel or a path."
         ),
     )
     llm: LLMConfig | None = Field(
         default=None,
         description=(
-            "LLM-assisted discovery and free-text replacement settings, or null "
-            "(the default) to run without LLM assistance. Reserved: supplying a "
-            "value is rejected at config validation in this release."
+            "Optional OpenAI-compatible settings shared by plan enhancement and free-text replacement. "
+            "Use an empty mapping to enable NSS inference defaults."
         ),
     )
     replacement: PiiReplacementSettings = Field(
@@ -666,22 +685,12 @@ class ReplacePiiConfig(Parameters):
             raise_if_removed_legacy_fields(cls, cast(Mapping[str, object], value), path=())
         return value
 
-    @field_validator("llm")
-    @classmethod
-    def _reject_unsupported_llm(cls, value: LLMConfig | None) -> LLMConfig | None:
-        if value is not None:
-            raise ParameterError(
-                "replace_pii.llm is not supported in this release; omit it or set "
-                "replace_pii.llm to null (the default)."
-            )
-        return value
-
     @field_validator("replacement_plan", mode="before")
     @classmethod
     def _resolve_replacement_plan(cls, value: object) -> object:
         """Resolve the plan/string union here so errors describe the plan, not the union.
 
-        Left to the union, a malformed inline plan reports the plan's own errors
+        Left to the union, a malformed embedded plan reports the plan's own errors
         *and* "input should be a valid string", which reads as though a file path
         was expected. Validating a mapping as a plan up front keeps the report to
         the fields the user actually got wrong.
@@ -693,13 +702,13 @@ class ReplacePiiConfig(Parameters):
                 details = "; ".join(
                     f"{'.'.join(str(part) for part in error['loc'])}: {error['msg']}" for error in exc.errors()
                 )
-                raise ParameterError(f"invalid inline replacement plan ({details})") from exc
+                raise ParameterError(f"invalid embedded replacement plan ({details})") from exc
         if isinstance(value, Path):
             return str(value)
         if isinstance(value, str | PiiReplacementPlan):
             return value
         raise ParameterError(
-            f"replacement_plan must be {AUTO_DISCOVERY!r}, a path to a plan file, or an inline plan; "
+            f"replacement_plan must be {AUTO_DISCOVERY!r}, an embedded plan, or a path to a plan file; "
             f"got {type(value).__name__}"
         )
 
@@ -716,6 +725,6 @@ class ReplacePiiConfig(Parameters):
         return None
 
     @property
-    def inline_plan(self) -> PiiReplacementPlan | None:
-        """The inline plan, or ``None`` if auto-discovery or a path reference."""
+    def embedded_plan(self) -> PiiReplacementPlan | None:
+        """The embedded plan, or ``None`` for auto-discovery or a plan file."""
         return self.replacement_plan if isinstance(self.replacement_plan, PiiReplacementPlan) else None

--- a/src/nemo_safe_synthesizer/defaults.py
+++ b/src/nemo_safe_synthesizer/defaults.py
@@ -74,6 +74,7 @@ DEFAULT_EXCLUDE_COLUMNS: tuple[str, ...] = (PSEUDO_GROUP_COLUMN,)
 
 # Unused default LLM inference endpoint (reserved for PII replacement v3).
 DEFAULT_NSS_INFERENCE_ENDPOINT = "https://integrate.api.nvidia.com/v1"
+PII_REPLACEMENT_PLAN_FILENAME = "pii_replacement_plan.yaml"
 
 # Managed parquet assets for the PII sampler (``datasets/{locale}.parquet``).
 NSS_MANAGED_ASSETS_PATH_ENV = "NSS_MANAGED_ASSETS_PATH"

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/__init__.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/__init__.py
@@ -5,7 +5,15 @@
 
 from __future__ import annotations
 
+from .assembly import (
+    ColumnClassification,
+    DependencyCandidate,
+    apply_dependencies,
+    derive_dependency_candidates,
+    plan_from_classifications,
+)
 from .io import load_plan, save_plan
+from .patterns import pattern_grammar_catalog
 from .resolver import (
     ColumnGrain,
     ColumnProfile,
@@ -18,13 +26,19 @@ from .resolver import (
 from .validation import protected_columns, validate_plan
 
 __all__ = [
+    "ColumnClassification",
     "ColumnGrain",
     "ColumnProfile",
+    "DependencyCandidate",
     "HeuristicPlanDiscoverer",
     "PlanDiscoverer",
     "PlanDiscoveryInput",
     "PlanEnhancer",
+    "apply_dependencies",
+    "derive_dependency_candidates",
     "load_plan",
+    "pattern_grammar_catalog",
+    "plan_from_classifications",
     "protected_columns",
     "resolve_plan",
     "save_plan",

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/__init__.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/__init__.py
@@ -15,7 +15,6 @@ from .assembly import (
 from .io import load_plan, save_plan
 from .patterns import pattern_grammar_catalog
 from .resolver import (
-    ColumnGrain,
     ColumnProfile,
     HeuristicPlanDiscoverer,
     PlanDiscoverer,
@@ -27,7 +26,6 @@ from .validation import protected_columns, validate_plan
 
 __all__ = [
     "ColumnClassification",
-    "ColumnGrain",
     "ColumnProfile",
     "DependencyCandidate",
     "HeuristicPlanDiscoverer",

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/__init__.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/__init__.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Internal planning module for dataset-specific PII replacement plans."""
+
+from __future__ import annotations
+
+from .io import load_plan, save_plan
+from .resolver import (
+    ColumnGrain,
+    ColumnProfile,
+    HeuristicPlanDiscoverer,
+    PlanDiscoverer,
+    PlanDiscoveryInput,
+    PlanEnhancer,
+    resolve_plan,
+)
+from .validation import protected_columns, validate_plan
+
+__all__ = [
+    "ColumnGrain",
+    "ColumnProfile",
+    "HeuristicPlanDiscoverer",
+    "PlanDiscoverer",
+    "PlanDiscoveryInput",
+    "PlanEnhancer",
+    "load_plan",
+    "protected_columns",
+    "resolve_plan",
+    "save_plan",
+    "validate_plan",
+]

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/assembly.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/assembly.py
@@ -1,0 +1,163 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic assembly shared by PII plan discoverers and enhancers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence, Set
+from dataclasses import dataclass
+from typing import Self
+
+from pydantic import BaseModel, ConfigDict, model_validator
+
+from ...config.replace_pii import (
+    ALLOWED_DEPENDS_ON,
+    ENTITY_BY_TYPE,
+    ConditioningColumn,
+    EntityType,
+    PiiColumnPlan,
+    PiiReplacementPlan,
+    PiiReplacementScope,
+    is_columns_to_replace_type,
+)
+from ...errors import ParameterError
+
+__all__ = [
+    "ColumnClassification",
+    "DependencyCandidate",
+    "apply_dependencies",
+    "derive_dependency_candidates",
+    "plan_from_classifications",
+]
+
+
+class ColumnClassification(BaseModel):
+    """Semantic classification produced by a heuristic or LLM planner."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    column_name: str
+    entity_type: EntityType | None
+    pattern: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_pattern_eligibility(self) -> Self:
+        if self.pattern is None:
+            return self
+        if not self.pattern.strip():
+            raise ValueError("patterns must be non-empty when provided")
+        if self.entity_type is None:
+            raise ValueError("unclassified columns cannot include a pattern")
+        if ENTITY_BY_TYPE[self.entity_type].pattern_syntax is None:
+            raise ValueError("the classified entity_type does not support patterns")
+        return self
+
+
+@dataclass(frozen=True, slots=True)
+class DependencyCandidate:
+    """One catalog-permitted dependency that a planner may select."""
+
+    target_column: str
+    target_entity_type: EntityType
+    source_column: str
+    source_entity_type: EntityType
+
+    def __post_init__(self) -> None:
+        if self.target_column == self.source_column:
+            raise ParameterError("a dependency candidate cannot target and source the same column")
+        allowed_sources = ALLOWED_DEPENDS_ON.get(self.target_entity_type, frozenset())
+        if self.source_entity_type not in allowed_sources:
+            raise ParameterError(
+                f"entity_type {self.source_entity_type.value!r} cannot condition "
+                f"entity_type {self.target_entity_type.value!r}"
+            )
+
+
+def plan_from_classifications(
+    scope: PiiReplacementScope,
+    classifications: Sequence[ColumnClassification],
+    *,
+    protected_columns: Set[str] = frozenset(),
+) -> PiiReplacementPlan:
+    """Build replacement membership deterministically from semantic classifications."""
+    columns_to_replace: list[PiiColumnPlan] = []
+    for classification in classifications:
+        entity_type = classification.entity_type
+        if (
+            entity_type is None
+            or not is_columns_to_replace_type(entity_type)
+            or classification.column_name in protected_columns
+        ):
+            continue
+        columns_to_replace.append(
+            PiiColumnPlan(
+                column_name=classification.column_name,
+                entity_type=entity_type,
+                pattern=classification.pattern,
+            )
+        )
+    return PiiReplacementPlan(scope=scope, columns_to_replace=columns_to_replace)
+
+
+def derive_dependency_candidates(
+    plan: PiiReplacementPlan,
+    classifications: Sequence[ColumnClassification],
+) -> list[DependencyCandidate]:
+    """Return every dependency permitted by the entity relationship catalog."""
+    candidates: list[DependencyCandidate] = []
+    for target in plan.columns_to_replace:
+        allowed_sources = ALLOWED_DEPENDS_ON.get(target.entity_type, frozenset())
+        for source in classifications:
+            if (
+                source.entity_type is None
+                or source.entity_type not in allowed_sources
+                or source.column_name == target.column_name
+            ):
+                continue
+            candidates.append(
+                DependencyCandidate(
+                    target_column=target.column_name,
+                    target_entity_type=target.entity_type,
+                    source_column=source.column_name,
+                    source_entity_type=source.entity_type,
+                )
+            )
+    return candidates
+
+
+def apply_dependencies(
+    plan: PiiReplacementPlan,
+    dependencies: Sequence[DependencyCandidate],
+) -> PiiReplacementPlan:
+    """Return ``plan`` with the selected catalog-derived dependencies applied."""
+    dependencies_by_target: dict[str, list[ConditioningColumn]] = {}
+    targets = {spec.column_name: spec for spec in plan.columns_to_replace}
+    for dependency in dependencies:
+        target = targets.get(dependency.target_column)
+        if target is None:
+            raise ParameterError(f"dependency targets unknown replacement column {dependency.target_column!r}")
+        if target.entity_type is not dependency.target_entity_type:
+            raise ParameterError(
+                f"dependency target {dependency.target_column!r} is classified as "
+                f"{dependency.target_entity_type.value!r}, but the plan uses {target.entity_type.value!r}"
+            )
+        dependencies_by_target.setdefault(dependency.target_column, []).append(
+            ConditioningColumn(
+                column_name=dependency.source_column,
+                entity_type=dependency.source_entity_type,
+            )
+        )
+
+    return PiiReplacementPlan(
+        scope=plan.scope,
+        columns_to_replace=[
+            PiiColumnPlan(
+                column_name=spec.column_name,
+                entity_type=spec.entity_type,
+                pattern=spec.pattern,
+                depends_on=dependencies_by_target.get(spec.column_name, []),
+            )
+            for spec in plan.columns_to_replace
+        ],
+    )

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/io.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/io.py
@@ -15,7 +15,7 @@ from ...errors import ParameterError
 
 __all__ = ["load_plan", "save_plan"]
 
-_CURRENT_PLAN_SCHEMA_VERSION = 1
+_CURRENT_PLAN_SCHEMA_VERSION = 3
 
 
 def _plan_body(raw: dict[object, object], plan_path: Path) -> dict[object, object]:
@@ -37,7 +37,7 @@ def load_plan(path: str | Path) -> PiiReplacementPlan:
 
     A plan file contains ``schema_version`` metadata followed by the same fields
     accepted as an inline ``replace_pii.replacement_plan`` value. A missing
-    version is interpreted as version 1.
+    version is interpreted as version 3.
 
     Args:
         path: YAML file containing a replacement-plan mapping.

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/io.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/io.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Load and save dataset-specific PII replacement plans."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+from pydantic import ValidationError
+
+from ...config.replace_pii import PiiReplacementPlan
+from ...errors import ParameterError
+
+__all__ = ["load_plan", "save_plan"]
+
+
+def load_plan(path: str | Path) -> PiiReplacementPlan:
+    """Load a replacement plan from a standalone YAML file.
+
+    A plan file contains the same mapping accepted as an embedded
+    ``replace_pii.replacement_plan`` value in the main NSS configuration.
+
+    Args:
+        path: YAML file containing a replacement-plan mapping.
+
+    Returns:
+        The parsed, context-free validated plan.
+
+    Raises:
+        ParameterError: If the file cannot be read, parsed, or validated.
+    """
+    plan_path = Path(path)
+    try:
+        raw = yaml.safe_load(plan_path.read_text())
+    except OSError as exc:
+        raise ParameterError(f"Could not read PII replacement plan file {str(plan_path)!r}: {exc}") from exc
+    except yaml.YAMLError as exc:
+        raise ParameterError(f"Invalid YAML in PII replacement plan file {str(plan_path)!r}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise ParameterError(f"PII replacement plan file {str(plan_path)!r} must contain a mapping")
+
+    try:
+        return PiiReplacementPlan.model_validate(raw)
+    except ValidationError as exc:
+        raise ParameterError(f"Invalid PII replacement plan in {str(plan_path)!r}: {exc}") from exc
+
+
+def save_plan(plan: PiiReplacementPlan, path: str | Path) -> Path:
+    """Save a replacement plan as reusable standalone YAML."""
+    plan_path = Path(path)
+    plan_path.parent.mkdir(parents=True, exist_ok=True)
+    plan.to_yaml(plan_path, exclude_unset=False)
+    return plan_path

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/io.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/io.py
@@ -15,12 +15,29 @@ from ...errors import ParameterError
 
 __all__ = ["load_plan", "save_plan"]
 
+_CURRENT_PLAN_SCHEMA_VERSION = 1
+
+
+def _plan_body(raw: dict[object, object], plan_path: Path) -> dict[object, object]:
+    """Validate document metadata and return the unversioned runtime plan body."""
+    body = dict(raw)
+    version = body.pop("schema_version", _CURRENT_PLAN_SCHEMA_VERSION)
+    if type(version) is not int:
+        raise ParameterError(f"PII replacement plan file {str(plan_path)!r} schema_version must be an integer")
+    if version != _CURRENT_PLAN_SCHEMA_VERSION:
+        raise ParameterError(
+            f"PII replacement plan file {str(plan_path)!r} uses unsupported schema version {version}; "
+            f"this NSS release supports version {_CURRENT_PLAN_SCHEMA_VERSION}"
+        )
+    return body
+
 
 def load_plan(path: str | Path) -> PiiReplacementPlan:
     """Load a replacement plan from a standalone YAML file.
 
-    A plan file contains the same mapping accepted as an inline
-    ``replace_pii.replacement_plan`` value in the main NSS configuration.
+    A plan file contains ``schema_version`` metadata followed by the same fields
+    accepted as an inline ``replace_pii.replacement_plan`` value. A missing
+    version is interpreted as version 1.
 
     Args:
         path: YAML file containing a replacement-plan mapping.
@@ -43,14 +60,18 @@ def load_plan(path: str | Path) -> PiiReplacementPlan:
         raise ParameterError(f"PII replacement plan file {str(plan_path)!r} must contain a mapping")
 
     try:
-        return PiiReplacementPlan.model_validate(raw)
+        return PiiReplacementPlan.model_validate(_plan_body(raw, plan_path))
     except ValidationError as exc:
         raise ParameterError(f"Invalid PII replacement plan in {str(plan_path)!r}: {exc}") from exc
 
 
 def save_plan(plan: PiiReplacementPlan, path: str | Path) -> Path:
-    """Save a replacement plan as reusable standalone YAML."""
+    """Save a replacement plan as a versioned reusable standalone YAML document."""
     plan_path = Path(path)
     plan_path.parent.mkdir(parents=True, exist_ok=True)
-    plan.to_yaml(plan_path, exclude_unset=False)
+    document = {
+        "schema_version": _CURRENT_PLAN_SCHEMA_VERSION,
+        **plan.model_dump(mode="json", exclude_unset=False),
+    }
+    plan_path.write_text(yaml.safe_dump(document, sort_keys=False))
     return plan_path

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/io.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/io.py
@@ -19,7 +19,7 @@ __all__ = ["load_plan", "save_plan"]
 def load_plan(path: str | Path) -> PiiReplacementPlan:
     """Load a replacement plan from a standalone YAML file.
 
-    A plan file contains the same mapping accepted as an embedded
+    A plan file contains the same mapping accepted as an inline
     ``replace_pii.replacement_plan`` value in the main NSS configuration.
 
     Args:

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/patterns.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/patterns.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Canonical descriptions of the supported PII replacement pattern grammars."""
+
+from __future__ import annotations
+
+from ...config.replace_pii import PatternSyntax
+
+__all__ = ["pattern_grammar_catalog"]
+
+
+def pattern_grammar_catalog() -> dict[str, dict[str, object]]:
+    """Return structured grammar documentation keyed by pattern syntax name."""
+    return {
+        PatternSyntax.NAME_PARTS.name.lower(): {
+            "description": "Whole-value templates composed of literals and name-part placeholders.",
+            "placeholders": {
+                "{first}": "first name",
+                "{middle}": "middle name",
+                "{last}": "last name",
+                "{f}": "first-name initial",
+                "{m}": "middle-name initial",
+                "{l}": "last-name initial",
+                "{First}": "title-case first name",
+                "{Middle}": "title-case middle name",
+                "{Last}": "title-case last name",
+                "{FIRST}": "uppercase first name",
+                "{MIDDLE}": "uppercase middle name",
+                "{LAST}": "uppercase last name",
+                "{domain}": "email domain; email entities only",
+            },
+            "rules": [
+                "Literal separators and punctuation are preserved.",
+                "{domain} may only be used for email.",
+                "Email patterns must contain @.",
+                "In email patterns, # emits one digit.",
+            ],
+            "examples": ["{First} {Last}", "{f}.{last}@{domain}"],
+        },
+        PatternSyntax.CHARACTER_MASK.name.lower(): {
+            "description": "One generated character per variable token; all other characters are literal.",
+            "tokens": {
+                "#": "digit 0-9",
+                "^": "uppercase letter A-Z",
+                "@": "lowercase letter a-z",
+                "&": "digit or uppercase letter",
+                "%": "digit or lowercase letter",
+                "*": "digit or letter",
+                "[abc]": "one literal character from the brackets",
+                "\\x": "literal x",
+            },
+            "rules": [
+                "Bracket contents are literal choices, not ranges.",
+                "The pattern must contain at least one variable token.",
+            ],
+            "examples": ["pmc-#######-#", "CUST-10[01]###"],
+        },
+        PatternSyntax.STRFTIME.name.lower(): {
+            "description": "Python strftime/strptime format describing the complete datetime value.",
+            "examples": ["%m/%d/%Y", "%Y-%m-%d"],
+        },
+    }

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/resolver.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/resolver.py
@@ -98,7 +98,15 @@ class HeuristicPlanDiscoverer(PlanDiscoverer):
 
 
 def _stable_samples(series: pd.Series) -> tuple[str, ...]:
+    """Pick a bounded set of distinct raw column values for discovery.
+
+    Nulls are removed, values are converted to truncated strings, and duplicate
+    strings are collapsed. Hash ordering assigns each distinct value a stable,
+    content-based priority, so reordering dataframe rows does not change which
+    values are selected.
+    """
     values = {str(value)[:MAX_PROFILE_SAMPLE_LENGTH] for value in series.dropna().tolist()}
+    # Rank distinct values by their content rather than sampling row positions.
     ordered = sorted(values, key=lambda value: hashlib.sha256(value.encode()).digest())
     return tuple(ordered[:MAX_PROFILE_SAMPLES])
 
@@ -131,8 +139,10 @@ def _profile_columns(
         non_null_count = len(non_null)
         unique_count = int(non_null.nunique(dropna=True))
         constancy = _group_constancy(df, column, group_column)
-        if column == group_column or column in structural_columns:
+        if column == group_column:
             grain = ColumnGrain.key
+        # A threshold below 1 tolerates a small amount of dirty data instead of
+        # treating an otherwise group-constant column as record-level.
         elif constancy is not None and constancy >= GROUP_GRAIN_THRESHOLD:
             grain = ColumnGrain.group
         else:

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/resolver.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/resolver.py
@@ -1,0 +1,222 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve one validated PII replacement plan from configuration and data."""
+
+from __future__ import annotations
+
+import hashlib
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+import pandas as pd
+
+from ...config.data import DataParameters
+from ...config.replace_pii import PiiReplacementPlan, PiiReplacementScope, ReplacePiiConfig
+from ...config.time_series import TimeSeriesParameters
+from ...errors import ParameterError
+from .io import load_plan, save_plan
+from .validation import protected_columns, validate_plan
+
+__all__ = [
+    "ColumnGrain",
+    "ColumnProfile",
+    "HeuristicPlanDiscoverer",
+    "PlanDiscoverer",
+    "PlanDiscoveryInput",
+    "PlanEnhancer",
+    "resolve_plan",
+]
+
+MAX_PROFILE_SAMPLES = 8
+MAX_PROFILE_SAMPLE_LENGTH = 128
+GROUP_GRAIN_THRESHOLD = 0.95
+
+
+class ColumnGrain(StrEnum):
+    """Observed structural grain of a dataframe column."""
+
+    key = "key"
+    group = "group"
+    record = "record"
+
+
+@dataclass(frozen=True, slots=True)
+class ColumnProfile:
+    """Bounded evidence about one column, shared by plan discoverers."""
+
+    column_name: str
+    dtype: str
+    non_null_count: int
+    unique_count: int
+    unique_ratio: float
+    group_constancy: float | None
+    grain: ColumnGrain
+    protected: bool
+    samples: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class PlanDiscoveryInput:
+    """Data and deterministic preparation supplied to discovery adapters."""
+
+    dataframe: pd.DataFrame
+    scope: PiiReplacementScope
+    group_column: str | None
+    protected_columns: frozenset[str]
+    column_profiles: tuple[ColumnProfile, ...]
+
+
+class PlanDiscoverer(ABC):
+    """Internal seam for producing the heuristic baseline plan."""
+
+    @abstractmethod
+    def discover(self, discovery_input: PlanDiscoveryInput) -> PiiReplacementPlan:
+        """Return a context-free valid baseline plan."""
+
+
+class PlanEnhancer(ABC):
+    """Internal seam for revising a heuristic baseline plan."""
+
+    @abstractmethod
+    def enhance(
+        self,
+        discovery_input: PlanDiscoveryInput,
+        baseline: PiiReplacementPlan,
+    ) -> PiiReplacementPlan:
+        """Return a context-free valid replacement for ``baseline``."""
+
+
+class HeuristicPlanDiscoverer(PlanDiscoverer):
+    """Initial no-op heuristic adapter, ready for later rule discovery."""
+
+    def discover(self, discovery_input: PlanDiscoveryInput) -> PiiReplacementPlan:
+        """Return an empty plan while preserving the deterministically resolved scope."""
+        return PiiReplacementPlan(scope=discovery_input.scope)
+
+
+def _stable_samples(series: pd.Series) -> tuple[str, ...]:
+    values = {str(value)[:MAX_PROFILE_SAMPLE_LENGTH] for value in series.dropna().tolist()}
+    ordered = sorted(values, key=lambda value: hashlib.sha256(value.encode()).digest())
+    return tuple(ordered[:MAX_PROFILE_SAMPLES])
+
+
+def _group_constancy(df: pd.DataFrame, column: str, group_column: str | None) -> float | None:
+    if group_column is None or group_column not in df.columns or column == group_column:
+        return None
+
+    evidence = pd.DataFrame(
+        {
+            "__group": df[group_column].astype("string"),
+            "__value": df[column].astype("string"),
+        }
+    ).dropna(subset=["__group"])
+    if evidence.empty:
+        return None
+    unique_per_group = evidence.groupby("__group", dropna=False)["__value"].nunique(dropna=True)
+    return float((unique_per_group <= 1).mean())
+
+
+def _profile_columns(
+    df: pd.DataFrame,
+    *,
+    group_column: str | None,
+    structural_columns: frozenset[str],
+) -> tuple[ColumnProfile, ...]:
+    profiles: list[ColumnProfile] = []
+    for column in df.columns:
+        non_null = df[column].dropna().astype(str)
+        non_null_count = len(non_null)
+        unique_count = int(non_null.nunique(dropna=True))
+        constancy = _group_constancy(df, column, group_column)
+        if column in structural_columns:
+            grain = ColumnGrain.key
+        elif constancy is not None and constancy >= GROUP_GRAIN_THRESHOLD:
+            grain = ColumnGrain.group
+        else:
+            grain = ColumnGrain.record
+        profiles.append(
+            ColumnProfile(
+                column_name=column,
+                dtype=str(df[column].dtype),
+                non_null_count=non_null_count,
+                unique_count=unique_count,
+                unique_ratio=unique_count / non_null_count if non_null_count else 0.0,
+                group_constancy=constancy,
+                grain=grain,
+                protected=column in structural_columns,
+                samples=_stable_samples(df[column]),
+            )
+        )
+    return tuple(profiles)
+
+
+def _prepare_discovery_input(
+    df: pd.DataFrame,
+    data_config: DataParameters,
+    time_series: TimeSeriesParameters | None,
+) -> PlanDiscoveryInput:
+    group_column = data_config.group_training_examples_by
+    scope = PiiReplacementScope.GROUP if group_column is not None else PiiReplacementScope.DATAFRAME
+    structural_columns = protected_columns(data_config, time_series)
+    return PlanDiscoveryInput(
+        dataframe=df,
+        scope=scope,
+        group_column=group_column,
+        protected_columns=structural_columns,
+        column_profiles=_profile_columns(
+            df,
+            group_column=group_column,
+            structural_columns=structural_columns,
+        ),
+    )
+
+
+def _configured_plan(config: ReplacePiiConfig) -> PiiReplacementPlan:
+    if config.plan_path is not None:
+        return load_plan(config.plan_path)
+    if config.embedded_plan is not None:
+        return config.embedded_plan
+    raise ParameterError("replacement_plan must be auto_discovery, an embedded plan, or a path to a plan file")
+
+
+def resolve_plan(
+    df: pd.DataFrame,
+    config: ReplacePiiConfig,
+    data_config: DataParameters,
+    time_series: TimeSeriesParameters | None = None,
+    *,
+    discoverer: PlanDiscoverer | None = None,
+    enhancer: PlanEnhancer | None = None,
+    output_path: str | Path | None = None,
+) -> PiiReplacementPlan:
+    """Resolve, validate, and optionally persist one replacement plan.
+
+    Embedded plans and plan files are authoritative and bypass discovery.
+    Auto-discovery always runs the heuristic adapter first, then runs an LLM
+    enhancer only when ``config.llm`` is configured. Dataframe-aware validation
+    occurs once, after the final plan has been selected.
+    """
+    if not config.is_auto_discovery:
+        plan = _configured_plan(config)
+    else:
+        discovery_input = _prepare_discovery_input(df, data_config, time_series)
+        baseline = (discoverer or HeuristicPlanDiscoverer()).discover(discovery_input)
+        if config.llm is None:
+            plan = baseline
+        elif enhancer is None:
+            raise ParameterError("replace_pii.llm is configured, but no LLM plan enhancer is available in this build")
+        else:
+            plan = enhancer.enhance(discovery_input, baseline)
+
+    validate_plan(
+        df,
+        plan,
+        data_config=data_config,
+        time_series=time_series,
+    )
+    if output_path is not None:
+        save_plan(plan, output_path)
+    return plan

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/resolver.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/resolver.py
@@ -131,7 +131,7 @@ def _profile_columns(
         non_null_count = len(non_null)
         unique_count = int(non_null.nunique(dropna=True))
         constancy = _group_constancy(df, column, group_column)
-        if column in structural_columns:
+        if column == group_column or column in structural_columns:
             grain = ColumnGrain.key
         elif constancy is not None and constancy >= GROUP_GRAIN_THRESHOLD:
             grain = ColumnGrain.group

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/resolver.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/resolver.py
@@ -177,9 +177,9 @@ def _prepare_discovery_input(
 def _configured_plan(config: ReplacePiiConfig) -> PiiReplacementPlan:
     if config.plan_path is not None:
         return load_plan(config.plan_path)
-    if config.embedded_plan is not None:
-        return config.embedded_plan
-    raise ParameterError("replacement_plan must be auto_discovery, an embedded plan, or a path to a plan file")
+    if config.inline_plan is not None:
+        return config.inline_plan
+    raise ParameterError("replacement_plan must be auto_discovery, an inline plan, or a path to a plan file")
 
 
 def resolve_plan(
@@ -194,7 +194,7 @@ def resolve_plan(
 ) -> PiiReplacementPlan:
     """Resolve, validate, and optionally persist one replacement plan.
 
-    Embedded plans and plan files are authoritative and bypass discovery.
+    Inline plans and plan files are authoritative and bypass discovery.
     Auto-discovery always runs the heuristic adapter first, then runs an LLM
     enhancer only when ``config.llm`` is configured. Dataframe-aware validation
     occurs once, after the final plan has been selected.

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/resolver.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/resolver.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import hashlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from enum import StrEnum
 from pathlib import Path
 
 import pandas as pd
@@ -21,7 +20,6 @@ from .io import load_plan, save_plan
 from .validation import protected_columns, validate_plan
 
 __all__ = [
-    "ColumnGrain",
     "ColumnProfile",
     "HeuristicPlanDiscoverer",
     "PlanDiscoverer",
@@ -32,29 +30,17 @@ __all__ = [
 
 MAX_PROFILE_SAMPLES = 8
 MAX_PROFILE_SAMPLE_LENGTH = 128
-GROUP_GRAIN_THRESHOLD = 0.95
-
-
-class ColumnGrain(StrEnum):
-    """Observed structural grain of a dataframe column."""
-
-    key = "key"
-    group = "group"
-    record = "record"
 
 
 @dataclass(frozen=True, slots=True)
 class ColumnProfile:
-    """Bounded evidence about one column, shared by plan discoverers."""
+    """Bounded descriptive evidence about one column for plan discovery."""
 
     column_name: str
     dtype: str
     non_null_count: int
     unique_count: int
     unique_ratio: float
-    group_constancy: float | None
-    grain: ColumnGrain
-    protected: bool
     samples: tuple[str, ...]
 
 
@@ -111,42 +97,12 @@ def _stable_samples(series: pd.Series) -> tuple[str, ...]:
     return tuple(ordered[:MAX_PROFILE_SAMPLES])
 
 
-def _group_constancy(df: pd.DataFrame, column: str, group_column: str | None) -> float | None:
-    if group_column is None or group_column not in df.columns or column == group_column:
-        return None
-
-    evidence = pd.DataFrame(
-        {
-            "__group": df[group_column].astype("string"),
-            "__value": df[column].astype("string"),
-        }
-    ).dropna(subset=["__group"])
-    if evidence.empty:
-        return None
-    unique_per_group = evidence.groupby("__group", dropna=False)["__value"].nunique(dropna=True)
-    return float((unique_per_group <= 1).mean())
-
-
-def _profile_columns(
-    df: pd.DataFrame,
-    *,
-    group_column: str | None,
-    structural_columns: frozenset[str],
-) -> tuple[ColumnProfile, ...]:
+def _profile_columns(df: pd.DataFrame) -> tuple[ColumnProfile, ...]:
     profiles: list[ColumnProfile] = []
     for column in df.columns:
         non_null = df[column].dropna().astype(str)
         non_null_count = len(non_null)
         unique_count = int(non_null.nunique(dropna=True))
-        constancy = _group_constancy(df, column, group_column)
-        if column == group_column:
-            grain = ColumnGrain.key
-        # A threshold below 1 tolerates a small amount of dirty data instead of
-        # treating an otherwise group-constant column as record-level.
-        elif constancy is not None and constancy >= GROUP_GRAIN_THRESHOLD:
-            grain = ColumnGrain.group
-        else:
-            grain = ColumnGrain.record
         profiles.append(
             ColumnProfile(
                 column_name=column,
@@ -154,9 +110,6 @@ def _profile_columns(
                 non_null_count=non_null_count,
                 unique_count=unique_count,
                 unique_ratio=unique_count / non_null_count if non_null_count else 0.0,
-                group_constancy=constancy,
-                grain=grain,
-                protected=column in structural_columns,
                 samples=_stable_samples(df[column]),
             )
         )
@@ -176,11 +129,7 @@ def _prepare_discovery_input(
         scope=scope,
         group_column=group_column,
         protected_columns=structural_columns,
-        column_profiles=_profile_columns(
-            df,
-            group_column=group_column,
-            structural_columns=structural_columns,
-        ),
+        column_profiles=_profile_columns(df),
     )
 
 

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/validation.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/validation.py
@@ -1,0 +1,249 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dataframe-aware validation for final PII replacement plans."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from datetime import datetime
+
+import pandas as pd
+
+from ...config.data import DataParameters
+from ...config.replace_pii import (
+    ENTITY_BY_TYPE,
+    EntityType,
+    PatternSyntax,
+    PiiReplacementPlan,
+    PiiReplacementScope,
+)
+from ...config.time_series import TimeSeriesParameters
+from ...errors import ParameterError
+
+__all__ = ["protected_columns", "validate_plan"]
+
+MIN_PATTERN_COVERAGE = 0.85
+_NAME_PART_PATTERN = re.compile(r"\{([^{}]+)\}")
+_NAME_PART_TOKENS = frozenset({"first", "middle", "last", "domain", "f", "m", "l"})
+
+
+def protected_columns(
+    data_config: DataParameters,
+    time_series: TimeSeriesParameters | None = None,
+) -> frozenset[str]:
+    """Return structural columns that automatic replacement must preserve."""
+    candidates = {
+        data_config.group_training_examples_by,
+        data_config.order_training_examples_by,
+        time_series.timestamp_column if time_series is not None else None,
+    }
+    return frozenset(column for column in candidates if column is not None)
+
+
+def _template_regex(pattern: str) -> tuple[re.Pattern[str] | None, str | None]:
+    parts: list[str] = []
+    has_variable = False
+    index = 0
+    token_regex = {"#": r"\d", "^": "[A-Z]", "@": "[a-z]", "*": "[A-Za-z0-9]"}
+
+    while index < len(pattern):
+        char = pattern[index]
+        if char == "\\" and index + 1 < len(pattern):
+            index += 1
+            parts.append(re.escape(pattern[index]))
+        elif char in token_regex:
+            parts.append(token_regex[char])
+            has_variable = True
+        elif char == "[":
+            end = pattern.find("]", index + 1)
+            if end < 0:
+                return None, "has an unclosed '[' character class"
+            choices = pattern[index + 1 : end]
+            if not choices:
+                return None, "has an empty '[]' character class"
+            parts.append("[" + re.escape(choices) + "]")
+            has_variable = True
+            index = end
+        else:
+            parts.append(re.escape(char))
+        index += 1
+
+    if not has_variable:
+        return None, "has no variable placeholder"
+    return re.compile("".join(parts)), None
+
+
+def _name_parts_regex(
+    entity_type: EntityType,
+    pattern: str,
+) -> tuple[re.Pattern[str] | None, str | None]:
+    matches = list(_NAME_PART_PATTERN.finditer(pattern))
+    if not matches:
+        return None, "has no name-part placeholder"
+    if "{" in _NAME_PART_PATTERN.sub("", pattern) or "}" in _NAME_PART_PATTERN.sub("", pattern):
+        return None, "has an unmatched '{' or '}'"
+
+    parts: list[str] = []
+    cursor = 0
+    for match in matches:
+        parts.append(re.escape(pattern[cursor : match.start()]))
+        token = match.group(1).lower()
+        if token not in _NAME_PART_TOKENS:
+            return None, f"uses unknown placeholder {match.group(0)!r}"
+        if token == "domain" and entity_type is not EntityType.EMAIL:
+            return None, "uses {domain} outside an email pattern"
+        if token == "domain":
+            parts.append(r"[^@\s]+")
+        elif token in {"f", "m", "l"}:
+            parts.append(r"[^\W\d_]")
+        elif entity_type is EntityType.EMAIL:
+            parts.append(r"[^@\s.]+")
+        else:
+            parts.append(r"[^@\s]+")
+        cursor = match.end()
+    parts.append(re.escape(pattern[cursor:]))
+
+    if entity_type is EntityType.EMAIL and "@" not in pattern:
+        return None, "does not contain '@'"
+    return re.compile("".join(parts), re.UNICODE), None
+
+
+def _strftime_pattern_error(pattern: str) -> str | None:
+    try:
+        rendered = datetime(2001, 2, 3, 4, 5, 6).strftime(pattern)
+        datetime.strptime(rendered, pattern)
+    except ValueError as exc:
+        return str(exc)
+    return None
+
+
+def _pattern_matcher(
+    entity_type: EntityType,
+    pattern: str,
+) -> tuple[re.Pattern[str] | None, str | None]:
+    pattern_syntax = ENTITY_BY_TYPE[entity_type].pattern_syntax
+    if pattern_syntax is PatternSyntax.CHARACTER_MASK:
+        return _template_regex(pattern)
+    if pattern_syntax is PatternSyntax.NAME_PARTS:
+        return _name_parts_regex(entity_type, pattern)
+    return None, None
+
+
+def _iter_pattern_issues(df: pd.DataFrame, plan: PiiReplacementPlan) -> Iterator[str]:
+    for spec in plan.columns_to_replace:
+        pattern = spec.pattern
+        if pattern is None or spec.column_name not in df.columns:
+            continue
+
+        values = df[spec.column_name].dropna().astype(str).tolist()
+        pattern_syntax = ENTITY_BY_TYPE[spec.entity_type].pattern_syntax
+        if pattern_syntax is PatternSyntax.STRFTIME:
+            if error := _strftime_pattern_error(pattern):
+                yield f"column {spec.column_name!r}: pattern {pattern!r} is not valid strftime ({error})"
+                continue
+            matches = sum(_parses_datetime(value, pattern) for value in values)
+        else:
+            matcher, error = _pattern_matcher(spec.entity_type, pattern)
+            if error is not None:
+                yield f"column {spec.column_name!r}: pattern {pattern!r} {error}"
+                continue
+            if matcher is None:
+                continue
+            matches = sum(matcher.fullmatch(value) is not None for value in values)
+
+        if values and matches / len(values) < MIN_PATTERN_COVERAGE:
+            coverage = matches / len(values)
+            yield (
+                f"column {spec.column_name!r}: pattern {pattern!r} covers {coverage:.1%} of non-null values; "
+                f"at least {MIN_PATTERN_COVERAGE:.0%} is required"
+            )
+
+
+def _parses_datetime(value: str, pattern: str) -> bool:
+    try:
+        datetime.strptime(value, pattern)
+    except ValueError:
+        return False
+    return True
+
+
+def _iter_reference_issues(
+    df: pd.DataFrame,
+    plan: PiiReplacementPlan,
+    structural_columns: frozenset[str],
+) -> Iterator[str]:
+    dataframe_columns = set(df.columns)
+    for spec in plan.columns_to_replace:
+        if spec.column_name not in dataframe_columns:
+            yield f"replacement column {spec.column_name!r} is not present in the dataframe"
+        if spec.column_name in structural_columns:
+            yield f"structural column {spec.column_name!r} cannot be replaced"
+        for dependency in spec.depends_on:
+            if dependency.column_name not in dataframe_columns:
+                yield (
+                    f"column {spec.column_name!r}: depends_on column "
+                    f"{dependency.column_name!r} is not present in the dataframe"
+                )
+            if dependency.column_name == spec.column_name:
+                yield f"column {spec.column_name!r} cannot depend on itself"
+
+
+def _cycle_columns(plan: PiiReplacementPlan) -> list[str]:
+    targets = {spec.column_name for spec in plan.columns_to_replace}
+    adjacency: dict[str, set[str]] = {column: set() for column in targets}
+    indegree = dict.fromkeys(targets, 0)
+
+    for spec in plan.columns_to_replace:
+        for dependency in spec.depends_on:
+            source = dependency.column_name
+            if source not in targets or source == spec.column_name or spec.column_name in adjacency[source]:
+                continue
+            adjacency[source].add(spec.column_name)
+            indegree[spec.column_name] += 1
+
+    ready = [column for column, degree in indegree.items() if degree == 0]
+    visited = 0
+    while ready:
+        source = ready.pop()
+        visited += 1
+        for target in adjacency[source]:
+            indegree[target] -= 1
+            if indegree[target] == 0:
+                ready.append(target)
+
+    if visited == len(targets):
+        return []
+    return sorted(column for column, degree in indegree.items() if degree > 0)
+
+
+def validate_plan(
+    df: pd.DataFrame,
+    plan: PiiReplacementPlan,
+    *,
+    data_config: DataParameters,
+    time_series: TimeSeriesParameters | None = None,
+) -> None:
+    """Validate the selected final plan against the dataframe and structural config.
+
+    This is the resolver's single dataframe-aware validation gate. Pydantic
+    model construction and LLM response parsing are separate, context-free
+    checks performed at their respective seams.
+    """
+    issues: list[str] = []
+    group_column = data_config.group_training_examples_by
+    if plan.scope is PiiReplacementScope.GROUP:
+        if group_column is None:
+            issues.append("plan scope is 'group' but data.group_training_examples_by is not configured")
+        elif group_column not in df.columns:
+            issues.append(f"group column {group_column!r} is not present in the dataframe")
+
+    issues.extend(_iter_reference_issues(df, plan, protected_columns(data_config, time_series)))
+    if cycles := _cycle_columns(plan):
+        issues.append("replacement dependencies contain a cycle involving: " + ", ".join(repr(name) for name in cycles))
+    issues.extend(_iter_pattern_issues(df, plan))
+
+    if issues:
+        details = "\n".join(f"  - {issue}" for issue in issues)
+        raise ParameterError(f"Invalid PII replacement plan for this dataframe:\n{details}")

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/validation.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/validation.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterator
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pandas as pd
 
@@ -125,7 +125,9 @@ def _name_parts_literal_regex(literal: str, entity_type: EntityType) -> str:
 
 def _strftime_pattern_error(pattern: str) -> str | None:
     try:
-        rendered = datetime(2001, 2, 3, 4, 5, 6).strftime(pattern)
+        # Use an aware probe so timezone directives such as ``%z`` and ``%Z``
+        # render values that can be parsed back with the same format.
+        rendered = datetime(2001, 2, 3, 4, 5, 6, tzinfo=timezone.utc).strftime(pattern)
         datetime.strptime(rendered, pattern)
     except ValueError as exc:
         return str(exc)
@@ -204,6 +206,12 @@ def _iter_reference_issues(
 
 
 def _cycle_columns(plan: PiiReplacementPlan) -> list[str]:
+    """Return replacement columns involved in a dependency cycle.
+
+    The current allowed dependency matrix is acyclic, so normally validated
+    plans cannot contain a cycle. Keep this dataframe-aware gate as a defensive
+    check in case that matrix evolves or model validation is bypassed.
+    """
     targets = {spec.column_name for spec in plan.columns_to_replace}
     adjacency: dict[str, set[str]] = {column: set() for column in targets}
     indegree = dict.fromkeys(targets, 0)

--- a/src/nemo_safe_synthesizer/pii_replacer/planning/validation.py
+++ b/src/nemo_safe_synthesizer/pii_replacer/planning/validation.py
@@ -33,9 +33,8 @@ def protected_columns(
     data_config: DataParameters,
     time_series: TimeSeriesParameters | None = None,
 ) -> frozenset[str]:
-    """Return structural columns that automatic replacement must preserve."""
+    """Return ordering columns that automatic replacement must preserve."""
     candidates = {
-        data_config.group_training_examples_by,
         data_config.order_training_examples_by,
         time_series.timestamp_column if time_series is not None else None,
     }
@@ -46,7 +45,14 @@ def _template_regex(pattern: str) -> tuple[re.Pattern[str] | None, str | None]:
     parts: list[str] = []
     has_variable = False
     index = 0
-    token_regex = {"#": r"\d", "^": "[A-Z]", "@": "[a-z]", "*": "[A-Za-z0-9]"}
+    token_regex = {
+        "#": r"\d",
+        "^": "[A-Z]",
+        "@": "[a-z]",
+        "&": "[A-Z0-9]",
+        "%": "[a-z0-9]",
+        "*": "[A-Za-z0-9]",
+    }
 
     while index < len(pattern):
         char = pattern[index]
@@ -88,7 +94,8 @@ def _name_parts_regex(
     parts: list[str] = []
     cursor = 0
     for match in matches:
-        parts.append(re.escape(pattern[cursor : match.start()]))
+        literal = pattern[cursor : match.start()]
+        parts.append(_name_parts_literal_regex(literal, entity_type))
         token = match.group(1).lower()
         if token not in _NAME_PART_TOKENS:
             return None, f"uses unknown placeholder {match.group(0)!r}"
@@ -103,11 +110,17 @@ def _name_parts_regex(
         else:
             parts.append(r"[^@\s]+")
         cursor = match.end()
-    parts.append(re.escape(pattern[cursor:]))
+    parts.append(_name_parts_literal_regex(pattern[cursor:], entity_type))
 
     if entity_type is EntityType.EMAIL and "@" not in pattern:
         return None, "does not contain '@'"
     return re.compile("".join(parts), re.UNICODE), None
+
+
+def _name_parts_literal_regex(literal: str, entity_type: EntityType) -> str:
+    if entity_type is not EntityType.EMAIL:
+        return re.escape(literal)
+    return "".join(r"\d" if character == "#" else re.escape(character) for character in literal)
 
 
 def _strftime_pattern_error(pattern: str) -> str | None:

--- a/src/nemo_safe_synthesizer/sdk/config_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/config_builder.py
@@ -198,14 +198,15 @@ class ConfigBuilder:
     ) -> Self:
         """Request or disable PII replacement.
 
-        This branch contains only a placeholder configuration. Pass
-        ``enable=False`` to set ``replace_pii=None`` and run the pipeline.
+        The configuration drives :meth:`SafeSynthesizer.plan_pii_replacement`.
+        Replacement execution is deferred; pass ``enable=False`` to set
+        ``replace_pii=None`` and run the synthesis pipeline.
 
         Args:
             config: PII replacement configuration object or raw mapping.
             enable: When ``False``, disables PII replacement entirely
                 and clears any previously set config.
-            **kwargs: Reserved for the replacement configuration added later.
+            **kwargs: Field-level replacement configuration overrides.
 
         Returns:
             This builder instance with PII replacement configured.

--- a/src/nemo_safe_synthesizer/sdk/library_builder.py
+++ b/src/nemo_safe_synthesizer/sdk/library_builder.py
@@ -13,26 +13,17 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pandas as pd
-from datasets import Dataset
 
 from ..cli.artifact_structure import Workdir
 from ..config import (
     SafeSynthesizerParameters,
 )
-from ..config.autoconfig import AutoConfigResolver
 from ..config.unknown_fields import UnknownFieldBehavior, normalize_unknown_fields
 from ..configurator.parameters import Parameters
 from ..errors import ParameterError
-from ..evaluation.evaluator import Evaluator
-from ..generation.timeseries_backend import TimeseriesBackend
-from ..generation.vllm_backend import VllmBackend
-from ..holdout.holdout import Holdout
-from ..llm.metadata import ModelMetadata
 from ..llm.utils import get_device_name
 from ..observability import LogCategory, configure_logging_from_workdir, get_logger, initialize_observability, traced
 from ..package_info import __version__
-from ..preflight import PreflightReport, PreflightStage, run_preflight
-from ..results import SafeSynthesizerResults, make_nss_results
 from ..telemetry import (
     DeploymentTypeEnum,
     NSSTrainingAndGenerationEvent,
@@ -44,13 +35,17 @@ from ..telemetry import (
     bucket_records,
     sanitize_model_for_telemetry,
 )
-from ..training.huggingface_backend import HuggingFaceBackend
 from .config_builder import ConfigBuilder
 
 logger = get_logger(__name__)
 
 if TYPE_CHECKING:
+    from ..config.replace_pii import PiiReplacementPlan
+    from ..evaluation.evaluator import Evaluator
     from ..generation.backend import GeneratorBackend
+    from ..llm.metadata import ModelMetadata
+    from ..preflight import PreflightReport
+    from ..results import SafeSynthesizerResults
     from ..training.backend import TrainingBackend
 
 
@@ -291,6 +286,8 @@ class SafeSynthesizer(ConfigBuilder):
         Returns:
             Self for method chaining.
         """
+        from ..llm.metadata import ModelMetadata
+
         self._ensure_observability()
         assert self._workdir is not None
         # Use source paths which point to parent workdir when resuming for generation
@@ -363,6 +360,44 @@ class SafeSynthesizer(ConfigBuilder):
             )
         return self
 
+    @traced("SafeSynthesizer.plan_pii_replacement", category=LogCategory.RUNTIME)
+    def plan_pii_replacement(self, output_path: Path | str | None = None) -> PiiReplacementPlan:
+        """Resolve a PII replacement plan from the full input dataframe.
+
+        This plan-only workflow does not split the input or enter model
+        metadata, training, generation, replacement, or evaluation stages.
+        When ``output_path`` is provided, the resolved plan is also written as
+        reusable YAML.
+
+        Args:
+            output_path: Optional destination for the replacement-plan YAML.
+
+        Returns:
+            The dataframe-aware validated replacement plan.
+
+        Raises:
+            ParameterError: If PII replacement is disabled.
+            ValueError: If no valid data source is configured.
+        """
+        self._ensure_observability()
+        self.resolve()
+
+        assert self._nss_config is not None
+        assert isinstance(self._data_source, pd.DataFrame)
+        replace_pii = self._nss_config.replace_pii
+        if replace_pii is None:
+            raise ParameterError("PII replacement is disabled; configure replace_pii before planning")
+
+        from ..pii_replacer.planning import resolve_plan
+
+        return resolve_plan(
+            self._data_source,
+            replace_pii,
+            self._nss_config.data,
+            self._nss_config.time_series,
+            output_path=output_path,
+        )
+
     @traced("SafeSynthesizer.process_data", category=LogCategory.RUNTIME)
     def process_data(self, check_only: bool = False) -> SafeSynthesizer:
         """Perform train/test split, auto-config resolution, and optional PII replacement.
@@ -388,6 +423,11 @@ class SafeSynthesizer(ConfigBuilder):
         Returns:
             Self for method chaining.
         """
+        from ..config.autoconfig import AutoConfigResolver
+        from ..holdout.holdout import Holdout
+        from ..llm.metadata import ModelMetadata
+        from ..preflight import PreflightStage, run_preflight
+
         self._total_start = time.monotonic()
         if not os.environ.get("NSS_PHASE"):
             os.environ["NSS_PHASE"] = "process_data"
@@ -519,6 +559,10 @@ class SafeSynthesizer(ConfigBuilder):
             RuntimeError: If called after ``load_from_save_path()`` or
                 before ``process_data()``.
         """
+        from datasets import Dataset
+
+        from ..training.huggingface_backend import HuggingFaceBackend
+
         if self._loaded_from_save_path:
             raise RuntimeError(
                 "train() cannot be called after load_from_save_path(). "
@@ -566,6 +610,9 @@ class SafeSynthesizer(ConfigBuilder):
         Returns:
             Self for method chaining.
         """
+        from ..generation.timeseries_backend import TimeseriesBackend
+        from ..generation.vllm_backend import VllmBackend
+
         if not os.environ.get("NSS_PHASE"):
             os.environ["NSS_PHASE"] = "generate"
         if TYPE_CHECKING:
@@ -605,6 +652,9 @@ class SafeSynthesizer(ConfigBuilder):
         Returns:
             Self for method chaining.
         """
+        from ..evaluation.evaluator import Evaluator
+        from ..results import make_nss_results
+
         if not os.environ.get("NSS_PHASE"):
             os.environ["NSS_PHASE"] = "evaluate"
         if TYPE_CHECKING:

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -742,6 +742,7 @@ class TestRunReplacePii:
         assert plan.columns_to_replace[0].column_name == "col1"
         assert plan.columns_to_replace[0].entity_type is EntityType.UNIQUE_IDENTIFIER
 
+
 class TestRunGenerateOptions:
     """Tests for run generate command options."""
 

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -15,6 +15,8 @@ import nemo_safe_synthesizer.sdk.library_builder  # noqa: F401 - ensure submodul
 from nemo_safe_synthesizer.cli.run import run
 from nemo_safe_synthesizer.cli.settings import CLISettings
 from nemo_safe_synthesizer.cli.utils import merge_overrides
+from nemo_safe_synthesizer.config.replace_pii import EntityType
+from nemo_safe_synthesizer.pii_replacer.planning import load_plan
 from nemo_safe_synthesizer.telemetry import DeploymentTypeEnum, TaskStatusEnum
 from nemo_safe_synthesizer.tooling import PreflightRenderContext
 
@@ -54,6 +56,7 @@ def mock_safe_synthesizer() -> MagicMock:
     ss.generate.return_value = ss
     ss.evaluate.return_value = ss
     ss.load_from_save_path.return_value = ss
+    ss.plan_pii_replacement.return_value = MagicMock()
     ss.run.return_value = ss
     ss.save_results.return_value = ss  # Return self for method chaining
     ss.generator.teardown.return_value = None
@@ -638,6 +641,106 @@ class TestValidateMode:
         assert render_context.data_source == str(dummy_csv)
         assert render_context.artifact_dir == mock_workdir.run_dir
 
+
+class TestRunReplacePii:
+    """Tests for the plan-only PII replacement command."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_observability(self, monkeypatch: pytest.MonkeyPatch):
+        """Keep real CLI invocations isolated from global logging state."""
+        obs._INITIALIZED_OBSERVABILITY = False
+        monkeypatch.delenv("NSS_PHASE", raising=False)
+        for name in ("NSS_LOG_LEVEL", "NSS_LOG_FORMAT", "NSS_LOG_FILE", "NSS_LOG_COLOR"):
+            monkeypatch.delenv(name, raising=False)
+
+        yield
+
+        obs._INITIALIZED_OBSERVABILITY = False
+
+    def test_help_exposes_plan_only_command(self, cli_runner: CliRunner) -> None:
+        result = cli_runner.invoke(run, ["replace-pii", "--help"])
+
+        assert result.exit_code == 0
+        assert "--plan-only" in result.output
+
+    def test_plan_only_uses_full_input_without_pipeline_stages(
+        self,
+        cli_runner: CliRunner,
+        dummy_csv: Path,
+        mock_dataframe: MagicMock,
+        mock_workdir: MagicMock,
+        patched_run_dependencies: dict,
+    ) -> None:
+        result = cli_runner.invoke(
+            run,
+            ["replace-pii", "--plan-only", "--data-source", str(dummy_csv)],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        setup_kwargs = patched_run_dependencies["common_setup"].call_args.kwargs
+        assert setup_kwargs["phase"] == "replace_pii"
+        assert setup_kwargs["skip_wandb"] is True
+
+        nss = patched_run_dependencies["safe_synthesizer"]
+        nss.with_data_source.assert_called_once_with(mock_dataframe)
+        nss.plan_pii_replacement.assert_called_once_with(output_path=mock_workdir.run_dir / "pii_replacement_plan.yaml")
+        nss.process_data.assert_not_called()
+        nss.train.assert_not_called()
+        nss.generate.assert_not_called()
+        nss.evaluate.assert_not_called()
+        nss.run.assert_not_called()
+
+    def test_command_requires_plan_only_until_replacement_exists(
+        self,
+        cli_runner: CliRunner,
+        dummy_csv: Path,
+        patched_run_dependencies: dict,
+    ) -> None:
+        result = cli_runner.invoke(run, ["replace-pii", "--data-source", str(dummy_csv)])
+
+        assert result.exit_code != 0
+        assert "requires --plan-only" in result.output
+        patched_run_dependencies["common_setup"].assert_not_called()
+
+    def test_plan_only_writes_reusable_yaml_from_dataset(
+        self,
+        cli_runner: CliRunner,
+        dummy_csv: Path,
+        tmp_path: Path,
+    ) -> None:
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "replace_pii:\n"
+            "  replacement_plan:\n"
+            "    scope: dataframe\n"
+            "    columns_to_replace:\n"
+            "      - column_name: col1\n"
+            "        entity_type: unique_identifier\n"
+        )
+        run_path = tmp_path / "plan-run"
+
+        result = cli_runner.invoke(
+            run,
+            [
+                "replace-pii",
+                "--plan-only",
+                "--config",
+                str(config_path),
+                "--data-source",
+                str(dummy_csv),
+                "--run-path",
+                str(run_path),
+            ],
+            catch_exceptions=False,
+        )
+
+        assert result.exit_code == 0
+        plan_path = run_path / "pii_replacement_plan.yaml"
+        assert plan_path.exists()
+        plan = load_plan(plan_path)
+        assert plan.columns_to_replace[0].column_name == "col1"
+        assert plan.columns_to_replace[0].entity_type is EntityType.UNIQUE_IDENTIFIER
 
 class TestRunGenerateOptions:
     """Tests for run generate command options."""

--- a/tests/config/test_parameters.py
+++ b/tests/config/test_parameters.py
@@ -78,15 +78,16 @@ def test_emit_telemetry_from_yaml_uses_env_when_unset(monkeypatch):
         ({"steps": []}, "replace_pii.steps"),
     ],
 )
-def test_replace_pii_v2_fields_raise_removed_error(payload: dict[str, object], field: str):
-    pattern = rf"PII replacement v2 configuration was removed.*{field}"
+def test_replace_pii_v2_fields_raise_schema_compatibility_error(payload: dict[str, object], field: str):
+    message = "configuration uses the PII replacement v2 schema.*Configure replace_pii.replacement_plan instead"
+    pattern = rf"{message}.*{field}"
     with pytest.raises((ParameterError, ValidationError), match=pattern):
         SafeSynthesizerParameters.model_validate({"replace_pii": payload})
-    with pytest.raises((ParameterError, ValidationError), match="PII replacement v2 configuration was removed"):
+    with pytest.raises((ParameterError, ValidationError), match=message):
         SafeSynthesizerParameters.model_validate({"unknown_fields": "ignore", "replace_pii": payload})
-    with pytest.raises((ParameterError, ValidationError), match="PII replacement v2 configuration was removed"):
+    with pytest.raises((ParameterError, ValidationError), match=message):
         ReplacePiiConfig.model_validate(payload)
-    with pytest.raises(ParameterError, match="PII replacement v2 configuration was removed"):
+    with pytest.raises(ParameterError, match=message):
         ReplacePiiConfig.from_config_source(payload)
 
 

--- a/tests/config/test_replace_pii.py
+++ b/tests/config/test_replace_pii.py
@@ -361,20 +361,21 @@ class TestReplacePiiConfig:
         assert config.replacement_plan == AUTO_DISCOVERY
         assert config.is_auto_discovery
         assert config.plan_path is None
-        assert config.inline_plan is None
+        assert config.embedded_plan is None
+        assert config.llm is None
         assert config.sampler.backend is PiiSamplerBackend.MANAGED
         assert ENTITY_BY_TYPE[EntityType.FREE_TEXT].action is EntityAction.REPLACE_IN_TEXT
 
-    def test_plan_path_and_inline_plan_properties(self) -> None:
+    def test_plan_path_and_embedded_plan_properties(self) -> None:
         path_config = ReplacePiiConfig(replacement_plan="/tmp/plan.yaml")
         assert path_config.plan_path == "/tmp/plan.yaml"
-        assert path_config.inline_plan is None
+        assert path_config.embedded_plan is None
         assert not path_config.is_auto_discovery
 
         plan = PiiReplacementPlan(scope=PiiReplacementScope.RECORD)
-        inline = ReplacePiiConfig(replacement_plan=plan)
-        assert inline.inline_plan is plan
-        assert inline.plan_path is None
+        embedded = ReplacePiiConfig(replacement_plan=plan)
+        assert embedded.embedded_plan is plan
+        assert embedded.plan_path is None
 
     def test_path_object_is_stored_as_string(self) -> None:
         config = ReplacePiiConfig.model_validate({"replacement_plan": Path("plans/pii.yaml")})
@@ -401,20 +402,38 @@ class TestReplacePiiConfig:
                 }
             }
         )
-        assert isinstance(config.inline_plan, PiiReplacementPlan)
-        assert config.inline_plan.scope.value == "record"
+        assert isinstance(config.embedded_plan, PiiReplacementPlan)
+        assert config.embedded_plan.scope.value == "record"
 
-    def test_malformed_inline_plan_raises_parameter_error(self) -> None:
-        with _raises("invalid inline replacement plan"):
+    def test_malformed_embedded_plan_raises_parameter_error(self) -> None:
+        with _raises("invalid embedded replacement plan"):
             ReplacePiiConfig.model_validate({"replacement_plan": {"scope": "galaxy"}})
 
-    def test_llm_defaults_to_none_and_any_value_is_rejected(self) -> None:
-        assert ReplacePiiConfig().llm is None
-        assert ReplacePiiConfig.model_validate({"llm": None}).llm is None
-        with _raises("replace_pii.llm is not supported"):
-            ReplacePiiConfig.model_validate({"llm": {"max_workers": 8}})
-        with _raises("replace_pii.llm is not supported"):
-            ReplacePiiConfig(llm=LLMConfig())
+    def test_llm_mapping_configures_shared_openai_compatible_inference(self) -> None:
+        config = ReplacePiiConfig.model_validate(
+            {
+                "llm": {
+                    "endpoint_url": "http://localhost:8000/v1",
+                    "model_id": "local-model",
+                }
+            }
+        )
+
+        assert config.llm == LLMConfig(
+            endpoint_url="http://localhost:8000/v1",
+            model_id="local-model",
+        )
+        assert config.llm is not None
+        assert config.llm.max_workers == 8
+
+    def test_empty_llm_mapping_enables_inference_defaults(self) -> None:
+        config = ReplacePiiConfig.model_validate({"llm": {}})
+
+        assert config.llm == LLMConfig()
+
+    def test_llm_max_workers_must_be_positive(self) -> None:
+        with _raises("greater than or equal to 1"):
+            ReplacePiiConfig.model_validate({"llm": {"max_workers": 0}})
 
     def test_resolved_managed_assets_path_uses_override(self, tmp_path: Path) -> None:
         config = ReplacePiiConfig.model_validate(

--- a/tests/config/test_replace_pii.py
+++ b/tests/config/test_replace_pii.py
@@ -361,21 +361,21 @@ class TestReplacePiiConfig:
         assert config.replacement_plan == AUTO_DISCOVERY
         assert config.is_auto_discovery
         assert config.plan_path is None
-        assert config.embedded_plan is None
+        assert config.inline_plan is None
         assert config.llm is None
         assert config.sampler.backend is PiiSamplerBackend.MANAGED
         assert ENTITY_BY_TYPE[EntityType.FREE_TEXT].action is EntityAction.REPLACE_IN_TEXT
 
-    def test_plan_path_and_embedded_plan_properties(self) -> None:
+    def test_plan_path_and_inline_plan_properties(self) -> None:
         path_config = ReplacePiiConfig(replacement_plan="/tmp/plan.yaml")
         assert path_config.plan_path == "/tmp/plan.yaml"
-        assert path_config.embedded_plan is None
+        assert path_config.inline_plan is None
         assert not path_config.is_auto_discovery
 
         plan = PiiReplacementPlan(scope=PiiReplacementScope.RECORD)
-        embedded = ReplacePiiConfig(replacement_plan=plan)
-        assert embedded.embedded_plan is plan
-        assert embedded.plan_path is None
+        inline = ReplacePiiConfig(replacement_plan=plan)
+        assert inline.inline_plan is plan
+        assert inline.plan_path is None
 
     def test_path_object_is_stored_as_string(self) -> None:
         config = ReplacePiiConfig.model_validate({"replacement_plan": Path("plans/pii.yaml")})
@@ -402,11 +402,11 @@ class TestReplacePiiConfig:
                 }
             }
         )
-        assert isinstance(config.embedded_plan, PiiReplacementPlan)
-        assert config.embedded_plan.scope.value == "record"
+        assert isinstance(config.inline_plan, PiiReplacementPlan)
+        assert config.inline_plan.scope.value == "record"
 
-    def test_malformed_embedded_plan_raises_parameter_error(self) -> None:
-        with _raises("invalid embedded replacement plan"):
+    def test_malformed_inline_plan_raises_parameter_error(self) -> None:
+        with _raises("invalid inline replacement plan"):
             ReplacePiiConfig.model_validate({"replacement_plan": {"scope": "galaxy"}})
 
     def test_llm_mapping_configures_shared_openai_compatible_inference(self) -> None:

--- a/tests/config/test_replace_pii.py
+++ b/tests/config/test_replace_pii.py
@@ -367,6 +367,27 @@ class TestReplacePiiConfig:
         assert config.sampler.backend is PiiSamplerBackend.MANAGED
         assert ENTITY_BY_TYPE[EntityType.FREE_TEXT].action is EntityAction.REPLACE_IN_TEXT
 
+    def test_missing_schema_version_is_v1_and_sparse_serialization_includes_it(self) -> None:
+        config = ReplacePiiConfig.model_validate({})
+
+        assert config.schema_version == 1
+        assert config.model_dump(exclude_unset=True)["schema_version"] == 1
+
+    def test_sparse_parent_serialization_includes_schema_version(self) -> None:
+        config = SafeSynthesizerParameters(replace_pii=ReplacePiiConfig())
+
+        assert config.model_dump(exclude_unset=True)["replace_pii"]["schema_version"] == 1
+
+    @pytest.mark.parametrize("schema_version", [2, 0, -1])
+    def test_unsupported_schema_version_is_rejected(self, schema_version: int) -> None:
+        with _raises(f"schema version {schema_version} is unsupported.*supports version 1"):
+            ReplacePiiConfig.model_validate({"schema_version": schema_version})
+
+    @pytest.mark.parametrize("schema_version", [True, 1.0, "1", None])
+    def test_non_integer_schema_version_is_rejected(self, schema_version: object) -> None:
+        with _raises("schema_version must be an integer"):
+            ReplacePiiConfig.model_validate({"schema_version": schema_version})
+
     def test_plan_path_and_inline_plan_properties(self) -> None:
         path_config = ReplacePiiConfig(replacement_plan="/tmp/plan.yaml")
         assert path_config.plan_path == "/tmp/plan.yaml"

--- a/tests/config/test_replace_pii.py
+++ b/tests/config/test_replace_pii.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
+from nemo_safe_synthesizer.config.parameters import SafeSynthesizerParameters
 from nemo_safe_synthesizer.config.replace_pii import (
     ALLOWED_DEPENDS_ON,
     AUTO_DISCOVERY,
@@ -409,22 +410,24 @@ class TestReplacePiiConfig:
         with _raises("invalid inline replacement plan"):
             ReplacePiiConfig.model_validate({"replacement_plan": {"scope": "galaxy"}})
 
-    def test_llm_mapping_configures_shared_openai_compatible_inference(self) -> None:
+    def test_llm_mapping_configures_shared_inference_behavior(self) -> None:
         config = ReplacePiiConfig.model_validate(
             {
                 "llm": {
-                    "endpoint_url": "http://localhost:8000/v1",
                     "model_id": "local-model",
                 }
             }
         )
 
-        assert config.llm == LLMConfig(
-            endpoint_url="http://localhost:8000/v1",
-            model_id="local-model",
-        )
+        assert config.llm == LLMConfig(model_id="local-model")
         assert config.llm is not None
         assert config.llm.max_workers == 8
+
+    def test_llm_endpoint_is_runtime_only(self) -> None:
+        with _raises("Unknown configuration field 'replace_pii.llm.endpoint_url'"):
+            SafeSynthesizerParameters.model_validate(
+                {"replace_pii": {"llm": {"endpoint_url": "http://localhost:8000/v1"}}}
+            )
 
     def test_empty_llm_mapping_enables_inference_defaults(self) -> None:
         config = ReplacePiiConfig.model_validate({"llm": {}})

--- a/tests/config/test_replace_pii.py
+++ b/tests/config/test_replace_pii.py
@@ -358,7 +358,7 @@ class TestPiiReplacementPlan:
 class TestReplacePiiConfig:
     def test_defaults_are_auto_discovery(self) -> None:
         config = ReplacePiiConfig()
-        assert config.schema_version == 1
+        assert config.schema_version == 3
         assert config.replacement_plan == AUTO_DISCOVERY
         assert config.is_auto_discovery
         assert config.plan_path is None
@@ -367,20 +367,20 @@ class TestReplacePiiConfig:
         assert config.sampler.backend is PiiSamplerBackend.MANAGED
         assert ENTITY_BY_TYPE[EntityType.FREE_TEXT].action is EntityAction.REPLACE_IN_TEXT
 
-    def test_missing_schema_version_is_v1_and_sparse_serialization_includes_it(self) -> None:
+    def test_missing_schema_version_is_v3_and_sparse_serialization_includes_it(self) -> None:
         config = ReplacePiiConfig.model_validate({})
 
-        assert config.schema_version == 1
-        assert config.model_dump(exclude_unset=True)["schema_version"] == 1
+        assert config.schema_version == 3
+        assert config.model_dump(exclude_unset=True)["schema_version"] == 3
 
     def test_sparse_parent_serialization_includes_schema_version(self) -> None:
         config = SafeSynthesizerParameters(replace_pii=ReplacePiiConfig())
 
-        assert config.model_dump(exclude_unset=True)["replace_pii"]["schema_version"] == 1
+        assert config.model_dump(exclude_unset=True)["replace_pii"]["schema_version"] == 3
 
-    @pytest.mark.parametrize("schema_version", [2, 0, -1])
+    @pytest.mark.parametrize("schema_version", [1, 2, 0, -1])
     def test_unsupported_schema_version_is_rejected(self, schema_version: int) -> None:
-        with _raises(f"schema version {schema_version} is unsupported.*supports version 1"):
+        with _raises(f"schema version {schema_version} is unsupported.*supports version 3"):
             ReplacePiiConfig.model_validate({"schema_version": schema_version})
 
     @pytest.mark.parametrize("schema_version", [True, 1.0, "1", None])

--- a/tests/pii_replacer/planning/test_assembly.py
+++ b/tests/pii_replacer/planning/test_assembly.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from nemo_safe_synthesizer.config.replace_pii import EntityType, PiiReplacementScope
+from nemo_safe_synthesizer.errors import ParameterError
+from nemo_safe_synthesizer.pii_replacer.planning import (
+    ColumnClassification,
+    DependencyCandidate,
+    apply_dependencies,
+    derive_dependency_candidates,
+    pattern_grammar_catalog,
+    plan_from_classifications,
+)
+
+
+@pytest.mark.unit
+class TestPlanAssembly:
+    def test_replacement_membership_is_derived_from_entity_metadata(self) -> None:
+        plan = plan_from_classifications(
+            PiiReplacementScope.GROUP,
+            [
+                ColumnClassification(column_name="patient_id", entity_type=EntityType.UNIQUE_IDENTIFIER),
+                ColumnClassification(column_name="email", entity_type=EntityType.EMAIL),
+                ColumnClassification(column_name="company", entity_type=EntityType.ORGANIZATION),
+                ColumnClassification(column_name="notes", entity_type=None),
+            ],
+            protected_columns=frozenset({"email"}),
+        )
+
+        assert plan.scope is PiiReplacementScope.GROUP
+        assert [spec.column_name for spec in plan.columns_to_replace] == ["patient_id"]
+
+    def test_dependency_candidates_are_derived_from_catalog_relationships(self) -> None:
+        classifications = [
+            ColumnClassification(column_name="email", entity_type=EntityType.EMAIL),
+            ColumnClassification(column_name="first_name", entity_type=EntityType.FIRST_NAME),
+            ColumnClassification(column_name="company", entity_type=EntityType.ORGANIZATION),
+            ColumnClassification(column_name="gender", entity_type=EntityType.GENDER),
+        ]
+        plan = plan_from_classifications(PiiReplacementScope.DATAFRAME, classifications)
+
+        candidates = derive_dependency_candidates(plan, classifications)
+
+        assert candidates == [
+            DependencyCandidate(
+                target_column="email",
+                target_entity_type=EntityType.EMAIL,
+                source_column="first_name",
+                source_entity_type=EntityType.FIRST_NAME,
+            ),
+            DependencyCandidate(
+                target_column="email",
+                target_entity_type=EntityType.EMAIL,
+                source_column="company",
+                source_entity_type=EntityType.ORGANIZATION,
+            ),
+            DependencyCandidate(
+                target_column="first_name",
+                target_entity_type=EntityType.FIRST_NAME,
+                source_column="gender",
+                source_entity_type=EntityType.GENDER,
+            ),
+        ]
+
+    def test_selected_dependencies_are_applied_to_the_plan(self) -> None:
+        classifications = [
+            ColumnClassification(column_name="email", entity_type=EntityType.EMAIL),
+            ColumnClassification(column_name="company", entity_type=EntityType.ORGANIZATION),
+        ]
+        plan = plan_from_classifications(PiiReplacementScope.DATAFRAME, classifications)
+        candidate = derive_dependency_candidates(plan, classifications)[0]
+
+        result = apply_dependencies(plan, [candidate])
+
+        assert result.columns_to_replace[0].depends_on[0].column_name == "company"
+        assert result.columns_to_replace[0].depends_on[0].entity_type is EntityType.ORGANIZATION
+
+    def test_dependency_candidates_reject_relationships_outside_the_catalog(self) -> None:
+        with pytest.raises(ParameterError, match="cannot condition"):
+            DependencyCandidate(
+                target_column="email",
+                target_entity_type=EntityType.EMAIL,
+                source_column="gender",
+                source_entity_type=EntityType.GENDER,
+            )
+
+    def test_dependencies_must_match_a_replacement_target(self) -> None:
+        plan = plan_from_classifications(
+            PiiReplacementScope.DATAFRAME,
+            [ColumnClassification(column_name="email", entity_type=EntityType.EMAIL)],
+        )
+        candidate = DependencyCandidate(
+            target_column="name",
+            target_entity_type=EntityType.FULL_NAME,
+            source_column="gender",
+            source_entity_type=EntityType.GENDER,
+        )
+
+        with pytest.raises(ParameterError, match="unknown replacement column"):
+            apply_dependencies(plan, [candidate])
+
+    def test_pattern_grammar_catalog_documents_supported_tokens(self) -> None:
+        grammars = pattern_grammar_catalog()
+
+        assert grammars["character_mask"]["tokens"] == {
+            "#": "digit 0-9",
+            "^": "uppercase letter A-Z",
+            "@": "lowercase letter a-z",
+            "&": "digit or uppercase letter",
+            "%": "digit or lowercase letter",
+            "*": "digit or letter",
+            "[abc]": "one literal character from the brackets",
+            "\\x": "literal x",
+        }
+        name_placeholders = grammars["name_parts"]["placeholders"]
+        assert isinstance(name_placeholders, dict)
+        assert "{domain}" in name_placeholders

--- a/tests/pii_replacer/planning/test_io.py
+++ b/tests/pii_replacer/planning/test_io.py
@@ -19,21 +19,21 @@ class TestPlanIo:
         path = save_plan(plan, tmp_path / "nested" / "plan.yaml")
 
         assert path == tmp_path / "nested" / "plan.yaml"
-        assert yaml.safe_load(path.read_text())["schema_version"] == 1
+        assert yaml.safe_load(path.read_text())["schema_version"] == 3
         assert load_plan(path) == plan
 
-    def test_load_treats_missing_schema_version_as_v1(self, tmp_path: Path) -> None:
+    def test_load_treats_missing_schema_version_as_v3(self, tmp_path: Path) -> None:
         path = tmp_path / "plan.yaml"
         path.write_text("scope: dataframe\ncolumns_to_replace: []\n")
 
         assert load_plan(path) == PiiReplacementPlan()
 
-    @pytest.mark.parametrize("schema_version", [2, 0, -1])
+    @pytest.mark.parametrize("schema_version", [1, 2, 0, -1])
     def test_load_rejects_unsupported_schema_version(self, tmp_path: Path, schema_version: int) -> None:
         path = tmp_path / "plan.yaml"
         path.write_text(f"schema_version: {schema_version}\nscope: dataframe\ncolumns_to_replace: []\n")
 
-        with pytest.raises(ParameterError, match=f"unsupported schema version {schema_version}.*supports version 1"):
+        with pytest.raises(ParameterError, match=f"unsupported schema version {schema_version}.*supports version 3"):
             load_plan(path)
 
     @pytest.mark.parametrize("schema_version", [True, 1.0, "1", None])

--- a/tests/pii_replacer/planning/test_io.py
+++ b/tests/pii_replacer/planning/test_io.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from nemo_safe_synthesizer.config.replace_pii import EntityType, PiiColumnPlan, PiiReplacementPlan
+from nemo_safe_synthesizer.errors import ParameterError
+from nemo_safe_synthesizer.pii_replacer.planning import load_plan, save_plan
+
+
+@pytest.mark.unit
+class TestPlanIo:
+    def test_save_then_load_round_trip(self, tmp_path: Path) -> None:
+        plan = PiiReplacementPlan(columns_to_replace=[PiiColumnPlan(column_name="email", entity_type=EntityType.EMAIL)])
+
+        path = save_plan(plan, tmp_path / "nested" / "plan.yaml")
+
+        assert path == tmp_path / "nested" / "plan.yaml"
+        assert load_plan(path) == plan
+
+    def test_load_rejects_non_mapping_yaml(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text("- not\n- a\n- mapping\n")
+
+        with pytest.raises(ParameterError, match="must contain a mapping"):
+            load_plan(path)
+
+    def test_load_wraps_missing_file_error(self, tmp_path: Path) -> None:
+        with pytest.raises(ParameterError, match="Could not read PII replacement plan file"):
+            load_plan(tmp_path / "missing.yaml")

--- a/tests/pii_replacer/planning/test_io.py
+++ b/tests/pii_replacer/planning/test_io.py
@@ -4,6 +4,7 @@
 from pathlib import Path
 
 import pytest
+import yaml
 
 from nemo_safe_synthesizer.config.replace_pii import EntityType, PiiColumnPlan, PiiReplacementPlan
 from nemo_safe_synthesizer.errors import ParameterError
@@ -18,7 +19,38 @@ class TestPlanIo:
         path = save_plan(plan, tmp_path / "nested" / "plan.yaml")
 
         assert path == tmp_path / "nested" / "plan.yaml"
+        assert yaml.safe_load(path.read_text())["schema_version"] == 1
         assert load_plan(path) == plan
+
+    def test_load_treats_missing_schema_version_as_v1(self, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text("scope: dataframe\ncolumns_to_replace: []\n")
+
+        assert load_plan(path) == PiiReplacementPlan()
+
+    @pytest.mark.parametrize("schema_version", [2, 0, -1])
+    def test_load_rejects_unsupported_schema_version(self, tmp_path: Path, schema_version: int) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text(f"schema_version: {schema_version}\nscope: dataframe\ncolumns_to_replace: []\n")
+
+        with pytest.raises(ParameterError, match=f"unsupported schema version {schema_version}.*supports version 1"):
+            load_plan(path)
+
+    @pytest.mark.parametrize("schema_version", [True, 1.0, "1", None])
+    def test_load_rejects_non_integer_schema_version(self, tmp_path: Path, schema_version: object) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text(
+            yaml.safe_dump(
+                {
+                    "schema_version": schema_version,
+                    "scope": "dataframe",
+                    "columns_to_replace": [],
+                }
+            )
+        )
+
+        with pytest.raises(ParameterError, match="schema_version must be an integer"):
+            load_plan(path)
 
     def test_load_rejects_non_mapping_yaml(self, tmp_path: Path) -> None:
         path = tmp_path / "plan.yaml"

--- a/tests/pii_replacer/planning/test_resolver.py
+++ b/tests/pii_replacer/planning/test_resolver.py
@@ -51,7 +51,8 @@ class RecordingEnhancer(PlanEnhancer):
 
 
 @pytest.fixture
-def patient_df() -> pd.DataFrame:
+def fixture_patient_df() -> pd.DataFrame:
+    """Return grouped patient rows for replacement-plan discovery tests."""
     return pd.DataFrame(
         {
             "patient_id": [1, 1, 2, 2],
@@ -64,12 +65,12 @@ def patient_df() -> pd.DataFrame:
 
 @pytest.mark.unit
 class TestResolvePlan:
-    def test_auto_discovery_uses_empty_heuristic_by_default(self, patient_df: pd.DataFrame) -> None:
-        plan = resolve_plan(patient_df, ReplacePiiConfig(), DataParameters())
+    def test_auto_discovery_uses_empty_heuristic_by_default(self, fixture_patient_df: pd.DataFrame) -> None:
+        plan = resolve_plan(fixture_patient_df, ReplacePiiConfig(), DataParameters())
 
         assert plan == PiiReplacementPlan(scope=PiiReplacementScope.DATAFRAME)
 
-    def test_llm_enhancer_receives_heuristic_baseline(self, patient_df: pd.DataFrame) -> None:
+    def test_llm_enhancer_receives_heuristic_baseline(self, fixture_patient_df: pd.DataFrame) -> None:
         baseline = PiiReplacementPlan(
             columns_to_replace=[PiiColumnPlan(column_name="name", entity_type=EntityType.FULL_NAME)]
         )
@@ -80,7 +81,7 @@ class TestResolvePlan:
         enhancer = RecordingEnhancer(enhanced)
 
         result = resolve_plan(
-            patient_df,
+            fixture_patient_df,
             ReplacePiiConfig(llm=LLMConfig()),
             DataParameters(),
             discoverer=discoverer,
@@ -91,17 +92,17 @@ class TestResolvePlan:
         assert len(discoverer.inputs) == 1
         assert enhancer.calls == [(discoverer.inputs[0], baseline)]
 
-    def test_configured_llm_without_enhancer_fails(self, patient_df: pd.DataFrame) -> None:
+    def test_configured_llm_without_enhancer_fails(self, fixture_patient_df: pd.DataFrame) -> None:
         with pytest.raises(ParameterError, match="no LLM plan enhancer is available"):
             resolve_plan(
-                patient_df,
+                fixture_patient_df,
                 ReplacePiiConfig(llm=LLMConfig()),
                 DataParameters(),
             )
 
     def test_inline_plan_bypasses_discovery_but_retains_llm_for_replacement(
         self,
-        patient_df: pd.DataFrame,
+        fixture_patient_df: pd.DataFrame,
     ) -> None:
         plan = PiiReplacementPlan(columns_to_replace=[PiiColumnPlan(column_name="email", entity_type=EntityType.EMAIL)])
         discoverer = RecordingDiscoverer()
@@ -109,7 +110,7 @@ class TestResolvePlan:
         config = ReplacePiiConfig(replacement_plan=plan, llm=LLMConfig())
 
         result = resolve_plan(
-            patient_df,
+            fixture_patient_df,
             config,
             DataParameters(),
             discoverer=discoverer,
@@ -121,13 +122,13 @@ class TestResolvePlan:
         assert discoverer.inputs == []
         assert enhancer.calls == []
 
-    def test_plan_file_bypasses_discovery(self, patient_df: pd.DataFrame, tmp_path: Path) -> None:
+    def test_plan_file_bypasses_discovery(self, fixture_patient_df: pd.DataFrame, tmp_path: Path) -> None:
         path = tmp_path / "plan.yaml"
         path.write_text("scope: dataframe\ncolumns_to_replace:\n  - column_name: email\n    entity_type: email\n")
         discoverer = RecordingDiscoverer()
 
         result = resolve_plan(
-            patient_df,
+            fixture_patient_df,
             ReplacePiiConfig(replacement_plan=str(path)),
             DataParameters(),
             discoverer=discoverer,
@@ -136,9 +137,9 @@ class TestResolvePlan:
         assert result.columns_to_replace[0].column_name == "email"
         assert discoverer.inputs == []
 
-    def test_profiles_are_bounded_deterministic_and_mark_structural_grain(
+    def test_profiles_are_bounded_deterministic_and_separate_key_grain_from_protection(
         self,
-        patient_df: pd.DataFrame,
+        fixture_patient_df: pd.DataFrame,
     ) -> None:
         discoverer = RecordingDiscoverer()
         data_config = DataParameters(
@@ -146,9 +147,14 @@ class TestResolvePlan:
             order_training_examples_by="event_index",
         )
 
-        resolve_plan(patient_df, ReplacePiiConfig(), data_config, discoverer=discoverer)
+        resolve_plan(fixture_patient_df, ReplacePiiConfig(), data_config, discoverer=discoverer)
         first_input = discoverer.inputs[0]
-        resolve_plan(patient_df.sample(frac=1, random_state=7), ReplacePiiConfig(), data_config, discoverer=discoverer)
+        resolve_plan(
+            fixture_patient_df.sample(frac=1, random_state=7),
+            ReplacePiiConfig(),
+            data_config,
+            discoverer=discoverer,
+        )
         second_input = discoverer.inputs[1]
 
         first_profiles = {profile.column_name: profile for profile in first_input.column_profiles}
@@ -156,15 +162,17 @@ class TestResolvePlan:
         assert first_input.scope is PiiReplacementScope.GROUP
         assert first_input.protected_columns == frozenset({"event_index"})
         assert first_profiles["patient_id"].grain is ColumnGrain.key
-        assert first_profiles["event_index"].grain is ColumnGrain.key
+        assert first_profiles["patient_id"].protected is False
+        assert first_profiles["event_index"].grain is ColumnGrain.record
+        assert first_profiles["event_index"].protected is True
         assert first_profiles["name"].grain is ColumnGrain.group
         assert first_profiles["name"].samples == second_profiles["name"].samples
 
-    def test_output_path_persists_the_final_plan(self, patient_df: pd.DataFrame, tmp_path: Path) -> None:
+    def test_output_path_persists_the_final_plan(self, fixture_patient_df: pd.DataFrame, tmp_path: Path) -> None:
         path = tmp_path / "pii_replacement_plan.yaml"
 
         plan = resolve_plan(
-            patient_df,
+            fixture_patient_df,
             ReplacePiiConfig(),
             DataParameters(),
             output_path=path,

--- a/tests/pii_replacer/planning/test_resolver.py
+++ b/tests/pii_replacer/planning/test_resolver.py
@@ -99,7 +99,7 @@ class TestResolvePlan:
                 DataParameters(),
             )
 
-    def test_embedded_plan_bypasses_discovery_but_retains_llm_for_replacement(
+    def test_inline_plan_bypasses_discovery_but_retains_llm_for_replacement(
         self,
         patient_df: pd.DataFrame,
     ) -> None:

--- a/tests/pii_replacer/planning/test_resolver.py
+++ b/tests/pii_replacer/planning/test_resolver.py
@@ -1,0 +1,174 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from nemo_safe_synthesizer.config.data import DataParameters
+from nemo_safe_synthesizer.config.replace_pii import (
+    EntityType,
+    LLMConfig,
+    PiiColumnPlan,
+    PiiReplacementPlan,
+    PiiReplacementScope,
+    ReplacePiiConfig,
+)
+from nemo_safe_synthesizer.errors import ParameterError
+from nemo_safe_synthesizer.pii_replacer.planning import (
+    ColumnGrain,
+    PlanDiscoverer,
+    PlanDiscoveryInput,
+    PlanEnhancer,
+    load_plan,
+    resolve_plan,
+)
+
+
+class RecordingDiscoverer(PlanDiscoverer):
+    def __init__(self, plan: PiiReplacementPlan | None = None) -> None:
+        self.plan = plan
+        self.inputs: list[PlanDiscoveryInput] = []
+
+    def discover(self, discovery_input: PlanDiscoveryInput) -> PiiReplacementPlan:
+        self.inputs.append(discovery_input)
+        return self.plan or PiiReplacementPlan(scope=discovery_input.scope)
+
+
+class RecordingEnhancer(PlanEnhancer):
+    def __init__(self, plan: PiiReplacementPlan) -> None:
+        self.plan = plan
+        self.calls: list[tuple[PlanDiscoveryInput, PiiReplacementPlan]] = []
+
+    def enhance(
+        self,
+        discovery_input: PlanDiscoveryInput,
+        baseline: PiiReplacementPlan,
+    ) -> PiiReplacementPlan:
+        self.calls.append((discovery_input, baseline))
+        return self.plan
+
+
+@pytest.fixture
+def patient_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "patient_id": [1, 1, 2, 2],
+            "event_index": [1, 2, 1, 2],
+            "name": ["Ada Lovelace", "Ada Lovelace", "Grace Hopper", "Grace Hopper"],
+            "email": ["ada@example.com", "ada@example.com", "grace@example.com", "grace@example.com"],
+        }
+    )
+
+
+@pytest.mark.unit
+class TestResolvePlan:
+    def test_auto_discovery_uses_empty_heuristic_by_default(self, patient_df: pd.DataFrame) -> None:
+        plan = resolve_plan(patient_df, ReplacePiiConfig(), DataParameters())
+
+        assert plan == PiiReplacementPlan(scope=PiiReplacementScope.DATAFRAME)
+
+    def test_llm_enhancer_receives_heuristic_baseline(self, patient_df: pd.DataFrame) -> None:
+        baseline = PiiReplacementPlan(
+            columns_to_replace=[PiiColumnPlan(column_name="name", entity_type=EntityType.FULL_NAME)]
+        )
+        enhanced = PiiReplacementPlan(
+            columns_to_replace=[PiiColumnPlan(column_name="email", entity_type=EntityType.EMAIL)]
+        )
+        discoverer = RecordingDiscoverer(baseline)
+        enhancer = RecordingEnhancer(enhanced)
+
+        result = resolve_plan(
+            patient_df,
+            ReplacePiiConfig(llm=LLMConfig()),
+            DataParameters(),
+            discoverer=discoverer,
+            enhancer=enhancer,
+        )
+
+        assert result is enhanced
+        assert len(discoverer.inputs) == 1
+        assert enhancer.calls == [(discoverer.inputs[0], baseline)]
+
+    def test_configured_llm_without_enhancer_fails(self, patient_df: pd.DataFrame) -> None:
+        with pytest.raises(ParameterError, match="no LLM plan enhancer is available"):
+            resolve_plan(
+                patient_df,
+                ReplacePiiConfig(llm=LLMConfig()),
+                DataParameters(),
+            )
+
+    def test_embedded_plan_bypasses_discovery_but_retains_llm_for_replacement(
+        self,
+        patient_df: pd.DataFrame,
+    ) -> None:
+        plan = PiiReplacementPlan(columns_to_replace=[PiiColumnPlan(column_name="email", entity_type=EntityType.EMAIL)])
+        discoverer = RecordingDiscoverer()
+        enhancer = RecordingEnhancer(PiiReplacementPlan())
+        config = ReplacePiiConfig(replacement_plan=plan, llm=LLMConfig())
+
+        result = resolve_plan(
+            patient_df,
+            config,
+            DataParameters(),
+            discoverer=discoverer,
+            enhancer=enhancer,
+        )
+
+        assert result is plan
+        assert config.llm is not None
+        assert discoverer.inputs == []
+        assert enhancer.calls == []
+
+    def test_plan_file_bypasses_discovery(self, patient_df: pd.DataFrame, tmp_path: Path) -> None:
+        path = tmp_path / "plan.yaml"
+        path.write_text("scope: dataframe\ncolumns_to_replace:\n  - column_name: email\n    entity_type: email\n")
+        discoverer = RecordingDiscoverer()
+
+        result = resolve_plan(
+            patient_df,
+            ReplacePiiConfig(replacement_plan=str(path)),
+            DataParameters(),
+            discoverer=discoverer,
+        )
+
+        assert result.columns_to_replace[0].column_name == "email"
+        assert discoverer.inputs == []
+
+    def test_profiles_are_bounded_deterministic_and_mark_structural_grain(
+        self,
+        patient_df: pd.DataFrame,
+    ) -> None:
+        discoverer = RecordingDiscoverer()
+        data_config = DataParameters(
+            group_training_examples_by="patient_id",
+            order_training_examples_by="event_index",
+        )
+
+        resolve_plan(patient_df, ReplacePiiConfig(), data_config, discoverer=discoverer)
+        first_input = discoverer.inputs[0]
+        resolve_plan(patient_df.sample(frac=1, random_state=7), ReplacePiiConfig(), data_config, discoverer=discoverer)
+        second_input = discoverer.inputs[1]
+
+        first_profiles = {profile.column_name: profile for profile in first_input.column_profiles}
+        second_profiles = {profile.column_name: profile for profile in second_input.column_profiles}
+        assert first_input.scope is PiiReplacementScope.GROUP
+        assert first_input.protected_columns == frozenset({"patient_id", "event_index"})
+        assert first_profiles["patient_id"].grain is ColumnGrain.key
+        assert first_profiles["event_index"].grain is ColumnGrain.key
+        assert first_profiles["name"].grain is ColumnGrain.group
+        assert first_profiles["name"].samples == second_profiles["name"].samples
+
+    def test_output_path_persists_the_final_plan(self, patient_df: pd.DataFrame, tmp_path: Path) -> None:
+        path = tmp_path / "pii_replacement_plan.yaml"
+
+        plan = resolve_plan(
+            patient_df,
+            ReplacePiiConfig(),
+            DataParameters(),
+            output_path=path,
+        )
+
+        assert path.exists()
+        assert load_plan(path) == plan

--- a/tests/pii_replacer/planning/test_resolver.py
+++ b/tests/pii_replacer/planning/test_resolver.py
@@ -154,7 +154,7 @@ class TestResolvePlan:
         first_profiles = {profile.column_name: profile for profile in first_input.column_profiles}
         second_profiles = {profile.column_name: profile for profile in second_input.column_profiles}
         assert first_input.scope is PiiReplacementScope.GROUP
-        assert first_input.protected_columns == frozenset({"patient_id", "event_index"})
+        assert first_input.protected_columns == frozenset({"event_index"})
         assert first_profiles["patient_id"].grain is ColumnGrain.key
         assert first_profiles["event_index"].grain is ColumnGrain.key
         assert first_profiles["name"].grain is ColumnGrain.group

--- a/tests/pii_replacer/planning/test_resolver.py
+++ b/tests/pii_replacer/planning/test_resolver.py
@@ -17,7 +17,6 @@ from nemo_safe_synthesizer.config.replace_pii import (
 )
 from nemo_safe_synthesizer.errors import ParameterError
 from nemo_safe_synthesizer.pii_replacer.planning import (
-    ColumnGrain,
     PlanDiscoverer,
     PlanDiscoveryInput,
     PlanEnhancer,
@@ -137,7 +136,7 @@ class TestResolvePlan:
         assert result.columns_to_replace[0].column_name == "email"
         assert discoverer.inputs == []
 
-    def test_profiles_are_bounded_deterministic_and_separate_key_grain_from_protection(
+    def test_profiles_are_bounded_deterministic_and_keep_group_metadata_separate(
         self,
         fixture_patient_df: pd.DataFrame,
     ) -> None:
@@ -160,12 +159,8 @@ class TestResolvePlan:
         first_profiles = {profile.column_name: profile for profile in first_input.column_profiles}
         second_profiles = {profile.column_name: profile for profile in second_input.column_profiles}
         assert first_input.scope is PiiReplacementScope.GROUP
+        assert first_input.group_column == "patient_id"
         assert first_input.protected_columns == frozenset({"event_index"})
-        assert first_profiles["patient_id"].grain is ColumnGrain.key
-        assert first_profiles["patient_id"].protected is False
-        assert first_profiles["event_index"].grain is ColumnGrain.record
-        assert first_profiles["event_index"].protected is True
-        assert first_profiles["name"].grain is ColumnGrain.group
         assert first_profiles["name"].samples == second_profiles["name"].samples
 
     def test_output_path_persists_the_final_plan(self, fixture_patient_df: pd.DataFrame, tmp_path: Path) -> None:

--- a/tests/pii_replacer/planning/test_validation.py
+++ b/tests/pii_replacer/planning/test_validation.py
@@ -17,7 +17,8 @@ from nemo_safe_synthesizer.pii_replacer.planning import validate_plan
 
 
 @pytest.fixture
-def pii_df() -> pd.DataFrame:
+def fixture_pii_df() -> pd.DataFrame:
+    """Return representative structured PII columns for plan validation."""
     return pd.DataFrame(
         {
             "patient_id": [1, 2],
@@ -31,7 +32,7 @@ def pii_df() -> pd.DataFrame:
 
 @pytest.mark.unit
 class TestValidatePlan:
-    def test_accepts_valid_dependencies_and_patterns(self, pii_df: pd.DataFrame) -> None:
+    def test_accepts_valid_dependencies_and_patterns(self, fixture_pii_df: pd.DataFrame) -> None:
         plan = PiiReplacementPlan(
             columns_to_replace=[
                 PiiColumnPlan(
@@ -58,7 +59,21 @@ class TestValidatePlan:
             ]
         )
 
-        validate_plan(pii_df, plan, data_config=DataParameters())
+        validate_plan(fixture_pii_df, plan, data_config=DataParameters())
+
+    def test_accepts_timezone_bearing_strftime_pattern(self) -> None:
+        dataframe = pd.DataFrame({"timestamp": ["2001-02-03+0000", "1999-12-31-0500"]})
+        plan = PiiReplacementPlan(
+            columns_to_replace=[
+                PiiColumnPlan(
+                    column_name="timestamp",
+                    entity_type=EntityType.DATE_OF_BIRTH,
+                    pattern="%Y-%m-%d%z",
+                )
+            ]
+        )
+
+        validate_plan(dataframe, plan, data_config=DataParameters())
 
     def test_accepts_all_documented_character_mask_classes(self) -> None:
         dataframe = pd.DataFrame({"identifier": ["A7-a8", "Z0-z9"]})
@@ -88,7 +103,7 @@ class TestValidatePlan:
 
         validate_plan(dataframe, plan, data_config=DataParameters())
 
-    def test_reports_missing_replacement_and_dependency_columns(self, pii_df: pd.DataFrame) -> None:
+    def test_reports_missing_replacement_and_dependency_columns(self, fixture_pii_df: pd.DataFrame) -> None:
         plan = PiiReplacementPlan(
             columns_to_replace=[
                 PiiColumnPlan(column_name="missing", entity_type=EntityType.EMAIL),
@@ -104,22 +119,22 @@ class TestValidatePlan:
             ParameterError,
             match="(?s)replacement column 'missing'.*depends_on column 'gender'",
         ):
-            validate_plan(pii_df, plan, data_config=DataParameters())
+            validate_plan(fixture_pii_df, plan, data_config=DataParameters())
 
-    def test_allows_replacing_the_group_column(self, pii_df: pd.DataFrame) -> None:
+    def test_allows_replacing_the_group_column(self, fixture_pii_df: pd.DataFrame) -> None:
         plan = PiiReplacementPlan(
             scope=PiiReplacementScope.GROUP,
             columns_to_replace=[PiiColumnPlan(column_name="patient_id", entity_type=EntityType.UNIQUE_IDENTIFIER)],
         )
 
         validate_plan(
-            pii_df,
+            fixture_pii_df,
             plan,
             data_config=DataParameters(group_training_examples_by="patient_id"),
         )
 
-    def test_rejects_replacing_an_ordering_column(self, pii_df: pd.DataFrame) -> None:
-        dataframe = pii_df.assign(event_index=[0, 0])
+    def test_rejects_replacing_an_ordering_column(self, fixture_pii_df: pd.DataFrame) -> None:
+        dataframe = fixture_pii_df.assign(event_index=[0, 0])
         plan = PiiReplacementPlan(
             scope=PiiReplacementScope.GROUP,
             columns_to_replace=[PiiColumnPlan(column_name="event_index", entity_type=EntityType.UNIQUE_IDENTIFIER)],
@@ -135,20 +150,20 @@ class TestValidatePlan:
                 ),
             )
 
-    def test_group_scope_requires_a_configured_existing_group_column(self, pii_df: pd.DataFrame) -> None:
+    def test_group_scope_requires_a_configured_existing_group_column(self, fixture_pii_df: pd.DataFrame) -> None:
         plan = PiiReplacementPlan(scope=PiiReplacementScope.GROUP)
 
         with pytest.raises(ParameterError, match="group_training_examples_by is not configured"):
-            validate_plan(pii_df, plan, data_config=DataParameters())
+            validate_plan(fixture_pii_df, plan, data_config=DataParameters())
 
         with pytest.raises(ParameterError, match="group column 'missing_group' is not present"):
             validate_plan(
-                pii_df,
+                fixture_pii_df,
                 plan,
                 data_config=DataParameters(group_training_examples_by="missing_group"),
             )
 
-    def test_rejects_self_dependency(self, pii_df: pd.DataFrame) -> None:
+    def test_rejects_self_dependency(self, fixture_pii_df: pd.DataFrame) -> None:
         plan = PiiReplacementPlan.model_construct(
             scope=PiiReplacementScope.DATAFRAME,
             columns_to_replace=[
@@ -164,9 +179,9 @@ class TestValidatePlan:
         )
 
         with pytest.raises(ParameterError, match="cannot depend on itself"):
-            validate_plan(pii_df, plan, data_config=DataParameters())
+            validate_plan(fixture_pii_df, plan, data_config=DataParameters())
 
-    def test_rejects_dependency_cycles(self, pii_df: pd.DataFrame) -> None:
+    def test_rejects_dependency_cycles(self, fixture_pii_df: pd.DataFrame) -> None:
         plan = PiiReplacementPlan.model_construct(
             scope=PiiReplacementScope.DATAFRAME,
             columns_to_replace=[
@@ -188,9 +203,9 @@ class TestValidatePlan:
         )
 
         with pytest.raises(ParameterError, match="dependencies contain a cycle"):
-            validate_plan(pii_df, plan, data_config=DataParameters())
+            validate_plan(fixture_pii_df, plan, data_config=DataParameters())
 
-    def test_rejects_pattern_below_coverage_threshold(self, pii_df: pd.DataFrame) -> None:
+    def test_rejects_pattern_below_coverage_threshold(self, fixture_pii_df: pd.DataFrame) -> None:
         plan = PiiReplacementPlan(
             columns_to_replace=[
                 PiiColumnPlan(
@@ -202,4 +217,4 @@ class TestValidatePlan:
         )
 
         with pytest.raises(ParameterError, match="covers 0.0%.*at least 85%"):
-            validate_plan(pii_df, plan, data_config=DataParameters())
+            validate_plan(fixture_pii_df, plan, data_config=DataParameters())

--- a/tests/pii_replacer/planning/test_validation.py
+++ b/tests/pii_replacer/planning/test_validation.py
@@ -60,6 +60,34 @@ class TestValidatePlan:
 
         validate_plan(pii_df, plan, data_config=DataParameters())
 
+    def test_accepts_all_documented_character_mask_classes(self) -> None:
+        dataframe = pd.DataFrame({"identifier": ["A7-a8", "Z0-z9"]})
+        plan = PiiReplacementPlan(
+            columns_to_replace=[
+                PiiColumnPlan(
+                    column_name="identifier",
+                    entity_type=EntityType.UNIQUE_IDENTIFIER,
+                    pattern="&&-%%",
+                )
+            ]
+        )
+
+        validate_plan(dataframe, plan, data_config=DataParameters())
+
+    def test_accepts_email_name_parts_pattern_with_digit_token(self) -> None:
+        dataframe = pd.DataFrame({"email": ["ada1@example.com", "grace2@example.com"]})
+        plan = PiiReplacementPlan(
+            columns_to_replace=[
+                PiiColumnPlan(
+                    column_name="email",
+                    entity_type=EntityType.EMAIL,
+                    pattern="{first}#@{domain}",
+                )
+            ]
+        )
+
+        validate_plan(dataframe, plan, data_config=DataParameters())
+
     def test_reports_missing_replacement_and_dependency_columns(self, pii_df: pd.DataFrame) -> None:
         plan = PiiReplacementPlan(
             columns_to_replace=[
@@ -78,17 +106,33 @@ class TestValidatePlan:
         ):
             validate_plan(pii_df, plan, data_config=DataParameters())
 
-    def test_rejects_replacing_a_structural_column(self, pii_df: pd.DataFrame) -> None:
+    def test_allows_replacing_the_group_column(self, pii_df: pd.DataFrame) -> None:
         plan = PiiReplacementPlan(
             scope=PiiReplacementScope.GROUP,
             columns_to_replace=[PiiColumnPlan(column_name="patient_id", entity_type=EntityType.UNIQUE_IDENTIFIER)],
         )
 
-        with pytest.raises(ParameterError, match="structural column 'patient_id' cannot be replaced"):
+        validate_plan(
+            pii_df,
+            plan,
+            data_config=DataParameters(group_training_examples_by="patient_id"),
+        )
+
+    def test_rejects_replacing_an_ordering_column(self, pii_df: pd.DataFrame) -> None:
+        dataframe = pii_df.assign(event_index=[0, 0])
+        plan = PiiReplacementPlan(
+            scope=PiiReplacementScope.GROUP,
+            columns_to_replace=[PiiColumnPlan(column_name="event_index", entity_type=EntityType.UNIQUE_IDENTIFIER)],
+        )
+
+        with pytest.raises(ParameterError, match="structural column 'event_index' cannot be replaced"):
             validate_plan(
-                pii_df,
+                dataframe,
                 plan,
-                data_config=DataParameters(group_training_examples_by="patient_id"),
+                data_config=DataParameters(
+                    group_training_examples_by="patient_id",
+                    order_training_examples_by="event_index",
+                ),
             )
 
     def test_group_scope_requires_a_configured_existing_group_column(self, pii_df: pd.DataFrame) -> None:

--- a/tests/pii_replacer/planning/test_validation.py
+++ b/tests/pii_replacer/planning/test_validation.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pandas as pd
+import pytest
+
+from nemo_safe_synthesizer.config.data import DataParameters
+from nemo_safe_synthesizer.config.replace_pii import (
+    ConditioningColumn,
+    EntityType,
+    PiiColumnPlan,
+    PiiReplacementPlan,
+    PiiReplacementScope,
+)
+from nemo_safe_synthesizer.errors import ParameterError
+from nemo_safe_synthesizer.pii_replacer.planning import validate_plan
+
+
+@pytest.fixture
+def pii_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "patient_id": [1, 2],
+            "name": ["Ada Lovelace", "Grace Hopper"],
+            "email": ["ada@example.com", "grace@example.com"],
+            "phone": ["+1-202-555-0101", "+1-303-555-0102"],
+            "dob": ["12/10/1815", "12/09/1906"],
+        }
+    )
+
+
+@pytest.mark.unit
+class TestValidatePlan:
+    def test_accepts_valid_dependencies_and_patterns(self, pii_df: pd.DataFrame) -> None:
+        plan = PiiReplacementPlan(
+            columns_to_replace=[
+                PiiColumnPlan(
+                    column_name="name",
+                    entity_type=EntityType.FULL_NAME,
+                    pattern="{First} {Last}",
+                ),
+                PiiColumnPlan(
+                    column_name="email",
+                    entity_type=EntityType.EMAIL,
+                    pattern="{first}@{domain}",
+                    depends_on=[ConditioningColumn(column_name="name")],
+                ),
+                PiiColumnPlan(
+                    column_name="phone",
+                    entity_type=EntityType.PHONE_NUMBER,
+                    pattern="+1-###-555-####",
+                ),
+                PiiColumnPlan(
+                    column_name="dob",
+                    entity_type=EntityType.DATE_OF_BIRTH,
+                    pattern="%m/%d/%Y",
+                ),
+            ]
+        )
+
+        validate_plan(pii_df, plan, data_config=DataParameters())
+
+    def test_reports_missing_replacement_and_dependency_columns(self, pii_df: pd.DataFrame) -> None:
+        plan = PiiReplacementPlan(
+            columns_to_replace=[
+                PiiColumnPlan(column_name="missing", entity_type=EntityType.EMAIL),
+                PiiColumnPlan(
+                    column_name="name",
+                    entity_type=EntityType.FULL_NAME,
+                    depends_on=[ConditioningColumn(column_name="gender", entity_type=EntityType.GENDER)],
+                ),
+            ]
+        )
+
+        with pytest.raises(
+            ParameterError,
+            match="(?s)replacement column 'missing'.*depends_on column 'gender'",
+        ):
+            validate_plan(pii_df, plan, data_config=DataParameters())
+
+    def test_rejects_replacing_a_structural_column(self, pii_df: pd.DataFrame) -> None:
+        plan = PiiReplacementPlan(
+            scope=PiiReplacementScope.GROUP,
+            columns_to_replace=[PiiColumnPlan(column_name="patient_id", entity_type=EntityType.UNIQUE_IDENTIFIER)],
+        )
+
+        with pytest.raises(ParameterError, match="structural column 'patient_id' cannot be replaced"):
+            validate_plan(
+                pii_df,
+                plan,
+                data_config=DataParameters(group_training_examples_by="patient_id"),
+            )
+
+    def test_group_scope_requires_a_configured_existing_group_column(self, pii_df: pd.DataFrame) -> None:
+        plan = PiiReplacementPlan(scope=PiiReplacementScope.GROUP)
+
+        with pytest.raises(ParameterError, match="group_training_examples_by is not configured"):
+            validate_plan(pii_df, plan, data_config=DataParameters())
+
+        with pytest.raises(ParameterError, match="group column 'missing_group' is not present"):
+            validate_plan(
+                pii_df,
+                plan,
+                data_config=DataParameters(group_training_examples_by="missing_group"),
+            )
+
+    def test_rejects_self_dependency(self, pii_df: pd.DataFrame) -> None:
+        plan = PiiReplacementPlan.model_construct(
+            scope=PiiReplacementScope.DATAFRAME,
+            columns_to_replace=[
+                PiiColumnPlan.model_construct(
+                    column_name="name",
+                    entity_type=EntityType.FULL_NAME,
+                    pattern=None,
+                    depends_on=[
+                        ConditioningColumn.model_construct(column_name="name", entity_type=EntityType.FULL_NAME)
+                    ],
+                )
+            ],
+        )
+
+        with pytest.raises(ParameterError, match="cannot depend on itself"):
+            validate_plan(pii_df, plan, data_config=DataParameters())
+
+    def test_rejects_dependency_cycles(self, pii_df: pd.DataFrame) -> None:
+        plan = PiiReplacementPlan.model_construct(
+            scope=PiiReplacementScope.DATAFRAME,
+            columns_to_replace=[
+                PiiColumnPlan.model_construct(
+                    column_name="name",
+                    entity_type=EntityType.FULL_NAME,
+                    pattern=None,
+                    depends_on=[ConditioningColumn.model_construct(column_name="email", entity_type=EntityType.EMAIL)],
+                ),
+                PiiColumnPlan.model_construct(
+                    column_name="email",
+                    entity_type=EntityType.EMAIL,
+                    pattern=None,
+                    depends_on=[
+                        ConditioningColumn.model_construct(column_name="name", entity_type=EntityType.FULL_NAME)
+                    ],
+                ),
+            ],
+        )
+
+        with pytest.raises(ParameterError, match="dependencies contain a cycle"):
+            validate_plan(pii_df, plan, data_config=DataParameters())
+
+    def test_rejects_pattern_below_coverage_threshold(self, pii_df: pd.DataFrame) -> None:
+        plan = PiiReplacementPlan(
+            columns_to_replace=[
+                PiiColumnPlan(
+                    column_name="phone",
+                    entity_type=EntityType.PHONE_NUMBER,
+                    pattern="###-###-####",
+                )
+            ]
+        )
+
+        with pytest.raises(ParameterError, match="covers 0.0%.*at least 85%"):
+            validate_plan(pii_df, plan, data_config=DataParameters())

--- a/tests/sdk/test_builder.py
+++ b/tests/sdk/test_builder.py
@@ -67,7 +67,10 @@ def fixture_base_builder() -> SafeSynthesizer:
 
 
 def test_pii_replacer_only_builder_rejects_legacy_config(fixture_base_builder: SafeSynthesizer):
-    with pytest.raises(ParameterError, match="PII replacement v2 configuration was removed"):
+    with pytest.raises(
+        ParameterError,
+        match="configuration uses the PII replacement v2 schema.*Configure replace_pii.replacement_plan instead",
+    ):
         fixture_base_builder.with_replace_pii(config={"globals": {}})
 
 

--- a/tests/sdk/test_pii_planning.py
+++ b/tests/sdk/test_pii_planning.py
@@ -65,10 +65,10 @@ def test_plan_pii_replacement_delegates_full_input_without_pipeline_stages(tmp_p
 
 def test_plan_pii_replacement_persists_when_output_path_is_supplied(tmp_path: Path) -> None:
     dataframe = pd.DataFrame({"email": ["ada@example.com", "grace@example.com"]})
-    embedded_plan = PiiReplacementPlan(
+    inline_plan = PiiReplacementPlan(
         columns_to_replace=[PiiColumnPlan(column_name="email", entity_type=EntityType.EMAIL)]
     )
-    config = SafeSynthesizerParameters(replace_pii=ReplacePiiConfig(replacement_plan=embedded_plan))
+    config = SafeSynthesizerParameters(replace_pii=ReplacePiiConfig(replacement_plan=inline_plan))
     output_path = tmp_path / "review" / "pii_replacement_plan.yaml"
 
     result = (
@@ -77,8 +77,8 @@ def test_plan_pii_replacement_persists_when_output_path_is_supplied(tmp_path: Pa
         .plan_pii_replacement(output_path=output_path)
     )
 
-    assert result == embedded_plan
-    assert load_plan(output_path) == embedded_plan
+    assert result == inline_plan
+    assert load_plan(output_path) == inline_plan
 
 
 def test_plan_pii_replacement_rejects_disabled_pii(tmp_path: Path) -> None:

--- a/tests/sdk/test_pii_planning.py
+++ b/tests/sdk/test_pii_planning.py
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the plan-only PII replacement SDK interface."""
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from nemo_safe_synthesizer.config import SafeSynthesizerParameters
+from nemo_safe_synthesizer.config.replace_pii import EntityType, PiiColumnPlan, PiiReplacementPlan, ReplacePiiConfig
+from nemo_safe_synthesizer.errors import ParameterError
+from nemo_safe_synthesizer.pii_replacer.planning import load_plan
+from nemo_safe_synthesizer.sdk.library_builder import SafeSynthesizer
+
+
+def test_importing_safe_synthesizer_does_not_load_model_stack() -> None:
+    code = (
+        "import sys;"
+        "from nemo_safe_synthesizer.sdk.library_builder import SafeSynthesizer;"
+        "forbidden = sorted(name for name in ('torch', 'torchao', 'transformers', 'vllm') if name in sys.modules);"
+        "print(','.join(forbidden));"
+        "sys.exit(1 if forbidden else 0)"
+    )
+
+    result = subprocess.run([sys.executable, "-c", code], capture_output=True, text=True)
+
+    assert result.returncode == 0, (
+        "Importing SafeSynthesizer loaded model dependencies that are not required "
+        f"for plan-only workflows: {result.stdout.strip()}\nstderr: {result.stderr}"
+    )
+
+
+def test_plan_pii_replacement_delegates_full_input_without_pipeline_stages(tmp_path: Path) -> None:
+    dataframe = pd.DataFrame({"row_id": range(100), "email": [f"person-{i}@example.com" for i in range(100)]})
+    config = SafeSynthesizerParameters(replace_pii=ReplacePiiConfig())
+    expected = PiiReplacementPlan()
+    nss = SafeSynthesizer(config=config, save_path=tmp_path).with_data_source(dataframe)
+
+    with (
+        patch("nemo_safe_synthesizer.pii_replacer.planning.resolve_plan", return_value=expected) as resolve_plan,
+        patch.object(nss, "process_data") as process_data,
+        patch.object(nss, "train") as train,
+        patch.object(nss, "generate") as generate,
+        patch.object(nss, "evaluate") as evaluate,
+    ):
+        result = nss.plan_pii_replacement()
+
+    assert result is expected
+    args = resolve_plan.call_args.args
+    assert args[0] is dataframe
+    assert args[1] == config.replace_pii
+    assert args[2] == config.data
+    assert args[3] == config.time_series
+    assert resolve_plan.call_args.kwargs == {"output_path": None}
+    process_data.assert_not_called()
+    train.assert_not_called()
+    generate.assert_not_called()
+    evaluate.assert_not_called()
+
+
+def test_plan_pii_replacement_persists_when_output_path_is_supplied(tmp_path: Path) -> None:
+    dataframe = pd.DataFrame({"email": ["ada@example.com", "grace@example.com"]})
+    embedded_plan = PiiReplacementPlan(
+        columns_to_replace=[PiiColumnPlan(column_name="email", entity_type=EntityType.EMAIL)]
+    )
+    config = SafeSynthesizerParameters(replace_pii=ReplacePiiConfig(replacement_plan=embedded_plan))
+    output_path = tmp_path / "review" / "pii_replacement_plan.yaml"
+
+    result = (
+        SafeSynthesizer(config=config, save_path=tmp_path / "artifacts")
+        .with_data_source(dataframe)
+        .plan_pii_replacement(output_path=output_path)
+    )
+
+    assert result == embedded_plan
+    assert load_plan(output_path) == embedded_plan
+
+
+def test_plan_pii_replacement_rejects_disabled_pii(tmp_path: Path) -> None:
+    config = SafeSynthesizerParameters(replace_pii=None)
+    nss = SafeSynthesizer(config=config, save_path=tmp_path).with_data_source(
+        pd.DataFrame({"email": ["a@example.com"]})
+    )
+
+    with pytest.raises(ParameterError, match="PII replacement is disabled"):
+        nss.plan_pii_replacement()

--- a/tests/sdk/test_process_data.py
+++ b/tests/sdk/test_process_data.py
@@ -106,10 +106,10 @@ def _wire_process_data_mocks(
 class TestProcessDataPiiSeparation:
     """``process_data`` must keep original and PII-replaced DataFrames separate."""
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.run_preflight", return_value=_EMPTY_PREFLIGHT)
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
-    @patch("nemo_safe_synthesizer.sdk.library_builder.AutoConfigResolver")
-    @patch("nemo_safe_synthesizer.sdk.library_builder.Holdout")
+    @patch("nemo_safe_synthesizer.preflight.run_preflight", return_value=_EMPTY_PREFLIGHT)
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
+    @patch("nemo_safe_synthesizer.config.autoconfig.AutoConfigResolver")
+    @patch("nemo_safe_synthesizer.holdout.holdout.Holdout")
     def test_process_data_without_pii_replacement_sets_original_training_df(
         self,
         mock_holdout_cls,
@@ -130,10 +130,10 @@ class TestProcessDataPiiSeparation:
         assert builder._training_df is not None
         pd.testing.assert_frame_equal(builder._training_df, train_split)
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.run_preflight", return_value=_EMPTY_PREFLIGHT)
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
-    @patch("nemo_safe_synthesizer.sdk.library_builder.AutoConfigResolver")
-    @patch("nemo_safe_synthesizer.sdk.library_builder.Holdout")
+    @patch("nemo_safe_synthesizer.preflight.run_preflight", return_value=_EMPTY_PREFLIGHT)
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
+    @patch("nemo_safe_synthesizer.config.autoconfig.AutoConfigResolver")
+    @patch("nemo_safe_synthesizer.holdout.holdout.Holdout")
     def test_process_data_without_pii_replacement_does_not_write_transformed_training(
         self,
         mock_holdout_cls,
@@ -168,10 +168,10 @@ class TestProcessDataPiiSeparation:
 class TestProcessDataMetadataLifecycle:
     """Validate-mode metadata fallback should not persist stub metadata."""
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.run_preflight", return_value=_EMPTY_PREFLIGHT)
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
-    @patch("nemo_safe_synthesizer.sdk.library_builder.AutoConfigResolver")
-    @patch("nemo_safe_synthesizer.sdk.library_builder.Holdout")
+    @patch("nemo_safe_synthesizer.preflight.run_preflight", return_value=_EMPTY_PREFLIGHT)
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
+    @patch("nemo_safe_synthesizer.config.autoconfig.AutoConfigResolver")
+    @patch("nemo_safe_synthesizer.holdout.holdout.Holdout")
     def test_check_only_stub_metadata_not_persisted_for_followup_run(
         self,
         mock_holdout_cls,
@@ -220,8 +220,8 @@ class TestProcessDataMetadataLifecycle:
 class TestEvaluateUsesOriginalTrainingDf:
     """``evaluate()`` passes the original training data to ``Evaluator``."""
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.make_nss_results")
-    @patch("nemo_safe_synthesizer.sdk.library_builder.Evaluator")
+    @patch("nemo_safe_synthesizer.results.make_nss_results")
+    @patch("nemo_safe_synthesizer.evaluation.evaluator.Evaluator")
     def test_evaluate_uses_original_training_df(
         self,
         mock_evaluator_cls,
@@ -247,7 +247,7 @@ class TestEvaluateUsesOriginalTrainingDf:
         call_kwargs = mock_evaluator_cls.call_args[1]
         pd.testing.assert_frame_equal(call_kwargs["training_df"], train_split)
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.Evaluator")
+    @patch("nemo_safe_synthesizer.evaluation.evaluator.Evaluator")
     def test_evaluate_disabled_skips_evaluator_and_builds_results(
         self,
         mock_evaluator_cls,
@@ -327,7 +327,7 @@ class TestLoadFromSavePath:
 
         return workdir, train_split, test_split
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_load_restores_training_split(
         self,
         mock_metadata_cls,
@@ -350,7 +350,7 @@ class TestLoadFromSavePath:
         assert builder._original_training_df is not None
         pd.testing.assert_frame_equal(builder._original_training_df, train_split)
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_load_rejects_unknown_legacy_saved_fields_by_default(
         self,
         mock_metadata_cls,
@@ -376,7 +376,7 @@ class TestLoadFromSavePath:
             builder.load_from_save_path()
 
     @pytest.mark.parametrize("policy_source", ["saved", "builder", "runtime"])
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_load_can_ignore_unknown_legacy_saved_fields(
         self,
         mock_metadata_cls,
@@ -417,7 +417,7 @@ class TestLoadFromSavePath:
         assert builder._nss_config.unknown_fields == "ignore"
         assert not hasattr(builder._nss_config.training, "epoch")
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_load_applies_runtime_generation_and_evaluation_config(
         self,
         mock_metadata_cls,
@@ -456,7 +456,7 @@ class TestLoadFromSavePath:
         assert builder._nss_config.generation.structured_generation.schema_method == "auto"
         assert builder._nss_config.evaluation.enabled is False
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_load_preserves_saved_generation_when_runtime_config_has_no_overrides(
         self,
         mock_metadata_cls,
@@ -488,7 +488,7 @@ class TestLoadFromSavePath:
         assert builder._nss_config.generation.structured_generation.schema_method == "auto"
         assert builder._nss_config.evaluation.enabled is True
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_load_deep_merges_nested_validation_overrides(
         self,
         mock_metadata_cls,
@@ -522,7 +522,7 @@ class TestLoadFromSavePath:
         # Unrelated saved generation field preserved.
         assert builder._nss_config.generation.num_records == 3000
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_load_full_runtime_config_replaces_supported_runtime_sections(
         self,
         mock_metadata_cls,
@@ -561,7 +561,7 @@ class TestLoadFromSavePath:
         assert builder._nss_config.generation.structured_generation.schema_method == "auto"
         assert builder._nss_config.evaluation.enabled is False
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_load_warns_when_saved_values_differ_from_current_defaults(
         self,
         mock_metadata_cls,
@@ -589,7 +589,7 @@ class TestLoadFromSavePath:
         assert builder._nss_config is not None
         assert builder._nss_config.generation.num_records == 3000
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_process_data_skips_when_cached_splits_loaded(
         self,
         mock_metadata_cls,
@@ -613,7 +613,7 @@ class TestLoadFromSavePath:
         assert builder._original_training_df is not None
         pd.testing.assert_frame_equal(builder._original_training_df, train_split)
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_train_after_load_from_save_path_raises(
         self,
         mock_metadata_cls,
@@ -635,7 +635,7 @@ class TestLoadFromSavePath:
         with pytest.raises(RuntimeError, match="train.*cannot be called after load_from_save_path"):
             builder.train()
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_run_after_load_from_save_path_raises(
         self,
         mock_metadata_cls,
@@ -704,10 +704,10 @@ class TestLoadFromSavePathHoldoutZero:
 
         return workdir, train_split
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.run_preflight", return_value=_EMPTY_PREFLIGHT)
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
-    @patch("nemo_safe_synthesizer.sdk.library_builder.AutoConfigResolver")
-    @patch("nemo_safe_synthesizer.sdk.library_builder.Holdout")
+    @patch("nemo_safe_synthesizer.preflight.run_preflight", return_value=_EMPTY_PREFLIGHT)
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
+    @patch("nemo_safe_synthesizer.config.autoconfig.AutoConfigResolver")
+    @patch("nemo_safe_synthesizer.holdout.holdout.Holdout")
     def test_process_data_no_test_csv_when_holdout_zero(
         self,
         mock_holdout_cls,
@@ -740,7 +740,7 @@ class TestLoadFromSavePathHoldoutZero:
         assert not fixture_workdir.dataset.test.exists()
         assert builder._test_df is None
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_load_succeeds_without_test_csv(
         self,
         mock_metadata_cls,
@@ -765,7 +765,7 @@ class TestLoadFromSavePathHoldoutZero:
         assert builder._test_df is None
         assert builder._loaded_from_save_path is True
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.ModelMetadata")
+    @patch("nemo_safe_synthesizer.llm.metadata.ModelMetadata")
     def test_load_handles_empty_test_csv_from_old_runs(
         self,
         mock_metadata_cls,
@@ -814,7 +814,7 @@ class TestProcessDataConfigValidation:
     replacement, or any disk I/O.
     """
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.Holdout")
+    @patch("nemo_safe_synthesizer.holdout.holdout.Holdout")
     def test_invalid_groupby_raises_before_holdout(
         self,
         mock_holdout_cls,
@@ -842,7 +842,7 @@ class TestProcessDataConfigValidation:
         )
         mock_holdout_cls.assert_not_called()
 
-    @patch("nemo_safe_synthesizer.sdk.library_builder.Holdout")
+    @patch("nemo_safe_synthesizer.holdout.holdout.Holdout")
     def test_invalid_orderby_raises_before_holdout(
         self,
         mock_holdout_cls,


### PR DESCRIPTION
# Summary

- Add plan resolution interfaces that always run the heuristic baseline before optional LLM enhancement.
- Support inline and standalone YAML plans with context-free model validation followed by one dataframe-aware validation gate.
- Add deterministic bounded column profiling, canonical sparse plan serialization, tests, and configuration documentation.

## Human review

Select exactly one. The default is no human review; uncheck it when choosing another level.

- [ ] ⚪ No human review; automated review only
- [x] 🟡 Partially reviewed or spot-checked by a human
- [ ] 🔵 Complete diff reviewed by a human
- [ ] 🟢 Complete diff reviewed and verified by a human

Verification performed:

- `mise run check`
- Focused config/planning/SDK/CLI suite (183 passed)

## Pre-Review Checklist

Ensure that the following pass:

- [x] `mise run format && mise run check` or via prek validation.
- [ ] `mise run test` passes locally
- [ ] `mise run test:e2e` passes locally
- [ ] `mise run test:ci-container` passes locally (recommended)
- [ ] GPU CI status check passes -- comment `/sync` on this PR to trigger a run (auto-triggers on ready-for-review)

## Pre-Merge Checklist

- [x] New or updated tests for any fix or new behavior
- [x] Updated documentation for new features and behaviors, including docstrings for API docs.

## Other Notes

- No linked issue.
- The full unit suite reaches an unrelated existing telemetry context-manager failure; the changed-area suites pass.
